### PR TITLE
Add docker & readme for Embedding Microservice

### DIFF
--- a/comps/embeddings/README.md
+++ b/comps/embeddings/README.md
@@ -1,0 +1,97 @@
+# Embeddings Microservice
+
+The Embedding Microservice is designed to efficiently convert textual strings into vectorized embeddings, facilitating seamless integration into various machine learning and data processing workflows. This service utilizes advanced algorithms to generate high-quality embeddings that capture the semantic essence of the input text, making it ideal for applications in natural language processing, information retrieval, and similar fields.
+
+Key Features:
+
+**High Performance**: Optimized for quick and reliable conversion of textual data into vector embeddings.
+
+**Scalability**: Built to handle high volumes of requests simultaneously, ensuring robust performance even under heavy loads.
+
+**Ease of Integration**: Provides a simple and intuitive API, allowing for straightforward integration into existing systems and workflows.
+
+**Customizable**: Supports configuration and customization to meet specific use case requirements, including different embedding models and preprocessing techniques.
+
+Users are albe to configure and build embedding-related services according to their actual needs.
+
+
+# 🚀Start Microservice with Python
+Currently, we provide two ways to implement the embedding service: 
+1. Build the embedding model ***locally*** from the server, which is faster, but takes up memory on the local server.
+
+2. Build it based on the ***TEI endpoint***, which provides more flexibility, but may bring some network latency.
+
+For both of the implementations, you need to install requirements first.
+
+## Install Requirements
+
+```bash
+pip install -r langchain/requirements.txt
+```
+
+## Start Embedding Service with Local Model
+
+```bash
+python local_embedding.py
+```
+
+## Start Embedding Service with TEI
+First, you need to start a TEI service.
+```bash
+your_port=8090
+model="BAAI/bge-large-en-v1.5"
+revision="refs/pr/5"
+docker run -p $your_port:80 -v ./data:/data --name tei_server -e http_proxy=$http_proxy -e https_proxy=$https_proxy --pull always ghcr.io/huggingface/text-embeddings-inference:cpu-1.2 --model-id $model --revision $revision
+```
+
+Then you need to test your TEI service using the following commands:
+```bash
+curl localhost:$your_port/embed \
+    -X POST \
+    -d '{"inputs":"What is Deep Learning?"}' \
+    -H 'Content-Type: application/json'
+```
+
+Start the embedding service with the TEI_ENDPOINT.
+```bash
+cd langchain
+export TEI_ENDPOINT="http://localhost:$yourport"
+python embedding_tei_gaudi.py
+```
+
+
+# 🚀Start Microservice with Docker
+
+## Build Docker Image
+```bash
+cd ../../
+docker build -t genaicomps/microservice/embedding:0.0.1 --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy -f comps/embeddings/docker/Dockerfile .
+```
+
+## Run Docker with CLI
+```bash
+docker run -d --name="embedding_server" -p 6000:6000 --ipc=host -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e TEI_ENDPOINT=$TEI_ENDPOINT  genaicomps/microservice/embedding:0.0.1
+```
+
+## Run Docker with Docker Compose
+```bash
+cd docker
+docker compose -f docker_compose.yaml up -d
+```
+
+
+# 🚀Consume Embedding Service
+## Check Service Status
+```bash
+curl http://localhost:6000/v1/health_check\
+  -X GET \
+  -H 'Content-Type: application/json'
+```
+
+## Consume Embedding Service
+```bash
+curl http://localhost:6000/v1/embeddings\
+  -X POST \
+  -d '{"text":"Hello, world!"}' \
+  -H 'Content-Type: application/json'
+```

--- a/comps/embeddings/README.md
+++ b/comps/embeddings/README.md
@@ -14,12 +14,13 @@ Key Features:
 
 Users are albe to configure and build embedding-related services according to their actual needs.
 
-
 # 🚀Start Microservice with Python
-Currently, we provide two ways to implement the embedding service: 
-1. Build the embedding model ***locally*** from the server, which is faster, but takes up memory on the local server.
 
-2. Build it based on the ***TEI endpoint***, which provides more flexibility, but may bring some network latency.
+Currently, we provide two ways to implement the embedding service:
+
+1. Build the embedding model **_locally_** from the server, which is faster, but takes up memory on the local server.
+
+2. Build it based on the **_TEI endpoint_**, which provides more flexibility, but may bring some network latency.
 
 For both of the implementations, you need to install requirements first.
 
@@ -36,7 +37,9 @@ python local_embedding.py
 ```
 
 ## Start Embedding Service with TEI
+
 First, you need to start a TEI service.
+
 ```bash
 your_port=8090
 model="BAAI/bge-large-en-v1.5"
@@ -45,6 +48,7 @@ docker run -p $your_port:80 -v ./data:/data --name tei_server -e http_proxy=$htt
 ```
 
 Then you need to test your TEI service using the following commands:
+
 ```bash
 curl localhost:$your_port/embed \
     -X POST \
@@ -53,35 +57,39 @@ curl localhost:$your_port/embed \
 ```
 
 Start the embedding service with the TEI_ENDPOINT.
+
 ```bash
 cd langchain
 export TEI_ENDPOINT="http://localhost:$yourport"
 python embedding_tei_gaudi.py
 ```
 
-
 # 🚀Start Microservice with Docker
 
 ## Build Docker Image
+
 ```bash
 cd ../../
 docker build -t genaicomps/microservice/embedding:0.0.1 --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy -f comps/embeddings/docker/Dockerfile .
 ```
 
 ## Run Docker with CLI
+
 ```bash
 docker run -d --name="embedding_server" -p 6000:6000 --ipc=host -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e TEI_ENDPOINT=$TEI_ENDPOINT  genaicomps/microservice/embedding:0.0.1
 ```
 
 ## Run Docker with Docker Compose
+
 ```bash
 cd docker
 docker compose -f docker_compose.yaml up -d
 ```
 
-
 # 🚀Consume Embedding Service
+
 ## Check Service Status
+
 ```bash
 curl http://localhost:6000/v1/health_check\
   -X GET \
@@ -89,6 +97,7 @@ curl http://localhost:6000/v1/health_check\
 ```
 
 ## Consume Embedding Service
+
 ```bash
 curl http://localhost:6000/v1/embeddings\
   -X POST \

--- a/comps/embeddings/docker/Dockerfile
+++ b/comps/embeddings/docker/Dockerfile
@@ -1,0 +1,38 @@
+# Copyright (c) 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM langchain/langchain:latest
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
+    libgl1-mesa-glx \
+    libjemalloc-dev \
+    vim
+
+RUN useradd -m -s /bin/bash user && \
+    mkdir -p /home/user && \
+    chown -R user /home/user/
+
+USER user
+
+COPY comps /home/user/comps
+
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r /home/user/comps/embeddings/langchain/requirements.txt
+
+ENV PYTHONPATH=$PYTHONPATH:/home/user
+
+WORKDIR /home/user/comps/embeddings/langchain
+
+ENTRYPOINT ["python", "embedding_tei_gaudi.py"]
+

--- a/comps/embeddings/docker/docker_compose_embedding.yaml
+++ b/comps/embeddings/docker/docker_compose_embedding.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '3.8'
+version: "3.8"
 
 services:
   embedding:
@@ -30,4 +30,3 @@ services:
 networks:
   default:
     driver: bridge
-

--- a/comps/embeddings/docker/docker_compose_embedding.yaml
+++ b/comps/embeddings/docker/docker_compose_embedding.yaml
@@ -1,0 +1,33 @@
+# Copyright (c) 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: '3.8'
+
+services:
+  embedding:
+    image: genaicomps/microservice/embedding:0.0.1
+    container_name: embedding_server
+    ports:
+      - "6000:6000"
+    ipc: host
+    environment:
+      http_proxy: ${http_proxy}
+      https_proxy: ${https_proxy}
+      TEI_ENDPOINT: ${TEI_ENDPOINT}
+    restart: unless-stopped
+
+networks:
+  default:
+    driver: bridge
+

--- a/comps/embeddings/langchain/embedding_tei_gaudi.py
+++ b/comps/embeddings/langchain/embedding_tei_gaudi.py
@@ -22,13 +22,14 @@ from comps import EmbedDoc1024, TextDoc, opea_microservices, register_microservi
 @register_microservice(
     name="opea_service@embedding_tgi_gaudi",
     expose_endpoint="/v1/embeddings",
+    host="0.0.0.0",
     port=6000,
     input_datatype=TextDoc,
     output_datatype=EmbedDoc1024,
 )
 def embedding(input: TextDoc) -> TextDoc:
     embed_vector = embeddings.embed_query(input.text)
-    res = EmbedDoc1024(query=input.text, embedding=embed_vector)
+    res = EmbedDoc1024(text=input.text, embedding=embed_vector)
     return res
 
 

--- a/comps/embeddings/langchain/requirements.txt
+++ b/comps/embeddings/langchain/requirements.txt
@@ -1,4 +1,4 @@
-langchain
-sentence_transformers
 docarray[full]
 fastapi
+langchain
+sentence_transformers

--- a/comps/embeddings/langchain/requirements.txt
+++ b/comps/embeddings/langchain/requirements.txt
@@ -1,2 +1,4 @@
 langchain
 sentence_transformers
+docarray[full]
+fastapi

--- a/comps/proto/docarray.py
+++ b/comps/proto/docarray.py
@@ -39,7 +39,6 @@ class EmbedDoc1024(BaseDoc):
     embedding: conlist(float, min_length=1024, max_length=1024)
 
 
-
 class Audio2TextDoc(AudioDoc):
     url: Optional[AudioUrl] = Field(
         description="The path to the audio.",

--- a/comps/proto/docarray.py
+++ b/comps/proto/docarray.py
@@ -31,7 +31,13 @@ class Base64ByteStrDoc(BaseDoc):
 
 class EmbedDoc768(BaseDoc):
     text: str
-    embedding: conlist(float, min_items=768, max_items=768)
+    embedding: conlist(float, min_length=768, max_length=768)
+
+
+class EmbedDoc1024(BaseDoc):
+    text: str
+    embedding: conlist(float, min_length=1024, max_length=1024)
+
 
 
 class Audio2TextDoc(AudioDoc):
@@ -47,11 +53,6 @@ class Audio2TextDoc(AudioDoc):
         description="The language that Whisper prefer to detect.",
         default="auto",
     )
-
-
-class EmbedDoc1024(BaseDoc):
-    text: str
-    embedding: conlist(float, min_items=1024, max_items=1024)
 
 
 class SearchedDoc(BaseDoc):


### PR DESCRIPTION
## Type of Change

Docker and Readme.

## Description

Add docker & readme for Embedding Microservice.
Fix minor bugs of embedding service.
Embedding service can be started using docker (manually or docker compose).

## How has this PR been tested?

Local tested on SPR.
![image](https://github.com/opea-project/GenAIComps/assets/106566639/6cea100f-531f-4bbe-8e41-eccc7aaebec9)


## Dependency Change?

Add dependendies in requirements.txt
