### PR TITLE
 Bug fix LLM Dockerfile would not build

### DIFF
--- a/comps/llms/langchain/docker/Dockerfile
+++ b/comps/llms/langchain/docker/Dockerfile
@@ -28,8 +28,7 @@ USER user
 COPY comps /home/user/comps
 
 RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir -r /home/user/comps/llms/requirements.txt && \
-    pip install --no-cache-dir -r /home/user/comps/cores/telemetry/requirements.txt
+    pip install --no-cache-dir -r /home/user/comps/llms/requirements.txt
 
 ENV PYTHONPATH=$PYTHONPATH:/home/user
 


### PR DESCRIPTION
## Bug fix

## Description

Bug fix: Dockerfile (`comps/llms/langchain/docker/Dockerfile`) referenced file that does not exist (`comps/cores/telemetry/requirements.txt`).  This file was removed in following commit: 

[migrate all the ut cases under cores and fix bug (](https://github.com/opea-project/GenAIComps/commit/a9399ed8579778f8aebfb01794d992b193791c0a)https://github.com/opea-project/GenAIComps/pull/47[)](https://github.com/opea-project/GenAIComps/commit/a9399ed8579778f8aebfb01794d992b193791c0a) by @chensuyue.

 Following Docker build would error.

```
docker build -t opea/gen-ai-comps:llm-tgi-server --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy -f comps/llms/langchain/docker/Dockerfile .
```

## How has this PR been tested?

Docker build now passes:

```
docker build -t opea/gen-ai-comps:llm-tgi-server --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy -f comps/llms/langchain/docker/Dockerfile .
```

## Dependency Change?

None