### PR TITLE
Fix Stream Forwarding Issue

### DIFF
--- a/comps/cores/mega/orchestrator.py
+++ b/comps/cores/mega/orchestrator.py
@@ -73,7 +73,7 @@ class ServiceOrchestrator(DAG):
 
             def generate():
                 if response:
-                    for chunk in response.iter_lines(decode_unicode=False, delimiter=b"\0"):
+                    for chunk in response.iter_content(chunk_size=None):
                         if chunk:
                             yield chunk
 

--- a/comps/llms/langchain/llm_tgi.py
+++ b/comps/llms/langchain/llm_tgi.py
@@ -55,9 +55,9 @@ def llm_generate(input: LLMParamsDoc):
 
     if input.streaming:
 
-        def stream_generator():
+        async def stream_generator():
             chat_response = ""
-            for text in llm.stream(input.query):
+            async for text in llm.astream(input.query):
                 chat_response += text
                 processed_text = post_process_text(text)
                 if text and processed_text:


### PR DESCRIPTION
## Description

Fix the stream forwarding issue between LLM and Megaservice gateway.
Two root causes:
1. HuggingFaceEndpoint.stream
    - `llm.stream` doesn't work in streaming way, need to use `llm.atream` instead
    - Need to modify the generator into asynchronous function.
2. SSE Protocol
- response.iter_lines()
    - **delimiter=b"\0"**：Recognizes a stream of bytes as a whole chunk and returns it in one shot.
    - **delimiter=None**: The default use of “\n” incorrectly cuts the byte stream, resulting in the absence of the required end identifier “\n\n” in the yield format.
- response.iter_content()
    - **chunk_size=None**：If stream=True, it will not cut the byte stream twice, and output the byte according to the received byte size directly; if stream=False, it will cut the byte stream with chunk_size=1.
    - **chunk_size=1/128 (int)**：The byte stream is cut according to the `chunk_size`, but the bytes are not deleted (unlike delimiter). When returning with the SSE protocol, the data received by the client will be based on the `data:` and `\n\n` identifiers, instead of the `chunk_size`. The `chunk_size` will not affect the transfer of data, but increase the effort of byte stream cutting. So `response.iter_content(chunk_size=None)` is adopted here.

## Issues

n/a

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

None

## Tests

Local tested on SPR.
Integration test with frontend.
