### PR TITLE
Add aio orchestrator to boost concurrent serving

### DIFF
--- a/comps/cores/mega/gateway.py
+++ b/comps/cores/mega/gateway.py
@@ -128,8 +128,8 @@ class ChatQnAGateway(Gateway):
             repetition_penalty=chat_request.presence_penalty if chat_request.presence_penalty else 1.03,
             streaming=chat_request.stream if chat_request.stream else True,
         )
-        await self.megaservice.schedule(initial_inputs={"text": prompt}, llm_parameters=parameters)
-        for node, response in self.megaservice.result_dict.items():
+        result_dict = await self.megaservice.schedule(initial_inputs={"text": prompt}, llm_parameters=parameters)
+        for node, response in result_dict.items():
             # Here it suppose the last microservice in the megaservice is LLM.
             if (
                 isinstance(response, StreamingResponse)
@@ -137,8 +137,8 @@ class ChatQnAGateway(Gateway):
                 and self.megaservice.services[node].service_type == ServiceType.LLM
             ):
                 return response
-        last_node = self.megaservice.all_leaves()[-1]
-        response = self.megaservice.result_dict[last_node]["text"]
+        last_node = self.megaservice.get_all_final_outputs()[-1]
+        response = result_dict[last_node]["text"]
         choices = []
         usage = UsageInfo()
         choices.append(
@@ -169,8 +169,8 @@ class CodeGenGateway(Gateway):
             repetition_penalty=chat_request.presence_penalty if chat_request.presence_penalty else 1.03,
             streaming=chat_request.stream if chat_request.stream else True,
         )
-        await self.megaservice.schedule(initial_inputs={"query": prompt}, llm_parameters=parameters)
-        for node, response in self.megaservice.result_dict.items():
+        result_dict = await self.megaservice.schedule(initial_inputs={"query": prompt}, llm_parameters=parameters)
+        for node, response in result_dict.items():
             # Here it suppose the last microservice in the megaservice is LLM.
             if (
                 isinstance(response, StreamingResponse)
@@ -178,8 +178,8 @@ class CodeGenGateway(Gateway):
                 and self.megaservice.services[node].service_type == ServiceType.LLM
             ):
                 return response
-        last_node = self.megaservice.all_leaves()[-1]
-        response = self.megaservice.result_dict[last_node]["text"]
+        last_node = self.megaservice.get_all_final_outputs()[-1]
+        response = result_dict[last_node]["text"]
         choices = []
         usage = UsageInfo()
         choices.append(
@@ -216,8 +216,8 @@ class CodeTransGateway(Gateway):
             ### Translated codes:
         """
         prompt = prompt_template.format(language_from=language_from, language_to=language_to, source_code=source_code)
-        await self.megaservice.schedule(initial_inputs={"query": prompt})
-        for node, response in self.megaservice.result_dict.items():
+        result_dict = await self.megaservice.schedule(initial_inputs={"query": prompt})
+        for node, response in result_dict.items():
             # Here it suppose the last microservice in the megaservice is LLM.
             if (
                 isinstance(response, StreamingResponse)
@@ -225,8 +225,8 @@ class CodeTransGateway(Gateway):
                 and self.megaservice.services[node].service_type == ServiceType.LLM
             ):
                 return response
-        last_node = self.megaservice.all_leaves()[-1]
-        response = self.megaservice.result_dict[last_node]["text"]
+        last_node = self.megaservice.get_all_final_outputs()[-1]
+        response = result_dict[last_node]["text"]
         choices = []
         usage = UsageInfo()
         choices.append(
@@ -257,8 +257,8 @@ class DocSumGateway(Gateway):
             repetition_penalty=chat_request.presence_penalty if chat_request.presence_penalty else 1.03,
             streaming=chat_request.stream if chat_request.stream else True,
         )
-        await self.megaservice.schedule(initial_inputs={"query": prompt}, llm_parameters=parameters)
-        for node, response in self.megaservice.result_dict.items():
+        result_dict = await self.megaservice.schedule(initial_inputs={"query": prompt}, llm_parameters=parameters)
+        for node, response in result_dict.items():
             # Here it suppose the last microservice in the megaservice is LLM.
             if (
                 isinstance(response, StreamingResponse)
@@ -266,8 +266,8 @@ class DocSumGateway(Gateway):
                 and self.megaservice.services[node].service_type == ServiceType.LLM
             ):
                 return response
-        last_node = self.megaservice.all_leaves()[-1]
-        response = self.megaservice.result_dict[last_node]["text"]
+        last_node = self.megaservice.get_all_final_outputs()[-1]
+        response = result_dict[last_node]["text"]
         choices = []
         usage = UsageInfo()
         choices.append(

--- a/comps/cores/mega/orchestrator.py
+++ b/comps/cores/mega/orchestrator.py
@@ -95,7 +95,7 @@ class ServiceOrchestrator(DAG):
                         if chunk:
                             yield chunk
 
-            return StreamingResponse(generate(), media_type="text/event-stream")
+            return StreamingResponse(generate(), media_type="text/event-stream"), cur_node
         else:
             async with session.post(endpoint, json=inputs) as response:
                 print(response.status)

--- a/comps/cores/mega/orchestrator.py
+++ b/comps/cores/mega/orchestrator.py
@@ -16,6 +16,7 @@ import json
 from typing import Dict, List
 
 import requests
+import aiohttp, asyncio
 from fastapi.responses import StreamingResponse
 
 from ..proto.docarray import LLMParams
@@ -28,7 +29,6 @@ class ServiceOrchestrator(DAG):
 
     def __init__(self) -> None:
         self.services = {}  # all services, id -> service
-        self.result_dict = {}
         super().__init__()
 
     def add(self, service):
@@ -48,23 +48,35 @@ class ServiceOrchestrator(DAG):
             return False
 
     async def schedule(self, initial_inputs: Dict, llm_parameters: LLMParams = LLMParams()):
-        for node in self.topological_sort():
-            if node in self.ind_nodes():
-                inputs = initial_inputs
-            else:
-                inputs = self.process_outputs(self.predecessors(node))
-            response = await self.execute(node, inputs, llm_parameters)
-            self.dump_outputs(node, response)
+        result_dict = {}
 
-    def process_outputs(self, prev_nodes: List) -> Dict:
+        async with aiohttp.ClientSession(trust_env=True) as session:
+            pending = {asyncio.create_task(self.execute(session, node, initial_inputs)) for node in self.ind_nodes()}
+
+            while pending:
+                done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
+                for done_task in done:
+                    response, node = await done_task
+                    self.dump_outputs(node, response, result_dict)
+
+                    # traverse the current node's downstream nodes and execute if all one's predecessors are finished
+                    downstreams = self.downstream(node)
+                    for d_node in downstreams:
+                        if all(i in result_dict for i in self.predecessors(d_node)):
+                            inputs = self.process_outputs(self.predecessors(d_node), result_dict)
+                            pending.add(asyncio.create_task(self.execute(session, d_node, inputs, llm_parameters)))
+
+        return result_dict
+
+    def process_outputs(self, prev_nodes: List, result_dict: Dict) -> Dict:
         all_outputs = {}
 
         # assume all prev_nodes outputs' keys are not duplicated
         for prev_node in prev_nodes:
-            all_outputs.update(self.result_dict[prev_node])
+            all_outputs.update(result_dict[prev_node])
         return all_outputs
 
-    async def execute(self, cur_node: str, inputs: Dict, llm_parameters: LLMParams = LLMParams()):
+    async def execute(self, session: aiohttp.client.ClientSession, cur_node: str, inputs: Dict, llm_parameters: LLMParams = LLMParams()):
         # send the cur_node request/reply
         endpoint = self.services[cur_node].endpoint_path
         llm_parameters_dict = llm_parameters.dict()
@@ -72,6 +84,7 @@ class ServiceOrchestrator(DAG):
             if inputs.get(field) != value:
                 inputs[field] = value
         if self.services[cur_node].service_type == ServiceType.LLM and llm_parameters.streaming:
+            # Still leave to sync requests.post for StreamingResponse
             response = requests.post(
                 url=endpoint, data=json.dumps(inputs), proxies={"http": None}, stream=True, timeout=1000
             )
@@ -84,13 +97,15 @@ class ServiceOrchestrator(DAG):
 
             return StreamingResponse(generate(), media_type="text/event-stream")
         else:
-            response = requests.post(url=endpoint, data=json.dumps(inputs), proxies={"http": None})
-            print(response)
-            return response.json()
+            async with session.post(endpoint, json=inputs) as response:
+                print(response.status)
+                return await response.json(), cur_node
 
-    def dump_outputs(self, node, response):
-        self.result_dict[node] = response
+    def dump_outputs(self, node, response, result_dict):
+        result_dict[node] = response
 
-    def get_all_final_outputs(self):
+    def get_all_final_outputs(self, result_dict):
+        final_output_dict = {}
         for leaf in self.all_leaves():
-            print(self.result_dict[leaf])
+            final_output_dict[leaf] = result_dict[leaf]
+        return final_output_dict

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ opentelemetry-sdk
 pyyaml
 requests
 shortuuid
+aiohttp

--- a/tests/cores/mega/test_aio.py
+++ b/tests/cores/mega/test_aio.py
@@ -1,0 +1,85 @@
+# Copyright (c) 2024 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import unittest
+import asyncio
+from comps import ServiceOrchestrator, TextDoc, opea_microservices, register_microservice
+import time
+
+@register_microservice(name="s1", host="0.0.0.0", port=8083, endpoint="/v1/add")
+async def s1_add(request: TextDoc) -> TextDoc:
+    time.sleep(5)
+    req = request.model_dump_json()
+    req_dict = json.loads(req)
+    text = req_dict["text"]
+    text += "opea"
+    return {"text": text}
+
+
+@register_microservice(name="s2", host="0.0.0.0", port=8084, endpoint="/v1/add")
+async def s2_add(request: TextDoc) -> TextDoc:
+    time.sleep(5)
+    req = request.model_dump_json()
+    req_dict = json.loads(req)
+    text = req_dict["text"]
+    text += " project1!"
+    return {"text": text}
+
+@register_microservice(name="s3", host="0.0.0.0", port=8085, endpoint="/v1/add")
+async def s3_add(request: TextDoc) -> TextDoc:
+    time.sleep(5)
+    req = request.model_dump_json()
+    req_dict = json.loads(req)
+    text = req_dict["text"]
+    text += " project2!"
+    return {"text": text}
+
+class TestServiceOrchestrator(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.s1 = opea_microservices["s1"]
+        self.s2 = opea_microservices["s2"]
+        self.s3 = opea_microservices["s3"]
+        self.s1.start()
+        self.s2.start()
+        self.s3.start()
+
+        self.service_builder = ServiceOrchestrator()
+
+        self.service_builder.add(opea_microservices["s1"]).add(opea_microservices["s2"]).add(opea_microservices["s3"])
+        self.service_builder.flow_to(self.s1, self.s2)
+        self.service_builder.flow_to(self.s1, self.s3)
+
+    def tearDown(self):
+        self.s1.stop()
+        self.s2.stop()
+        self.s3.stop()
+
+    async def test_schedule(self):
+        t = time.time()
+        task1 = asyncio.create_task(self.service_builder.schedule(initial_inputs={"text": "hello, "}))
+        task2 = asyncio.create_task(self.service_builder.schedule(initial_inputs={"text": "hi, "}))
+        await asyncio.gather(task1, task2)
+
+        result_dict1 = task1.result()
+        result_dict2 = task2.result()
+        self.assertEqual(result_dict1[self.s2.name]["text"], "hello, opea project1!")
+        self.assertEqual(result_dict1[self.s3.name]["text"], "hello, opea project2!")
+        self.assertEqual(result_dict2[self.s2.name]["text"], "hi, opea project1!")
+        self.assertEqual(result_dict2[self.s3.name]["text"], "hi, opea project2!")
+        self.assertEqual(int(time.time() - t), 15)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/cores/mega/test_aio.py
+++ b/tests/cores/mega/test_aio.py
@@ -78,6 +78,7 @@ class TestServiceOrchestrator(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result_dict1[self.s3.name]["text"], "hello, opea project2!")
         self.assertEqual(result_dict2[self.s2.name]["text"], "hi, opea project1!")
         self.assertEqual(result_dict2[self.s3.name]["text"], "hi, opea project2!")
+        self.assertEqual(len(self.service_builder.get_all_final_outputs(result_dict1).keys()), 2)
         self.assertEqual(int(time.time() - t), 15)
 
 

--- a/tests/cores/mega/test_service_orchestrator.py
+++ b/tests/cores/mega/test_service_orchestrator.py
@@ -53,8 +53,7 @@ class TestServiceOrchestrator(unittest.IsolatedAsyncioTestCase):
         self.s2.stop()
 
     async def test_schedule(self):
-        await self.service_builder.schedule(initial_inputs={"text": "hello, "})
-        result_dict = self.service_builder.result_dict
+        result_dict = await self.service_builder.schedule(initial_inputs={"text": "hello, "})
         self.assertEqual(result_dict[self.s2.name]["text"], "hello, opea project!")
 
 

--- a/tests/cores/mega/test_service_orchestrator_with_gateway.py
+++ b/tests/cores/mega/test_service_orchestrator_with_gateway.py
@@ -55,8 +55,7 @@ class TestServiceOrchestrator(unittest.IsolatedAsyncioTestCase):
         self.gateway.stop()
 
     async def test_schedule(self):
-        await self.service_builder.schedule(initial_inputs={"text": "hello, "})
-        result_dict = self.service_builder.result_dict
+        result_dict = await self.service_builder.schedule(initial_inputs={"text": "hello, "})
         self.assertEqual(result_dict[self.s2.name]["text"], "hello, opea project!")
 
 


### PR DESCRIPTION
## Description

This PR

* allow subsequent requests to be handled non-blocking in earlier microservices concurrently
* allow microservices on DAG branches to be handled concurrently

## Issues

n/a

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [x] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

aiohttp

## Tests

add a local test

also with GenAIEval, evals/benchmark/chatqna_benchmark.py

The  data shows a ~1.5x speedup for P99 latency with total concurrent number of requests: 2,4,8,16,32,64