### PR TITLE
Add docker and readme for LLM Microservice

### DIFF
--- a/comps/llms/README.md
+++ b/comps/llms/README.md
@@ -6,7 +6,6 @@ A prerequisite for using this microservice is that users must have a Text Genera
 
 Overall, this microservice offers a streamlined way to integrate large language model inference into applications, requiring minimal setup from the user beyond initiating a TGI service and configuring the necessary environment variables. This allows for the seamless processing of queries and documents to generate intelligent, context-aware responses.
 
-
 # 🚀Start Microservice with Python
 
 To start the LLM microservice, you need to install python packages first.
@@ -18,12 +17,14 @@ pip install -r requirements.txt
 ```
 
 ## Start TGI Service Manually
+
 ```bash
 export HUGGINGFACEHUB_API_TOKEN=${your_hf_api_token}
 docker run -p 8008:80 -v ./data:/data --name tgi_service --shm-size 1g ghcr.io/huggingface/text-generation-inference:1.4 --model-id ${your_hf_llm_model}
 ```
 
 ## Verify the TGI Service
+
 ```bash
 curl http://${your_ip}:8008/generate \
   -X POST \
@@ -38,12 +39,12 @@ export TGI_LLM_ENDPOINT="http://${your_ip}:8008"
 python langchain/llm_tgi.py
 ```
 
-
 # 🚀Start Microservice with Docker
 
 If you start an LLM microservice with docker, the `docker_compose_llm.yaml` file will automatically start a TGI service with docker.
 
 ## Setup Environment Variables
+
 In order to start TGI and LLM services, you need to setup the following environment variables first.
 
 ```bash

--- a/comps/llms/README.md
+++ b/comps/llms/README.md
@@ -1,0 +1,92 @@
+# LLM Microservice
+
+This microservice, designed for Language Model Inference (LLM), processes input consisting of a query string and associated reranked documents. It constructs a prompt based on the query and documents, which is then used to perform inference with a large language model. The service delivers the inference results as output.
+
+A prerequisite for using this microservice is that users must have a Text Generation Inference (TGI) service already running. Users need to set the TGI service's endpoint into an environment variable. The microservice utilizes this endpoint to create an LLM object, enabling it to communicate with the TGI service for executing language model operations.
+
+Overall, this microservice offers a streamlined way to integrate large language model inference into applications, requiring minimal setup from the user beyond initiating a TGI service and configuring the necessary environment variables. This allows for the seamless processing of queries and documents to generate intelligent, context-aware responses.
+
+
+# 🚀Start Microservice with Python
+
+To start the LLM microservice, you need to install python packages first.
+
+## Install Requirements
+
+```bash
+pip install -r requirements.txt
+```
+
+## Start TGI Service Manually
+```bash
+export HUGGINGFACEHUB_API_TOKEN=${your_hf_api_token}
+docker run -p 8008:80 -v ./data:/data --name tgi_service --shm-size 1g ghcr.io/huggingface/text-generation-inference:1.4 --model-id ${your_hf_llm_model}
+```
+
+## Verify the TGI Service
+```bash
+curl http://${your_ip}:8008/generate \
+  -X POST \
+  -d '{"inputs":"What is Deep Learning?","parameters":{"max_new_tokens":17, "do_sample": true}}' \
+  -H 'Content-Type: application/json'
+```
+
+## Start LLM Service with Python Script
+
+```bash
+export TGI_LLM_ENDPOINT="http://${your_ip}:8008"
+python langchain/llm_tgi.py
+```
+
+
+# 🚀Start Microservice with Docker
+
+If you start an LLM microservice with docker, the `docker_compose_llm.yaml` file will automatically start a TGI service with docker.
+
+## Setup Environment Variables
+In order to start TGI and LLM services, you need to setup the following environment variables first.
+
+```bash
+export HUGGINGFACEHUB_API_TOKEN=${your_hf_api_token}
+export TGI_LLM_ENDPOINT="http://${your_ip}:8008"
+export LLM_MODEL_ID=${your_hf_llm_model}
+```
+
+## Build Docker Image
+
+```bash
+cd ../../
+docker build -t intel/gen-ai-comps:llm-tgi-server --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy -f comps/llm/langchain/docker/Dockerfile .
+```
+
+## Run Docker with CLI
+
+```bash
+docker run -d --name="llm-tgi-server" -p 9000:9000 --ipc=host -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e TGI_LLM_ENDPOINT=$TGI_LLM_ENDPOINT -e HUGGINGFACEHUB_API_TOKEN=$HUGGINGFACEHUB_API_TOKEN intel/gen-ai-comps:llm-tgi-server
+```
+
+## Run Docker with Docker Compose
+
+```bash
+cd langchain/docker
+docker compose -f docker_compose_llm.yaml up -d
+```
+
+# 🚀Consume LLM Service
+
+## Check Service Status
+
+```bash
+curl http://localhost:9000/v1/health_check\
+  -X GET \
+  -H 'Content-Type: application/json'
+```
+
+## Consume LLM Service
+
+```bash
+curl http://localhost:9000/v1/chat/completions\
+  -X POST \
+  -d '{"input":{"query":"What is Deep Learning?","doc":{"text":"Deep Learning is a subset of machine learning in artificial intelligence (AI) that has networks capable of learning unsupervised from data that is unstructured or unlabeled."}},"params":{"max_new_tokens":128}}' \
+  -H 'Content-Type: application/json'
+```

--- a/comps/llms/langchain/docker/Dockerfile
+++ b/comps/llms/langchain/docker/Dockerfile
@@ -1,0 +1,37 @@
+# Copyright (c) 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM langchain/langchain:latest
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
+    libgl1-mesa-glx \
+    libjemalloc-dev \
+    vim
+
+RUN useradd -m -s /bin/bash user && \
+    mkdir -p /home/user && \
+    chown -R user /home/user/
+
+USER user
+
+COPY comps /home/user/comps
+
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r /home/user/comps/llms/requirements.txt
+
+ENV PYTHONPATH=$PYTHONPATH:/home/user
+
+WORKDIR /home/user/comps/llms/langchain
+
+ENTRYPOINT ["python", "llm_tgi_gaudi.py"]

--- a/comps/llms/langchain/docker/docker_compose_llm.yaml
+++ b/comps/llms/langchain/docker/docker_compose_llm.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: '3.8'
+version: "3.8"
 
 services:
   tgi_service:
@@ -40,4 +40,3 @@ services:
 networks:
   default:
     driver: bridge
-

--- a/comps/llms/langchain/docker/docker_compose_llm.yaml
+++ b/comps/llms/langchain/docker/docker_compose_llm.yaml
@@ -1,0 +1,43 @@
+# Copyright (c) 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version: '3.8'
+
+services:
+  tgi_service:
+    image: ghcr.io/huggingface/text-generation-inference:1.4
+    container_name: tgi_service
+    ports:
+      - "8008:80"
+    volumes:
+      - "./data:/data"
+    shm_size: 1g
+    command: --model-id ${LLM_MODEL_ID}
+  llm:
+    image: intel/gen-ai-comps:llm-tgi-server
+    container_name: llm-tgi-server
+    ports:
+      - "9000:9000"
+    ipc: host
+    environment:
+      http_proxy: ${http_proxy}
+      https_proxy: ${https_proxy}
+      TGI_LLM_ENDPOINT: ${TGI_LLM_ENDPOINT}
+      HUGGINGFACEHUB_API_TOKEN: ${HUGGINGFACEHUB_API_TOKEN}
+    restart: unless-stopped
+
+networks:
+  default:
+    driver: bridge
+

--- a/comps/llms/langchain/llm_tgi.py
+++ b/comps/llms/langchain/llm_tgi.py
@@ -20,11 +20,7 @@ from langchain_core.prompts import ChatPromptTemplate
 from comps import GeneratedDoc, LLMParamsDoc, RerankedDoc, opea_microservices, register_microservice
 
 
-@register_microservice(
-        name="opea_service@llm_tgi", 
-        expose_endpoint="/v1/chat/completions", 
-        host="0.0.0.0",
-        port=9000)
+@register_microservice(name="opea_service@llm_tgi", expose_endpoint="/v1/chat/completions", host="0.0.0.0", port=9000)
 def llm_generate(input: RerankedDoc, params: LLMParamsDoc = None) -> GeneratedDoc:
     llm_endpoint = os.getenv("TGI_LLM_ENDPOINT", "http://localhost:8080")
     params = params if params else LLMParamsDoc()

--- a/comps/llms/langchain/llm_tgi.py
+++ b/comps/llms/langchain/llm_tgi.py
@@ -13,21 +13,21 @@
 # limitations under the License.
 
 import os
-from typing import Union
 
 from langchain_community.llms import HuggingFaceEndpoint
-from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 
-from comps import GeneratedDoc, LLMParamsDoc, RerankedDoc, TextDoc, opea_microservices, register_microservice
+from comps import GeneratedDoc, LLMParamsDoc, RerankedDoc, opea_microservices, register_microservice
 
 
 @register_microservice(
-    name="opea_service@llm_tgi_gaudi", expose_endpoint="/v1/chat/completions", host="0.0.0.0", port=9000
-)
-def llm_generate(input: Union[TextDoc, RerankedDoc]) -> GeneratedDoc:
+        name="opea_service@llm_tgi", 
+        expose_endpoint="/v1/chat/completions", 
+        host="0.0.0.0",
+        port=9000)
+def llm_generate(input: RerankedDoc, params: LLMParamsDoc = None) -> GeneratedDoc:
     llm_endpoint = os.getenv("TGI_LLM_ENDPOINT", "http://localhost:8080")
-    params = LLMParamsDoc()
+    params = params if params else LLMParamsDoc()
     llm = HuggingFaceEndpoint(
         endpoint_url=llm_endpoint,
         max_new_tokens=params.max_new_tokens,
@@ -38,22 +38,17 @@ def llm_generate(input: Union[TextDoc, RerankedDoc]) -> GeneratedDoc:
         repetition_penalty=params.repetition_penalty,
         streaming=params.streaming,
     )
-    if isinstance(input, RerankedDoc):
-        template = """Answer the question based only on the following context:
-        {context}
+    template = """Answer the question based only on the following context:
+    {context}
 
-        Question: {question}
-        """
-        prompt = ChatPromptTemplate.from_template(template)
-        chain = prompt | llm | StrOutputParser()
-        response = chain.invoke({"question": input.query, "context": input.doc.text})
-    elif isinstance(input, TextDoc):
-        response = llm.invoke(input.text)
-    else:
-        raise TypeError("Invalid input type. Expected TextDoc or RerankedDoc.")
+    Question: {query}
+    """
+    prompt_template = ChatPromptTemplate.from_template(template)
+    prompt = prompt_template.format(context=input.doc.text, query=input.query)
+    response = llm.invoke(prompt)
     res = GeneratedDoc(text=response, prompt=input.query)
     return res
 
 
 if __name__ == "__main__":
-    opea_microservices["opea_service@llm_tgi_gaudi"].start()
+    opea_microservices["opea_service@llm_tgi"].start()

--- a/comps/llms/requirements.txt
+++ b/comps/llms/requirements.txt
@@ -1,4 +1,4 @@
 docarray[full]
 fastapi
+langchain==0.1.16
 huggingface_hub
-langchain_community

--- a/comps/llms/requirements.txt
+++ b/comps/llms/requirements.txt
@@ -1,4 +1,4 @@
 docarray[full]
 fastapi
-langchain==0.1.16
 huggingface_hub
+langchain==0.1.16


### PR DESCRIPTION
## Type of Change

Dockerfile and README

## Description

Add dockerfile and README for LLM Microservice.
Add requirements.
LLM service can be started using docker (manually or docker compose).

## How has this PR been tested?

Local tested on SPR.
![image](https://github.com/opea-project/GenAIComps/assets/106566639/f1aa8f64-986a-46b5-a8f1-c785ee42f640)


## Dependency Change?

Add dependendies in requirements.txt
