### PR TITLE
Add HTTPService and AsyncLoop for microservice

### DIFF
--- a/GenAIComps/micro/async_loop.py
+++ b/GenAIComps/micro/async_loop.py
@@ -1,0 +1,164 @@
+import argparse
+import asyncio
+import signal
+import time
+from typing import TYPE_CHECKING, Optional, Union, Dict
+from logger import Logger
+from utils import is_port_free
+
+if TYPE_CHECKING:  # pragma: no cover
+    import threading
+    import multiprocessing
+
+HANDLED_SIGNALS = (
+    signal.SIGINT,  # Unix signal 2. Sent by Ctrl+C.
+    signal.SIGTERM,  # Unix signal 15. Sent by `kill <pid>`.
+    signal.SIGSEGV,
+)
+
+
+class AsyncLoop:
+    """
+    Async loop to run a service asynchronously.
+    """
+
+    def __init__(self, 
+                 args: Optional[Dict] = None,
+                 cancel_event: Optional[
+                     Union['asyncio.Event', 'multiprocessing.Event', 'threading.Event']
+                     ] = None,
+    ) -> None:
+        self.args = args
+        if args.get('name', None):
+            self.name = f'{args.get("name")}/{self.__class__.__name__}'
+        else:
+            self.name = self.__class__.__name__
+        self.protocol = args.get('protocol', 'http')
+        self.host = args.get('host', 'localhost')
+        self.port = args.get('port', 8080)
+        self.quiet_error = args.get('quiet_error', False)
+        self.logger = Logger(self.name)
+        self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
+        self.is_cancel = cancel_event or asyncio.Event()
+        self.logger.info(f'Setting signal handlers')
+
+        def _cancel(signum, frame):
+                self.logger.info(f'Received signal {signum}')
+                self.is_cancel.set(),
+
+        for sig in HANDLED_SIGNALS:
+            signal.signal(sig, _cancel)
+
+        self._start_time = time.time()
+        self._loop.run_until_complete(self.async_setup())
+
+    def run_forever(self):
+        """
+        Running method to block the main thread.
+
+        Run the event loop until a Future is done.
+        """
+        self._loop.run_until_complete(self._loop_body())
+
+    def teardown(self):
+        """Call async_teardown() and stop and close the event loop."""
+        self._loop.run_until_complete(self.async_teardown())
+        self._loop.stop()
+        self._loop.close()
+        self._stop_time = time.time()
+        self.logger.info(f"Async loop is tore down. Duration: {self._stop_time - self._start_time}")
+
+    def _get_server(self):
+        # construct server type based on protocol (and potentially req handler class to keep backwards compatibility)
+        if self.protocol.lower() == 'http':
+            from http_service import HTTPService
+
+            runtime_args = self.args.get('runtime_args', None)
+            runtime_args['protocol'] = self.protocol
+            runtime_args['host'] = self.host
+            runtime_args['port'] = self.port
+            return HTTPService(
+                uvicorn_kwargs=self.args.get('uvicorn_kwargs', None),
+                runtime_args=runtime_args,
+                cors=self.args.get('cors', None),
+            )
+
+    async def async_setup(self):
+        """
+        The async method setup the runtime.
+
+        Setup the uvicorn server.
+        """
+        if not (is_port_free(self.host, self.port)):
+            raise RuntimeError(f'port:{self.port}')
+
+        self.server = self._get_server()
+        await self.server.setup_server()
+
+    async def async_run_forever(self):
+        """Running method of the server."""
+        await self.server.run_server()
+
+    async def async_teardown(self):
+        """Shutdown the server."""
+        await self.server.shutdown_server()
+
+    async def _wait_for_cancel(self):
+        """Do NOT override this method when inheriting from :class:`GatewayPod`"""
+        # threads are not using asyncio.Event, but threading.Event
+        if isinstance(self.is_cancel, asyncio.Event) and not hasattr(
+            self.server, '_should_exit'
+        ):
+            await self.is_cancel.wait()
+        else:
+            while not self.is_cancel.is_set() and not getattr(
+                self.server, '_should_exit', False
+            ):
+                await asyncio.sleep(0.1)
+
+        await self.async_teardown()
+
+    async def _loop_body(self):
+        """Do NOT override this method when inheriting from :class:`GatewayPod`"""
+        try:
+            await asyncio.gather(self.async_run_forever(), self._wait_for_cancel())
+        except asyncio.CancelledError:
+            self.logger.warning('received terminate ctrl message from main process')
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type == KeyboardInterrupt:
+            self.logger.info(f'{self!r} is interrupted by user')
+        elif exc_type and issubclass(exc_type, Exception):
+            self.logger.error(
+                (
+                    f'{exc_val!r} during {self.run_forever!r}'
+                    + f'\n add "--quiet-error" to suppress the exception details'
+                    if not self.quiet_error
+                    else ''
+                ),
+                exc_info=not self.quiet_error,
+            )
+        else:
+            self.logger.info(f'{self!r} is ended')
+        try:
+            # self.teardown()
+            pass
+        except OSError:
+            # OSError(Stream is closed) already
+            pass
+        except Exception as ex:
+            self.logger.error(
+                (
+                    f'{ex!r} during {self.teardown!r}'
+                    + f'\n add "--quiet-error" to suppress the exception details'
+                    if not self.args.quiet_error
+                    else ''
+                ),
+                exc_info=not self.args.quiet_error,
+            )
+
+        return True

--- a/GenAIComps/micro/base_service.py
+++ b/GenAIComps/micro/base_service.py
@@ -1,0 +1,131 @@
+import abc
+from logger import Logger
+from types import SimpleNamespace
+from typing import Dict, Optional, TYPE_CHECKING
+
+
+__all__ = ['BaseServer']
+
+
+class BaseService():
+    """
+    BaseService creates a HTTP/gRPC server as a microservice.
+    """
+
+    def __init__(
+        self,
+        name: Optional[str] = 'Base service',
+        runtime_args: Optional[Dict] = None,
+        **kwargs,
+    ):
+        self.name = name
+        self.runtime_args = runtime_args
+        self._reform_runtime_args()
+        self.title = self.runtime_args.title
+        self.description = self.runtime_args.description
+        self.logger = Logger(self.name)
+        self.server = None
+
+    def _reform_runtime_args(self):
+        _runtime_args = (
+            self.runtime_args
+            if isinstance(self.runtime_args, dict)
+            else vars(self.runtime_args or {})
+        )
+        self.runtime_args = SimpleNamespace(**_runtime_args)
+
+    @property
+    def port(self):
+        """Gets the first port of the port list argument. To be used in the regular case where a Gateway exposes a single port
+        :return: The first port to be exposed
+        """
+        return (
+            self.runtime_args.port[0]
+            if isinstance(self.runtime_args.port, list)
+            else self.runtime_args.port
+        )
+
+    @property
+    def ports(self):
+        """Gets all the list of ports from the runtime_args as a list.
+        :return: The lists of ports to be exposed
+        """
+        return (
+            self.runtime_args.port
+            if isinstance(self.runtime_args.port, list)
+            else [self.runtime_args.port]
+        )
+
+    @property
+    def protocol(self):
+        """Gets all the list of protocols from the runtime_args as a list.
+        :return: The lists of protocols to be exposed
+        """
+        return (
+            self.runtime_args.protocol
+            if isinstance(self.runtime_args.protocol, list)
+            else [self.runtime_args.protocol]
+        )
+
+    @property
+    def host(self):
+        """Gets the host from the runtime_args
+        :return: The host where to bind the gateway
+        """
+        return self.runtime_args.host or '127.0.0.1'
+
+    @abc.abstractmethod
+    async def setup_server(self):
+        """Setup server"""
+        ...
+
+    @abc.abstractmethod
+    async def run_server(self):
+        """Run server forever"""
+        ...
+
+    @abc.abstractmethod
+    async def shutdown(self):
+        """Shutdown the server and free other allocated resources, e.g, streamer object, health check service, ..."""
+        ...
+
+    @staticmethod
+    def is_ready(
+        ctrl_address: str,
+        protocol: Optional[str] = 'http',
+        **kwargs,
+    ) -> bool:
+        """
+        Check if status is ready.
+        :param ctrl_address: the address where the control request needs to be sent
+        :param protocol: protocol of the gateway runtime
+        :param kwargs: extra keyword arguments
+        :return: True if status is ready else False.
+        """
+        from http_service import HTTPService
+        res = False
+        if protocol is None or protocol == 'http':
+            res = HTTPService.is_ready(ctrl_address)
+        return res
+
+    @staticmethod
+    async def async_is_ready(
+        ctrl_address: str,
+        protocol: Optional[str] = 'grpc',
+        **kwargs,
+    ) -> bool:
+        """
+        Check if status is ready.
+        :param ctrl_address: the address where the control request needs to be sent
+        :param protocol: protocol of the gateway runtime
+        :param kwargs: extra keyword arguments
+        :return: True if status is ready else False.
+        """
+        if TYPE_CHECKING:
+            from http_service import HTTPService
+        res = False
+        if protocol is None or protocol == 'http':
+            res = HTTPService.async_is_ready(ctrl_address)
+        return res
+
+

--- a/GenAIComps/micro/http_service.py
+++ b/GenAIComps/micro/http_service.py
@@ -1,0 +1,189 @@
+import os
+from typing import Optional
+from base_service import BaseService
+from fastapi import FastAPI
+
+
+class HTTPService(BaseService):
+    """FastAPI HTTP service based on BaseService class. This property should return a fastapi app."""
+
+    def __init__(
+        self,
+        uvicorn_kwargs: Optional[dict] = None,
+        cors: Optional[bool] = False,
+        **kwargs,
+    ):
+        """Initialize the FastAPIBaseGateway
+        :param uvicorn_kwargs: Dictionary of kwargs arguments that will be passed to Uvicorn server when starting the server
+        :param title: The title of this HTTP server. It will be used in automatics docs such as Swagger UI.
+        :param description: The description of this HTTP server. It will be used in automatics docs such as Swagger UI.
+        :param expose_endpoints: A JSON string that represents a map from executor endpoints (`@requests(on=...)`) to HTTP endpoints.
+        :param cors: If set, a CORS middleware is added to FastAPI frontend to allow cross-origin access.
+        :param kwargs: keyword args
+        """
+        super().__init__(**kwargs)
+        self.uvicorn_kwargs = uvicorn_kwargs or {}
+        self.cors = cors
+        self._app = self._create_app()
+
+    @property
+    def app(self):
+        """Get the default base API app for Server
+        :return: Return a FastAPI app for the default HTTPGateway
+        """
+        return self._app
+
+    async def setup_server(self):
+        """
+        Initialize and return GRPC server
+        """
+        self.logger.info(f'Setting up HTTP server')
+        from uvicorn import Config, Server
+
+        class UviServer(Server):
+            """The uvicorn server."""
+
+            async def setup(self, sockets=None):
+                """
+                Setup uvicorn server.
+
+                :param sockets: sockets of server.
+                """
+                config = self.config
+                if not config.loaded:
+                    config.load()
+                self.lifespan = config.lifespan_class(config)
+                await self.startup(sockets=sockets)
+                if self.should_exit:
+                    return
+
+            async def serve(self, **kwargs):
+                """
+                Start the server.
+
+                :param kwargs: keyword arguments
+                """
+                await self.main_loop()
+
+        # app property will generate a new fastapi app each time called
+        app = self.app
+        
+        self.server = UviServer(
+            config=Config(
+                app=app,
+                host=self.host,
+                port=self.port,
+                log_level='info',
+                **self.uvicorn_kwargs,
+            )
+        )
+        self.logger.info(f'UviServer server setup on port {self.port}')
+        await self.server.setup()
+        self.logger.info(f'HTTP server setup successful')
+
+    async def shutdown_server(self):
+        """
+        Free resources allocated when setting up HTTP server
+        """
+        self.logger.info(f'Shutting down server')
+        await super().shutdown()
+        self.server.should_exit = True
+        await self.server.shutdown()
+        self.logger.info(f'Server shutdown finished')
+
+    async def run_server(self):
+        """Run HTTP server forever"""
+        await self.server.serve()
+
+    def _create_app(self):
+        from fastapi.middleware.cors import CORSMiddleware
+        _version = '0.0.1'
+
+        app = FastAPI(
+            title=self.title or 'My GenAI Micro Service',
+            description=self.description
+            or 'This is my awesome service. You can set `title` and `description` '
+            'to customize the title and description.',
+            version=_version,
+        )
+
+        if self.cors:
+            app.add_middleware(
+                CORSMiddleware,
+                allow_origins=['*'],
+                allow_credentials=True,
+                allow_methods=['*'],
+                allow_headers=['*'],
+            )
+            self.logger.warning('CORS is enabled. This service is accessible from any website!')
+
+        @app.get(
+            path='/v1/health_check',
+            summary='Get the status of GenAI microservice',
+            tags=['Debug'],
+        )
+        async def _health_check():
+            """
+            Get the health status of this GenAI microservice.
+            """
+            return {
+                'Service Title': self.title,
+                'Service Description': self.description,
+                'Service Version': _version
+            }
+        
+        return app
+    
+    def _add_route(self, 
+                   endpoint_path, 
+                   route_method,
+                   input_type):
+        app_kwargs = dict(
+            path=f'/{endpoint_path.strip("/")}',
+            methods=[route_method],
+            summary=f'Endpoint {endpoint_path}'
+        )
+
+        app = self.app
+        @app.api_route(**app_kwargs)
+        async def new_route(input: input_type):
+            pass
+
+    @staticmethod
+    def is_ready(
+        ctrl_address: str, timeout: float = 1.0, logger=None, **kwargs
+    ) -> bool:
+        """
+        Check if status is ready.
+        :param ctrl_address: the address where the control request needs to be sent
+        :param timeout: timeout of the health check in seconds
+        :param logger: JinaLogger to be used
+        :param kwargs: extra keyword arguments
+        :return: True if status is ready else False.
+        """
+        import urllib.request
+        from http import HTTPStatus
+
+        try:
+            conn = urllib.request.urlopen(url=f'http://{ctrl_address}', timeout=timeout)
+            return conn.code == HTTPStatus.OK
+        except Exception as exc:
+            if logger:
+                logger.info(f'Exception: {exc}')
+
+            return False
+
+    @staticmethod
+    async def async_is_ready(
+        ctrl_address: str, timeout: float = 1.0, logger=None, **kwargs
+    ) -> bool:
+        """
+        Async Check if status is ready.
+        :param ctrl_address: the address where the control request needs to be sent
+        :param timeout: timeout of the health check in seconds
+        :param logger: JinaLogger to be used
+        :param kwargs: extra keyword arguments
+        :return: True if status is ready else False.
+        """
+        return HTTPService.is_ready(ctrl_address, timeout, logger=logger)
+

--- a/GenAIComps/micro/logger.py
+++ b/GenAIComps/micro/logger.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+import logging
+from typing import Callable
+
+__all__ = [
+    'logger',
+]
+
+
+class Logger(object):
+    def __init__(self, name: str=None):
+        name = 'GenAIComps' if not name else name
+        self.logger = logging.getLogger(name)
+
+        log_config = {
+            'DEBUG': 10,
+            'INFO': 20,
+            'TRAIN': 21,
+            'EVAL': 22,
+            'WARNING': 30,
+            'ERROR': 40,
+            'CRITICAL': 50,
+            'EXCEPTION': 100,
+        }
+        for key, level in log_config.items():
+            logging.addLevelName(level, key)
+            if key == 'EXCEPTION':
+                self.__dict__[key.lower()] = self.logger.exception
+            else:
+                self.__dict__[key.lower()] = functools.partial(self.__call__,
+                                                               level)
+
+        self.format = logging.Formatter(
+            fmt='[%(asctime)-15s] [%(levelname)8s] - %(message)s')
+
+        self.handler = logging.StreamHandler()
+        self.handler.setFormatter(self.format)
+
+        self.logger.addHandler(self.handler)
+        self.logger.setLevel(logging.INFO)
+        self.logger.propagate = False
+
+    def __call__(self, log_level: str, msg: str):
+        self.logger.log(log_level, msg)
+
+    # just for pylint check
+    debug: Callable[[str], None]
+    info: Callable[[str], None]
+    train: Callable[[str], None]
+    eval: Callable[[str], None]
+    warning: Callable[[str], None]
+    error: Callable[[str], None]
+    critical: Callable[[str], None]
+    exception: Callable[[str], None]
+
+
+logger = Logger()

--- a/GenAIComps/micro/utils.py
+++ b/GenAIComps/micro/utils.py
@@ -1,0 +1,28 @@
+
+from socket import AF_INET, SOCK_STREAM, socket
+from typing import (
+    List,
+    Union,
+)
+
+
+def _single_port_free(host: str, port: int) -> bool:
+    with socket(AF_INET, SOCK_STREAM) as session:
+        if session.connect_ex((host, port)) == 0:
+            return False
+        else:
+            return True
+
+
+def is_port_free(host: Union[str, List[str]], port: Union[int, List[int]]) -> bool:
+    if isinstance(port, list):
+        if isinstance(host, str):
+            return all([_single_port_free(host, _p) for _p in port])
+        else:
+            return all([all([_single_port_free(_h, _p) for _p in port]) for _h in host])
+    else:
+        if isinstance(host, str):
+            return _single_port_free(host, port)
+        else:
+            return all([_single_port_free(_h, port) for _h in host])
+


### PR DESCRIPTION
# Description
The framework and base class for microservices.

# Expected behavior
Start an HTTP (fastapi) service using async loop. User could customize microservice based on HTTPService class.

# Test
Tested on local server.

# Usage
'''python
from async_loop import AsyncLoop
args = {
    'name': 'test_loop',
    'cors': False,
    'protocol': 'http',
    'port': 8080,
    'host': 'localhost',
    'runtime_args': {        
        'title': 'test_service',
        'description': "this is a test."
    }
}
loop = AsyncLoop(args)
with loop:
    loop.run_forever()
'''
