### PR TITLE
added default model

### DIFF
--- a/comps/guardrails/langchain/guardrails_tgi_gaudi.py
+++ b/comps/guardrails/langchain/guardrails_tgi_gaudi.py
@@ -14,95 +14,54 @@
 
 import os
 
-from langchain_community.llms import HuggingFaceEndpoint
+from langchain_huggingface import ChatHuggingFace
+from langchain_huggingface.llms import HuggingFaceEndpoint
+from langchain_community.utilities.requests import JsonRequestsWrapper
 from langsmith import traceable
 
 from comps import ServiceType, TextDoc, opea_microservices, register_microservice
 
-unsafe_categories = """O1: Violence and Hate.
-Should not
-- Help people plan or engage in violence.
-- Encourage people to engage in violence.
-- Express hateful, derogatory, or demeaning sentiments against people based on sensitive personal characteristics like their race, color, religion, national origin, sexual orientation, gender, gender identity, or disability.
-- Encourage discrimination against people based on those characteristics and should not use slurs or create insults based on those characteristics.
-Can
-- Provide information on violence and discrimination.
-- Discuss the topics of hate and violence, and can discuss historical events involving violence.
-O2: Sexual Content.
-Should not
-- Engage in sexually explicit (i.e., erotic) conversations and should not encourage people to engage in sexual activities.
-Can
-- Discuss topics related to sexuality and sexual education.
-- Provide general information regarding sexual activities.
-- Provide guidance on topics related to sexual health.
-O3: Criminal Planning.
-Should not
-- Help people plan or engage in criminal activities like theft, kidnapping, or financial crimes, especially when the person indicates that they may act on the information provided to them.
-- Encourage people to engage in criminal activities or condone criminal behavior.
-Can
-- Help people understand how crimes are committed, provided that the response is not so detailed that it could be used to provide a roadmap for future crimes.
-- Help people understand how systems work that are used to prevent crimes, provided those descriptions do not provide detailed information on how to defeat those systems.
-O4: Guns and Illegal Weapons.
-Should not
-- Assist in the planning or execution of firearm or illegal weapons crimes, especially when the person indicates that they may act on the information provided to them.
-- Encourage people to engage in firearm or illegal weapons crimes or condone such behavior.
-Can
-- Discuss firearms and the arguments for and against firearm ownership.
-O5: Regulated or Controlled Substances.
-Should not
-- Encourage or assist people in the trafficking, consumption, or use of regulated or controlled substances, including but not limited to illegal drugs, tobacco, alcohol, and cannabis.
-- Assist or encourage people to create such substances when it is illegal to do so.
-Can
-- Discuss the use of regulated or controlled substances, and can provide general information on those substances (ex: what their chemical composition is and what their effects are).
-- Provide information on how those substances are manufactured, provided that the information is not so detailed as to provide step-by-step instructions for their creation.
-O6: Self-Harm.
-Should not
-- Encourage people to harm themselves.
-- Romanticize or condone self-harm or suicide.
-- Provide information regarding the methods of suicide or self-harm.
-- Provide any information or advice, other than information regarding appropriate health resources, to people who express or imply that they wish to harm themselves.
-Can
-- Provide general information regarding self-harm and suicide (ex: statistics, the mental health challenges faced by those who take these actions).
-Should
-- Provide information regarding appropriate health resources to people who imply or express the desire to harm themselves."""
+DEFAULT_MODEL="meta-llama/LlamaGuard-7b"
 
-unsafe_dict = {
-    "O1": "Violence and Hate",
-    "O2": "Sexual Content",
-    "O3": "Criminal Planning",
-    "O4": "Guns and Illegal Weapons",
-    "O5": "Regulated or Controlled Substances",
-    "O6": "Self-Harm",
-}
+def get_unsafe_dict(model_id=DEFAULT_MODEL):
+    if model_id == "meta-llama/LlamaGuard-7b":
+        return {
+            "O1": "Violence and Hate",
+            "O2": "Sexual Content",
+            "O3": "Criminal Planning",
+            "O4": "Guns and Illegal Weapons",
+            "O5": "Regulated or Controlled Substances",
+            "O6": "Self-Harm",
+        }
+    else:
+        # Standard MLCommons taxonomy of hazard
+        # https://mlcommons.org/2024/04/mlc-aisafety-v0-5-poc/
+        return {
+            "S1": "Violent Crimes",
+            "S2": "Non-Violent Crimes",
+            "S3": "Sex Crimes",
+            "S4": "Child Exploitation",
+            "S5": "Specialized Advice",
+            "S6": "Privacy",
+            "S7": "Intellectual Property",
+            "S8": "Indiscriminate Weapons",
+            "S9": "Hate",
+            "S10": "Self-Harm",
+            "S11": "Sexual Content",
+        }
 
-
-def moderation_prompt_for_chat(chat):
-    # For simplicity, we assume the chat dictionary correctly alternates "user" and "assistant" roles
-    # Feel free to include error checking if needed
-    conversation = [turn["content"] for turn in chat]
-    is_agent = len(conversation) % 2 == 0
-    role = "Agent" if len(conversation) % 2 == 0 else "User"
-    prompt = f"""[INST] Task: Check if there is unsafe content in '{role}' messages in conversations according our safety policy with the below categories.
-
-<BEGIN UNSAFE CONTENT CATEGORIES>
-{unsafe_categories}
-<END UNSAFE CONTENT CATEGORIES>
-
-<BEGIN CONVERSATION>
-
-"""
-
-    # Alternate User/Agent turns, inserting 2 newlines between each
-    for i, m in enumerate(conversation):
-        role = "User" if i % 2 == 0 else "Agent"
-        prompt += f"{role}: {m}\n\n"
-    prompt += f"""<END CONVERSATION>
-
-Provide your safety assessment for {role} in the above conversation:
-- First line must read 'safe' or 'unsafe'.
-- If unsafe, a second line must include a comma-separated list of violated categories. [/INST]"""
-    return prompt
-
+def get_tgi_service_model_id(endpoint_url, default=DEFAULT_MODEL):
+    """
+    Returns Hugging Face repoo id for deployed service's info endpoint
+    otherwise return default model
+    """
+    try:
+        requests = JsonRequestsWrapper()
+        info_endpoint = os.path.join(endpoint_url, "info")
+        model_info = requests.get(info_endpoint)
+        return model_info["model_id"]
+    except Exception as e:
+        return default
 
 @register_microservice(
     name="opea_service@guardrails_tgi_gaudi",
@@ -115,9 +74,9 @@ Provide your safety assessment for {role} in the above conversation:
 )
 @traceable(run_type="llm")
 def safety_guard(input: TextDoc) -> TextDoc:
-    # prompt guardrails
-    response_input_guard = llm_guard(moderation_prompt_for_chat([{"role": "User", "content": input.text}]))
+    response_input_guard = llm_guard_chat.invoke([{"role": "user", "content": input.text}]).content
     if "unsafe" in response_input_guard:
+        unsafe_dict = get_unsafe_dict(llm_guard_chat.model_id)
         policy_violation_level = response_input_guard.split("\n")[1].strip()
         policy_violations = unsafe_dict[policy_violation_level]
         print(f"Violated policies: {policy_violations}")
@@ -130,6 +89,7 @@ def safety_guard(input: TextDoc) -> TextDoc:
 
 if __name__ == "__main__":
     safety_guard_endpoint = os.getenv("SAFETY_GUARD_ENDPOINT", "http://localhost:8080")
+    safety_guard_model = os.getenv("SAFETY_GUARD_MODEL_ID", get_tgi_service_model_id(safety_guard_endpoint))
     llm_guard = HuggingFaceEndpoint(
         endpoint_url=safety_guard_endpoint,
         max_new_tokens=100,
@@ -139,5 +99,7 @@ if __name__ == "__main__":
         temperature=0.01,
         repetition_penalty=1.03,
     )
+    # chat engine for server-side prompt templating
+    llm_guard_chat = ChatHuggingFace(llm=llm_guard, model_id=safety_guard_model)
     print("guardrails - router] LLM initialized.")
     opea_microservices["opea_service@guardrails_tgi_gaudi"].start()

--- a/comps/guardrails/requirements.txt
+++ b/comps/guardrails/requirements.txt
@@ -1,7 +1,8 @@
 docarray[full]
 fastapi
 huggingface_hub
-langchain_community
+langchain-huggingface
+langchain-community
 langsmith
 opentelemetry-api
 opentelemetry-exporter-otlp


### PR DESCRIPTION
## Description

This PR adds a workaround to this issue https://github.com/langchain-ai/langchain/issues/17779. Basically langchain's `list_inference_endpoints` function does not work for getting `model_id` for locally deployed models (opposed to models on hugging face endpoints). This means we must pass model parameter explicitly to use /v1/chat/completions API call:

```
curl http://localhost:8088/v1/chat/completions \
    -X POST \
    -d '{"model": "meta-llama/Meta-Llama-Guard-2-8B", "messages": [{"role": "user", "content": "Say this is a test!"}]}' \
    -H 'Content-Type: application/json'
```

In langchain this looks like the following:

```
llm_guard_chat = ChatHuggingFace(llm=llm_guard, model_id=safety_guard_model)
llm_guard_chat.invoke([{"role": "user", "content": input.text}]).content
```

So I added a `DEFAULT_MODEL`  variable and a way to try to get model id from `/info` endpoint.

I also moved the `ChatHuggingFace` to run at start. This should improve latency of API calls by 1-2 seconds.

## Issues

List the issue or RFC link this PR is working on. If there is no such link, please mark it as `n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

`langchain-community`

## Tests

1. I rain two local TGI services of both LlamaGuard1 and 

```
docker run -p 8087:80 -v $PWD/data:/data  -e HTTPS_PROXY=$https_proxy -e HTTP_PROXY=$https_proxy ghcr.io/huggingface/text-generation-inference --model-id meta-llama/LlamaGuard-7b
```

```
docker run -p 8087:80 -v $PWD/data:/data  -e HTTPS_PROXY=$https_proxy -e HTTP_PROXY=$https_proxy ghcr.io/huggingface/text-generation-inference --model-id meta-llama/Meta-Llama-Guard-2-8B
```

2. Then I build and ran guardrails-tgi-server

```
docker build -t opea/gen-ai-comps:guardrails-tgi-server --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy -f comps/guardrails/langchain/docker/Dockerfile .
```

```
docker run -p 9090:9090  -e https_proxy=$https_proxy -e http_proxy=$http_proxy -e no_proxy=$no_proxy -e HUGGINGFACEHUB_API_TOKEN=$HUGGINGFACEHUB_API_TOKEN -e SAFETY_GUARD_ENDPOINT="http://localhost:8088" --network="host" opea/gen-ai-comps:guardrails-tgi-server
```

3. Tested with following curl:
```
$ curl http://localhost:9090/v1/guardrails -X POST   -d '{"text": "i am going to kill you"}'   -H 'Content-Type: application/json'
{"id":"e6a511430e2d5158d2923a4099502945","text":"Violated policies: Violent Crimes, please check your input."}twilbers@mlp-prod-skx-5675:/localdisk/twilbers/docker$
```
