### PR TITLE
Refine the main readme by adding vllm/ray llm service

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The initially supported `Microservices` are described in the below table. More `
             <td><a href="https://www.langchain.com">LangChain</a></td>
 			<td><a href="https://huggingface.co/Intel/neural-chat-7b-v3-3">Intel/neural-chat-7b-v3-3</a></td>
 			<td><a href="https://github.com/ray-project/ray">Ray Serve</a></td>
-			<td>Gaudi2</td>
+			<td>Xeon</td>
 			<td>LLM on Xeon CPU</td>
 		</tr>
 	</tbody>

--- a/README.md
+++ b/README.md
@@ -108,6 +108,30 @@ The initially supported `Microservices` are described in the below table. More `
 			<td>Xeon</td>
 			<td>LLM on Xeon CPU</td>
 		</tr>
+		<tr>
+			<td><a href="./comps/llms/README.md">LLM</a></td>
+            <td><a href="https://www.langchain.com">LangChain</a></td>
+			<td><a href="https://huggingface.co/Intel/neural-chat-7b-v3-3">Intel/neural-chat-7b-v3-3</a></td>
+			<td><a href="https://github.com/vllm-project/vllm/">vLLM</a></td>
+			<td>Xeon</td>
+			<td>LLM on Xeon CPU</td>
+		</tr>
+		<tr>
+			<td><a href="./comps/llms/README.md">LLM</a></td>
+            <td><a href="https://www.langchain.com">LangChain</a></td>
+			<td><a href="https://huggingface.co/Intel/neural-chat-7b-v3-3">Intel/neural-chat-7b-v3-3</a></td>
+			<td><a href="https://github.com/ray-project/ray">Ray Serve</a></td>
+			<td>Gaudi2</td>
+			<td>LLM on Gaudi2</td>
+		</tr>
+		<tr>
+			<td><a href="./comps/llms/README.md">LLM</a></td>
+            <td><a href="https://www.langchain.com">LangChain</a></td>
+			<td><a href="https://huggingface.co/Intel/neural-chat-7b-v3-3">Intel/neural-chat-7b-v3-3</a></td>
+			<td><a href="https://github.com/ray-project/ray">Ray Serve</a></td>
+			<td>Gaudi2</td>
+			<td>LLM on Xeon CPU</td>
+		</tr>
 	</tbody>
 </table>
 


### PR DESCRIPTION
## Description

This PR mainly updates the table of main readme by adding vllm-cpu/ray-cpu/ray gaudi llm service.

## Issues

 `n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
    - just updated the main readme tables where llms support vllm-cpu and ray-cpu and ray-gaudi.

## Dependencies

N/A.

## Tests

This PR is validated through the previous [#79](https://github.com/opea-project/GenAIComps/pull/79).
