### PR TITLE
optional vllm microservice container build

### DIFF
--- a/comps/llms/text-generation/vllm/docker/Dockerfile.microservice
+++ b/comps/llms/text-generation/vllm/docker/Dockerfile.microservice
@@ -1,8 +1,9 @@
-
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 FROM langchain/langchain:latest
+
+ARG ARCH="cpu"
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
     libgl1-mesa-glx \
@@ -18,7 +19,11 @@ USER user
 COPY comps /home/user/comps
 
 RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir -r /home/user/comps/llms/text-generation/vllm/requirements.txt
+    if [ ${ARCH} = "cpu" ]; then \
+      pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r /home/user/comps/llms/text-generation/vllm/requirements.txt; \
+    else \
+      pip install --no-cache-dir -r /home/user/comps/llms/text-generation/vllm/requirements.txt; \
+    fi
 
 ENV PYTHONPATH=$PYTHONPATH:/home/user
 

--- a/comps/llms/text-generation/vllm/docker/Dockerfile.microservice
+++ b/comps/llms/text-generation/vllm/docker/Dockerfile.microservice
@@ -3,7 +3,7 @@
 
 FROM langchain/langchain:latest
 
-ARG ARCH="cpu"
+ARG ARCH="cpu"  # Set this to "cpu" or "gpu"
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
     libgl1-mesa-glx \


### PR DESCRIPTION
## Description

This PR adds optional `build-arg`'s for this Dockerfile: comps/llms/text-generation/vllm/docker/Dockerfile.microservice

## Issues

Current dockerfile always defaults to `gpu` Torch installation while `CPU` users might not necessarily need extra packages.
This leads to smaller containers for CPU users and faster build.

For users interested to do `gpu` builds all they need to do is build this image this way:
```
docker build --build-arg ARCH='gpu' -f comps/llms/text-generation/vllm/docker/Dockerfile.microservice . -t opea/llm-vllm:latest
```

## Type of change

List the type of change like below. Please delete options that are not relevant.

- extra `build-arg` option `ARCH` to build `vllm microservice` container for either CPU or GPU.

## Dependencies

None
