### PR TITLE
The embedding model should be consistent for microservice retriever

### DIFF
--- a/comps/retrievers/langchain/retriever_redis.py
+++ b/comps/retrievers/langchain/retriever_redis.py
@@ -30,7 +30,6 @@ from comps import (
 
 tei_embedding_endpoint = os.getenv("TEI_EMBEDDING_ENDPOINT")
 
-
 @register_microservice(
     name="opea_service@retriever_redis",
     service_type=ServiceType.RETRIEVER,

--- a/comps/retrievers/langchain/retriever_redis.py
+++ b/comps/retrievers/langchain/retriever_redis.py
@@ -30,6 +30,7 @@ from comps import (
 
 tei_embedding_endpoint = os.getenv("TEI_EMBEDDING_ENDPOINT")
 
+
 @register_microservice(
     name="opea_service@retriever_redis",
     service_type=ServiceType.RETRIEVER,

--- a/comps/retrievers/langchain/retriever_redis.py
+++ b/comps/retrievers/langchain/retriever_redis.py
@@ -39,9 +39,12 @@ tei_embedding_endpoint = os.getenv("TEI_EMBEDDING_ENDPOINT")
 )
 @opea_telemetry
 def retrieve(input: EmbedDoc768) -> SearchedDoc:
+    # Create vectorstore
     if tei_embedding_endpoint:
+        # create embeddings using TEI endpoint service
         embeddings = HuggingFaceHubEmbeddings(model=tei_embedding_endpoint)
     else:
+        # create embeddings using local embedding model
         embeddings = HuggingFaceBgeEmbeddings(model_name=EMBED_MODEL)
 
     vector_db = Redis.from_existing_index(

--- a/comps/retrievers/langchain/retriever_redis.py
+++ b/comps/retrievers/langchain/retriever_redis.py
@@ -43,6 +43,7 @@ def retrieve(input: EmbedDoc768) -> SearchedDoc:
         embeddings = HuggingFaceHubEmbeddings(model=tei_embedding_endpoint)
     else:
         embeddings = HuggingFaceBgeEmbeddings(model_name=EMBED_MODEL)
+
     vector_db = Redis.from_existing_index(
         embedding=embeddings,
         index_name=INDEX_NAME,

--- a/comps/retrievers/langchain/retriever_redis.py
+++ b/comps/retrievers/langchain/retriever_redis.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 
-from langchain_community.embeddings import HuggingFaceBgeEmbeddings
+from langchain_community.embeddings import HuggingFaceBgeEmbeddings, HuggingFaceHubEmbeddings
 from langchain_community.vectorstores import Redis
-from redis_config import INDEX_NAME, INDEX_SCHEMA, REDIS_URL
+from redis_config import EMBED_MODEL, INDEX_NAME, INDEX_SCHEMA, REDIS_URL
 
 from comps import (
     EmbedDoc768,
@@ -27,6 +28,7 @@ from comps import (
     register_microservice,
 )
 
+tei_embedding_endpoint = os.getenv("TEI_EMBEDDING_ENDPOINT")
 
 @register_microservice(
     name="opea_service@retriever_redis",
@@ -37,7 +39,10 @@ from comps import (
 )
 @opea_telemetry
 def retrieve(input: EmbedDoc768) -> SearchedDoc:
-    embeddings = HuggingFaceBgeEmbeddings(model_name="BAAI/bge-base-en-v1.5")
+    if tei_embedding_endpoint:
+        embeddings = HuggingFaceHubEmbeddings(model=tei_embedding_endpoint)
+    else:
+        embeddings = HuggingFaceBgeEmbeddings(model_name=EMBED_MODEL)
     vector_db = Redis.from_existing_index(
         embedding=embeddings,
         index_name=INDEX_NAME,


### PR DESCRIPTION
## Description

The ingestion and `redis` retriever should use the same embedding model. It seems that the ingestion decides the embedding model based on environment variable `TEI_EMBEDDING_ENDPOINT`, but `redis` retriever use a hardcode model named `BAAI/bge-base-en-v1.5`.  This PR makes them consistent.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

I run the test in my local K8s cluster.
