### PR TITLE
Enable Benchmark with Langsmith

### DIFF
--- a/comps/dataprep/redis/README.md
+++ b/comps/dataprep/redis/README.md
@@ -17,6 +17,9 @@ Please refer to this [readme](../../../vectorstores/langchain/redis/README.md).
 ```bash
 export REDIS_URL="redis://${your_ip}:6379"
 export INDEX_NAME=${your_index_name}
+export LANGCHAIN_TRACING_V2=true
+export LANGCHAIN_API_KEY=${your_langchain_api_key}
+export LANGCHAIN_PROJECT="opea/gen-ai-comps:dataprep"
 ```
 
 ## Start Document Preparation Microservice for Redis with Python Script
@@ -41,6 +44,9 @@ docker build -t opea/gen-ai-comps:dataprep-redis-xeon-server --build-arg https_p
 ```bash
 export REDIS_URL="redis://${your_ip}:6379"
 export INDEX_NAME=${your_index_name}
+export LANGCHAIN_TRACING_V2=true
+export LANGCHAIN_API_KEY=${your_langchain_api_key}
+export LANGCHAIN_PROJECT="opea/gen-ai-comps:dataprep"
 
 docker run -d --name="dataprep-redis-server" -p 6007:6007 --ipc=host -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e REDIS_URL=$REDIS_URL -e INDEX_NAME=$INDEX_NAME opea/gen-ai-comps:dataprep-redis-xeon-server
 ```

--- a/comps/dataprep/redis/docker/docker-compose-dataprep-redis.yaml
+++ b/comps/dataprep/redis/docker/docker-compose-dataprep-redis.yaml
@@ -32,6 +32,7 @@ services:
       REDIS_URL: ${REDIS_URL}
       INDEX_NAME: ${INDEX_NAME}
       TEI_ENDPOINT: ${TEI_ENDPOINT}
+      LANGCHAIN_API_KEY: ${LANGCHAIN_API_KEY}
     restart: unless-stopped
 
 networks:

--- a/comps/dataprep/redis/prepare_doc_redis.py
+++ b/comps/dataprep/redis/prepare_doc_redis.py
@@ -17,12 +17,13 @@ import os
 import uuid
 from pathlib import Path
 from typing import List, Optional, Union
-from langsmith import traceable
+
 from config import EMBED_MODEL, INDEX_NAME, INDEX_SCHEMA, REDIS_URL
 from fastapi import File, Form, HTTPException, UploadFile
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_community.embeddings import HuggingFaceBgeEmbeddings, HuggingFaceHubEmbeddings
 from langchain_community.vectorstores import Redis
+from langsmith import traceable
 
 from comps import DocPath, opea_microservices, register_microservice
 from comps.dataprep.utils import docment_loader, parse_html

--- a/comps/dataprep/redis/prepare_doc_redis.py
+++ b/comps/dataprep/redis/prepare_doc_redis.py
@@ -17,7 +17,7 @@ import os
 import uuid
 from pathlib import Path
 from typing import List, Optional, Union
-
+from langsmith import traceable
 from config import EMBED_MODEL, INDEX_NAME, INDEX_SCHEMA, REDIS_URL
 from fastapi import File, Form, HTTPException, UploadFile
 from langchain.text_splitter import RecursiveCharacterTextSplitter
@@ -107,6 +107,7 @@ def ingest_link_to_redis(link_list: List[str]):
 
 
 @register_microservice(name="opea_service@prepare_doc_redis", endpoint="/v1/dataprep", host="0.0.0.0", port=6007)
+@traceable(run_type="tool")
 async def ingest_documents(
     files: Optional[Union[UploadFile, List[UploadFile]]] = File(None), link_list: Optional[str] = Form(None)
 ):

--- a/comps/dataprep/redis/requirements.txt
+++ b/comps/dataprep/redis/requirements.txt
@@ -4,8 +4,8 @@ easyocr
 fastapi
 huggingface_hub
 langchain
-langsmith
 langchain-community
+langsmith
 numpy
 opentelemetry-api
 opentelemetry-exporter-otlp

--- a/comps/dataprep/redis/requirements.txt
+++ b/comps/dataprep/redis/requirements.txt
@@ -4,6 +4,7 @@ easyocr
 fastapi
 huggingface_hub
 langchain
+langsmith
 langchain-community
 numpy
 opentelemetry-api

--- a/comps/embeddings/README.md
+++ b/comps/embeddings/README.md
@@ -61,6 +61,9 @@ Start the embedding service with the TEI_EMBEDDING_ENDPOINT.
 ```bash
 cd langchain
 export TEI_EMBEDDING_ENDPOINT="http://localhost:$yourport"
+export LANGCHAIN_TRACING_V2=true
+export LANGCHAIN_API_KEY=${your_langchain_api_key}
+export LANGCHAIN_PROJECT="opea/gen-ai-comps:embeddings"
 python embedding_tei_gaudi.py
 ```
 

--- a/comps/embeddings/langchain/docker/docker_compose_embedding.yaml
+++ b/comps/embeddings/langchain/docker/docker_compose_embedding.yaml
@@ -25,6 +25,7 @@ services:
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       TEI_EMBEDDING_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
+      LANGCHAIN_API_KEY: ${LANGCHAIN_API_KEY}
     restart: unless-stopped
 
 networks:

--- a/comps/embeddings/langchain/embedding_tei_gaudi.py
+++ b/comps/embeddings/langchain/embedding_tei_gaudi.py
@@ -16,7 +16,8 @@ import os
 
 from langchain_community.embeddings import HuggingFaceHubEmbeddings
 
-from comps import EmbedDoc768, ServiceType, TextDoc, opea_microservices, opea_telemetry, register_microservice
+from langsmith import traceable
+from comps import EmbedDoc768, ServiceType, TextDoc, opea_microservices, register_microservice
 
 
 @register_microservice(
@@ -28,7 +29,7 @@ from comps import EmbedDoc768, ServiceType, TextDoc, opea_microservices, opea_te
     input_datatype=TextDoc,
     output_datatype=EmbedDoc768,
 )
-@opea_telemetry
+@traceable(run_type="embedding")
 def embedding(input: TextDoc) -> EmbedDoc768:
     embed_vector = embeddings.embed_query(input.text)
     embed_vector = embed_vector[:768]  # Keep only the first 768 elements

--- a/comps/embeddings/langchain/embedding_tei_gaudi.py
+++ b/comps/embeddings/langchain/embedding_tei_gaudi.py
@@ -15,8 +15,8 @@
 import os
 
 from langchain_community.embeddings import HuggingFaceHubEmbeddings
-
 from langsmith import traceable
+
 from comps import EmbedDoc768, ServiceType, TextDoc, opea_microservices, register_microservice
 
 

--- a/comps/embeddings/langchain/requirements.txt
+++ b/comps/embeddings/langchain/requirements.txt
@@ -2,6 +2,7 @@ docarray[full]
 fastapi
 huggingface_hub
 langchain
+langsmith
 opentelemetry-api
 opentelemetry-exporter-otlp
 opentelemetry-sdk

--- a/comps/guardrails/README.md
+++ b/comps/guardrails/README.md
@@ -34,6 +34,9 @@ pip install -r requirements.txt
 
 ```bash
 export HUGGINGFACEHUB_API_TOKEN=${your_hf_api_token}
+export LANGCHAIN_TRACING_V2=true
+export LANGCHAIN_API_KEY=${your_langchain_api_key}
+export LANGCHAIN_PROJECT="opea/gen-ai-comps:gaurdrails"
 volume=$PWD/data
 model_id="meta-llama/LlamaGuard-7b"
 docker pull ghcr.io/huggingface/tgi-gaudi:1.2.1
@@ -68,6 +71,9 @@ In order to start TGI and LLM services, you need to setup the following environm
 export HUGGINGFACEHUB_API_TOKEN=${your_hf_api_token}
 export SAFETY_GUARD_ENDPOINT="http://${your_ip}:8088"
 export LLM_MODEL_ID=${your_hf_llm_model}
+export LANGCHAIN_TRACING_V2=true
+export LANGCHAIN_API_KEY=${your_langchain_api_key}
+export LANGCHAIN_PROJECT="opea/gen-ai-comps:gaurdrails"
 ```
 
 ## Build Docker Image

--- a/comps/guardrails/langchain/docker/docker_compose_guardrails.yaml
+++ b/comps/guardrails/langchain/docker/docker_compose_guardrails.yaml
@@ -34,6 +34,7 @@ services:
       http_proxy: ${http_proxy}
       https_proxy: ${https_proxy}
       SAFETY_GUARD_ENDPOINT: ${SAFETY_GUARD_ENDPOINT}
+      LANGCHAIN_API_KEY: ${LANGCHAIN_API_KEY}
     restart: unless-stopped
 
 networks:

--- a/comps/guardrails/langchain/guardrails_tgi_gaudi.py
+++ b/comps/guardrails/langchain/guardrails_tgi_gaudi.py
@@ -14,8 +14,8 @@
 
 import os
 
-from langsmith import traceable
 from langchain_community.llms import HuggingFaceEndpoint
+from langsmith import traceable
 
 from comps import ServiceType, TextDoc, opea_microservices, register_microservice
 

--- a/comps/guardrails/langchain/guardrails_tgi_gaudi.py
+++ b/comps/guardrails/langchain/guardrails_tgi_gaudi.py
@@ -14,9 +14,10 @@
 
 import os
 
+from langsmith import traceable
 from langchain_community.llms import HuggingFaceEndpoint
 
-from comps import ServiceType, TextDoc, opea_microservices, opea_telemetry, register_microservice
+from comps import ServiceType, TextDoc, opea_microservices, register_microservice
 
 unsafe_categories = """O1: Violence and Hate.
 Should not
@@ -75,7 +76,6 @@ unsafe_dict = {
 }
 
 
-@opea_telemetry
 def moderation_prompt_for_chat(chat):
     # For simplicity, we assume the chat dictionary correctly alternates "user" and "assistant" roles
     # Feel free to include error checking if needed
@@ -113,7 +113,7 @@ Provide your safety assessment for {role} in the above conversation:
     input_datatype=TextDoc,
     output_datatype=TextDoc,
 )
-@opea_telemetry
+@traceable(run_type="llm")
 def safety_guard(input: TextDoc) -> TextDoc:
     # prompt guardrails
     response_input_guard = llm_guard(moderation_prompt_for_chat([{"role": "User", "content": input.text}]))

--- a/comps/guardrails/requirements.txt
+++ b/comps/guardrails/requirements.txt
@@ -1,8 +1,8 @@
 docarray[full]
 fastapi
 huggingface_hub
-langsmith
 langchain_community
+langsmith
 opentelemetry-api
 opentelemetry-exporter-otlp
 opentelemetry-sdk

--- a/comps/guardrails/requirements.txt
+++ b/comps/guardrails/requirements.txt
@@ -1,6 +1,7 @@
 docarray[full]
 fastapi
 huggingface_hub
+langsmith
 langchain_community
 opentelemetry-api
 opentelemetry-exporter-otlp

--- a/comps/llms/README.md
+++ b/comps/llms/README.md
@@ -20,6 +20,9 @@ pip install -r requirements.txt
 
 ```bash
 export HUGGINGFACEHUB_API_TOKEN=${your_hf_api_token}
+export LANGCHAIN_TRACING_V2=true
+export LANGCHAIN_API_KEY=${your_langchain_api_key}
+export LANGCHAIN_PROJECT="opea/gen-ai-comps:llms"
 docker run -p 8008:80 -v ./data:/data --name tgi_service --shm-size 1g ghcr.io/huggingface/text-generation-inference:1.4 --model-id ${your_hf_llm_model}
 ```
 
@@ -51,6 +54,9 @@ In order to start TGI and LLM services, you need to setup the following environm
 export HUGGINGFACEHUB_API_TOKEN=${your_hf_api_token}
 export TGI_LLM_ENDPOINT="http://${your_ip}:8008"
 export LLM_MODEL_ID=${your_hf_llm_model}
+export LANGCHAIN_TRACING_V2=true
+export LANGCHAIN_API_KEY=${your_langchain_api_key}
+export LANGCHAIN_PROJECT="opea/gen-ai-comps:llms"
 ```
 
 ## Build Docker Image

--- a/comps/llms/summarization/tgi/docker_compose_llm.yaml
+++ b/comps/llms/summarization/tgi/docker_compose_llm.yaml
@@ -35,6 +35,7 @@ services:
       https_proxy: ${https_proxy}
       TGI_LLM_ENDPOINT: ${TGI_LLM_ENDPOINT}
       HUGGINGFACEHUB_API_TOKEN: ${HUGGINGFACEHUB_API_TOKEN}
+      LANGCHAIN_API_KEY: ${LANGCHAIN_API_KEY}
     restart: unless-stopped
 
 networks:

--- a/comps/llms/summarization/tgi/llm.py
+++ b/comps/llms/summarization/tgi/llm.py
@@ -14,16 +14,17 @@
 
 import os
 
+from langsmith import traceable
 from fastapi.responses import StreamingResponse
 from langchain.chains.summarize import load_summarize_chain
 from langchain.docstore.document import Document
 from langchain.text_splitter import CharacterTextSplitter
 from langchain_community.llms import HuggingFaceEndpoint
 
-from comps import GeneratedDoc, LLMParamsDoc, ServiceType, opea_microservices, opea_telemetry, register_microservice
+from comps import GeneratedDoc, LLMParamsDoc, ServiceType, opea_microservices, register_microservice
 
 
-@opea_telemetry
+@traceable(run_type="tool")
 def post_process_text(text: str):
     if text == " ":
         return "data: @#$\n\n"
@@ -42,7 +43,7 @@ def post_process_text(text: str):
     host="0.0.0.0",
     port=9000,
 )
-@opea_telemetry
+@traceable(run_type="llm")
 def llm_generate(input: LLMParamsDoc):
     llm_endpoint = os.getenv("TGI_LLM_ENDPOINT", "http://localhost:8080")
     llm = HuggingFaceEndpoint(

--- a/comps/llms/summarization/tgi/llm.py
+++ b/comps/llms/summarization/tgi/llm.py
@@ -14,12 +14,12 @@
 
 import os
 
-from langsmith import traceable
 from fastapi.responses import StreamingResponse
 from langchain.chains.summarize import load_summarize_chain
 from langchain.docstore.document import Document
 from langchain.text_splitter import CharacterTextSplitter
 from langchain_community.llms import HuggingFaceEndpoint
+from langsmith import traceable
 
 from comps import GeneratedDoc, LLMParamsDoc, ServiceType, opea_microservices, register_microservice
 

--- a/comps/llms/summarization/tgi/requirements.txt
+++ b/comps/llms/summarization/tgi/requirements.txt
@@ -3,6 +3,7 @@ fastapi
 huggingface_hub
 langchain==0.1.16
 langserve
+langsmith
 opentelemetry-api
 opentelemetry-exporter-otlp
 opentelemetry-sdk

--- a/comps/llms/text-generation/tgi/docker_compose_llm.yaml
+++ b/comps/llms/text-generation/tgi/docker_compose_llm.yaml
@@ -35,6 +35,7 @@ services:
       https_proxy: ${https_proxy}
       TGI_LLM_ENDPOINT: ${TGI_LLM_ENDPOINT}
       HUGGINGFACEHUB_API_TOKEN: ${HUGGINGFACEHUB_API_TOKEN}
+      LANGCHAIN_API_KEY: ${LANGCHAIN_API_KEY}
     restart: unless-stopped
 
 networks:

--- a/comps/llms/text-generation/tgi/llm.py
+++ b/comps/llms/text-generation/tgi/llm.py
@@ -14,13 +14,14 @@
 
 import os
 
+from langsmith import traceable
 from fastapi.responses import StreamingResponse
 from langchain_community.llms import HuggingFaceEndpoint
 
-from comps import GeneratedDoc, LLMParamsDoc, ServiceType, opea_microservices, opea_telemetry, register_microservice
+from comps import GeneratedDoc, LLMParamsDoc, ServiceType, opea_microservices, register_microservice
 
 
-@opea_telemetry
+@traceable(run_type="tool")
 def post_process_text(text: str):
     if text == " ":
         return "data: @#$\n\n"
@@ -39,7 +40,7 @@ def post_process_text(text: str):
     host="0.0.0.0",
     port=9000,
 )
-@opea_telemetry
+@traceable(run_type="llm")
 def llm_generate(input: LLMParamsDoc):
     llm_endpoint = os.getenv("TGI_LLM_ENDPOINT", "http://localhost:8080")
     llm = HuggingFaceEndpoint(

--- a/comps/llms/text-generation/tgi/llm.py
+++ b/comps/llms/text-generation/tgi/llm.py
@@ -14,9 +14,9 @@
 
 import os
 
-from langsmith import traceable
 from fastapi.responses import StreamingResponse
 from langchain_community.llms import HuggingFaceEndpoint
+from langsmith import traceable
 
 from comps import GeneratedDoc, LLMParamsDoc, ServiceType, opea_microservices, register_microservice
 

--- a/comps/llms/text-generation/tgi/requirements.txt
+++ b/comps/llms/text-generation/tgi/requirements.txt
@@ -3,6 +3,7 @@ fastapi
 huggingface_hub
 langchain==0.1.16
 langserve
+langsmith
 opentelemetry-api
 opentelemetry-exporter-otlp
 opentelemetry-sdk

--- a/comps/reranks/README.md
+++ b/comps/reranks/README.md
@@ -16,6 +16,9 @@ pip install -r requirements.txt
 
 ```bash
 export HUGGINGFACEHUB_API_TOKEN=${your_hf_api_token}
+export LANGCHAIN_TRACING_V2=true
+export LANGCHAIN_API_KEY=${your_langchain_api_key}
+export LANGCHAIN_PROJECT="opea/gen-ai-comps:reranks"
 model=BAAI/bge-reranker-large
 revision=refs/pr/4
 volume=$PWD/data

--- a/comps/reranks/langchain/docker/docker_compose_reranking.yaml
+++ b/comps/reranks/langchain/docker/docker_compose_reranking.yaml
@@ -35,6 +35,7 @@ services:
       https_proxy: ${https_proxy}
       TEI_RERANKING_ENDPOINT: ${TEI_RERANKING_ENDPOINT}
       HUGGINGFACEHUB_API_TOKEN: ${HUGGINGFACEHUB_API_TOKEN}
+      LANGCHAIN_API_KEY: ${LANGCHAIN_API_KEY}
     restart: unless-stopped
 
 networks:

--- a/comps/reranks/langchain/local_reranking.py
+++ b/comps/reranks/langchain/local_reranking.py
@@ -12,9 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from langsmith import traceable
 from sentence_transformers import CrossEncoder
 
-from langsmith import traceable
 from comps import RerankedDoc, SearchedDoc, ServiceType, opea_microservices, register_microservice
 
 

--- a/comps/reranks/langchain/local_reranking.py
+++ b/comps/reranks/langchain/local_reranking.py
@@ -14,7 +14,8 @@
 
 from sentence_transformers import CrossEncoder
 
-from comps import RerankedDoc, SearchedDoc, ServiceType, opea_microservices, opea_telemetry, register_microservice
+from langsmith import traceable
+from comps import RerankedDoc, SearchedDoc, ServiceType, opea_microservices, register_microservice
 
 
 @register_microservice(
@@ -26,7 +27,7 @@ from comps import RerankedDoc, SearchedDoc, ServiceType, opea_microservices, ope
     input_datatype=SearchedDoc,
     output_datatype=RerankedDoc,
 )
-@opea_telemetry
+@traceable(run_type="llm")
 def reranking(input: SearchedDoc) -> RerankedDoc:
     query_and_docs = [(input.initial_query, doc.text) for doc in input.retrieved_docs]
     scores = reranker_model.predict(query_and_docs)

--- a/comps/reranks/langchain/reranking_tei_xeon.py
+++ b/comps/reranks/langchain/reranking_tei_xeon.py
@@ -16,9 +16,9 @@
 import json
 import os
 
-from langsmith import traceable
 import requests
 from langchain_core.prompts import ChatPromptTemplate
+from langsmith import traceable
 
 from comps import LLMParamsDoc, SearchedDoc, ServiceType, opea_microservices, register_microservice
 

--- a/comps/reranks/langchain/reranking_tei_xeon.py
+++ b/comps/reranks/langchain/reranking_tei_xeon.py
@@ -16,10 +16,11 @@
 import json
 import os
 
+from langsmith import traceable
 import requests
 from langchain_core.prompts import ChatPromptTemplate
 
-from comps import LLMParamsDoc, SearchedDoc, ServiceType, opea_microservices, opea_telemetry, register_microservice
+from comps import LLMParamsDoc, SearchedDoc, ServiceType, opea_microservices, register_microservice
 
 
 @register_microservice(
@@ -31,7 +32,7 @@ from comps import LLMParamsDoc, SearchedDoc, ServiceType, opea_microservices, op
     input_datatype=SearchedDoc,
     output_datatype=LLMParamsDoc,
 )
-@opea_telemetry
+@traceable(run_type="llm")
 def reranking(input: SearchedDoc) -> LLMParamsDoc:
     docs = [doc.text for doc in input.retrieved_docs]
     url = tei_reranking_endpoint + "/rerank"

--- a/comps/reranks/requirements.txt
+++ b/comps/reranks/requirements.txt
@@ -1,6 +1,7 @@
 docarray[full]
 fastapi
 langchain
+langsmith
 opentelemetry-api
 opentelemetry-exporter-otlp
 opentelemetry-sdk

--- a/comps/retrievers/README.md
+++ b/comps/retrievers/README.md
@@ -32,6 +32,9 @@ docker run -d --name="redis-vector-db" -p 6379:6379 -p 8001:8001 redis/redis-sta
 export REDIS_URL="redis://${your_ip}:6379"
 export INDEX_NAME=${your_index_name}
 export TEI_EMBEDDING_ENDPOINT=${your_embedding_endpoint}
+export LANGCHAIN_TRACING_V2=true
+export LANGCHAIN_API_KEY=${your_langchain_api_key}
+export LANGCHAIN_PROJECT="opea/gen-ai-comps:retrievers"
 ```
 
 ## Start Retriever Service with Local Model

--- a/comps/retrievers/langchain/docker/docker_compose_retriever.yaml
+++ b/comps/retrievers/langchain/docker/docker_compose_retriever.yaml
@@ -27,6 +27,7 @@ services:
       REDIS_URL: ${REDIS_URL}
       INDEX_NAME: ${INDEX_NAME}
       TEI_EMBEDDING_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
+      LANGCHAIN_API_KEY: ${LANGCHAIN_API_KEY}
     restart: unless-stopped
 
 networks:

--- a/comps/retrievers/langchain/retriever_redis.py
+++ b/comps/retrievers/langchain/retriever_redis.py
@@ -14,19 +14,12 @@
 
 import os
 
-from langsmith import traceable
 from langchain_community.embeddings import HuggingFaceBgeEmbeddings, HuggingFaceHubEmbeddings
 from langchain_community.vectorstores import Redis
+from langsmith import traceable
 from redis_config import EMBED_MODEL, INDEX_NAME, INDEX_SCHEMA, REDIS_URL
 
-from comps import (
-    EmbedDoc768,
-    SearchedDoc,
-    ServiceType,
-    TextDoc,
-    opea_microservices,
-    register_microservice,
-)
+from comps import EmbedDoc768, SearchedDoc, ServiceType, TextDoc, opea_microservices, register_microservice
 
 tei_embedding_endpoint = os.getenv("TEI_EMBEDDING_ENDPOINT")
 

--- a/comps/retrievers/langchain/retriever_redis.py
+++ b/comps/retrievers/langchain/retriever_redis.py
@@ -14,6 +14,7 @@
 
 import os
 
+from langsmith import traceable
 from langchain_community.embeddings import HuggingFaceBgeEmbeddings, HuggingFaceHubEmbeddings
 from langchain_community.vectorstores import Redis
 from redis_config import EMBED_MODEL, INDEX_NAME, INDEX_SCHEMA, REDIS_URL
@@ -24,7 +25,6 @@ from comps import (
     ServiceType,
     TextDoc,
     opea_microservices,
-    opea_telemetry,
     register_microservice,
 )
 
@@ -38,7 +38,7 @@ tei_embedding_endpoint = os.getenv("TEI_EMBEDDING_ENDPOINT")
     host="0.0.0.0",
     port=7000,
 )
-@opea_telemetry
+@traceable(run_type="retriever")
 def retrieve(input: EmbedDoc768) -> SearchedDoc:
     # Create vectorstore
     if tei_embedding_endpoint:

--- a/comps/retrievers/requirements.txt
+++ b/comps/retrievers/requirements.txt
@@ -1,6 +1,7 @@
 docarray[full]
 easyocr
 fastapi
+langsmith
 langchain_community
 opentelemetry-api
 opentelemetry-exporter-otlp

--- a/comps/retrievers/requirements.txt
+++ b/comps/retrievers/requirements.txt
@@ -1,8 +1,8 @@
 docarray[full]
 easyocr
 fastapi
-langsmith
 langchain_community
+langsmith
 opentelemetry-api
 opentelemetry-exporter-otlp
 opentelemetry-sdk


### PR DESCRIPTION
## Description

Enable Benchmark with Langsmith.
Users are able to monitor latency and thoughput of each microservices on Langsmith.

## Issues

n/a

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

Add `langsmith` in each `requirements.txt` files.

## Tests

Local tested on SPR.
