### PR TITLE
Documentation fix: fix api call parameter and added no proxy

### DIFF
--- a/comps/guardrails/README.md
+++ b/comps/guardrails/README.md
@@ -86,7 +86,7 @@ docker build -t opea/guardrails-tgi:latest --build-arg https_proxy=$https_proxy 
 ## 2.3 Run Docker with CLI
 
 ```bash
-docker run -d --name="guardrails-tgi-server" -p 9090:9090 --ipc=host -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e SAFETY_GUARD_ENDPOINT=$SAFETY_GUARD_ENDPOINT -e HUGGINGFACEHUB_API_TOKEN=$HUGGINGFACEHUB_API_TOKEN opea/guardrails-tgi:latest
+docker run -d --name="guardrails-tgi-server" -p 9090:9090 --ipc=host -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e no_proxy=$no_proxy -e SAFETY_GUARD_ENDPOINT=$SAFETY_GUARD_ENDPOINT -e HUGGINGFACEHUB_API_TOKEN=$HUGGINGFACEHUB_API_TOKEN opea/guardrails-tgi:latest
 ```
 
 ## 2.4 Run Docker with Docker Compose
@@ -111,6 +111,6 @@ curl http://localhost:9090/v1/health_check\
 ```bash
 curl http://localhost:9090/v1/guardrails\
   -X POST \
-  -d '{"inputs":"How do you buy a tiger in the US?","parameters":{"max_new_tokens":32}}' \
+  -d '{"text":"How do you buy a tiger in the US?","parameters":{"max_new_tokens":32}}' \
   -H 'Content-Type: application/json'
 ```


### PR DESCRIPTION
## Description

This makes two small changes to guardrails README.md:

- Changes to correct parameter of /v1/guardrails API call
- Add `-e no_proxy` to docker run since API calls to model inference service may be sent to proxy otherwise

## Issues

`n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

Documentation change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

## Tests

Describe the tests that you ran to verify your changes.
