### PR TITLE
compatible with openai/tgi/vllm request format

### DIFF
--- a/comps/cores/proto/docarray.py
+++ b/comps/cores/proto/docarray.py
@@ -87,7 +87,7 @@ class LLMParamsDoc(BaseDoc):
     # https://platform.openai.com/docs/api-reference/completions/create
     model: Optional[str] = None  # for openai, not used by tgi
     query: str  # alias 'prompt'
-    best_of: Optional[int] = None
+    best_of: Optional[int] = 1
     echo: Optional[bool] = False
     frequency_penalty: Optional[float] = 0.0
     logit_bias: Optional[Dict[str, float]] = None
@@ -96,7 +96,7 @@ class LLMParamsDoc(BaseDoc):
     n: Optional[int] = 1
     presence_penalty: Optional[float] = 0.0
     seed: Optional[int] = None
-    stop: Union[Optional[str], List[str], None] = None
+    stop: Union[Optional[str], List[str], None] = []
     streaming: Optional[bool] = False  # alias 'stream'
     stream_options: Optional[StreamOptions] = None
     suffix: Optional[str] = None

--- a/comps/cores/proto/docarray.py
+++ b/comps/cores/proto/docarray.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Optional, Dict, Union, List
+from typing import Dict, List, Optional, Union
 
 import numpy as np
 from docarray import BaseDoc, DocList
@@ -85,19 +85,19 @@ class LLMParamsDoc(BaseDoc):
     # Ordered by official OpenAI API documentation
     # default values are same with
     # https://platform.openai.com/docs/api-reference/completions/create
-    model: Optional[str] = None # for openai, not used by tgi
-    query: str # alias 'prompt'
+    model: Optional[str] = None  # for openai, not used by tgi
+    query: str  # alias 'prompt'
     best_of: Optional[int] = None
     echo: Optional[bool] = False
     frequency_penalty: Optional[float] = 0.0
     logit_bias: Optional[Dict[str, float]] = None
     logprobs: Optional[int] = None
-    max_new_tokens: Optional[int] = 16 # alias 'max_tokens'
+    max_new_tokens: Optional[int] = 16  # alias 'max_tokens'
     n: Optional[int] = 1
     presence_penalty: Optional[float] = 0.0
     seed: Optional[int] = None
     stop: Union[Optional[str], List[str], None] = None
-    streaming: Optional[bool] = False # alias 'stream'
+    streaming: Optional[bool] = False  # alias 'stream'
     stream_options: Optional[StreamOptions] = None
     suffix: Optional[str] = None
     temperature: Optional[float] = 1.0

--- a/comps/cores/proto/docarray.py
+++ b/comps/cores/proto/docarray.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Optional
+from typing import Optional, Dict, Union, List
 
 import numpy as np
 from docarray import BaseDoc, DocList
@@ -76,15 +76,45 @@ class RerankedDoc(BaseDoc):
     initial_query: str
 
 
+class StreamOptions(BaseDoc):
+    # refer https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/openai/protocol.py#L105
+    include_usage: Optional[bool]
+
+
 class LLMParamsDoc(BaseDoc):
-    query: str
-    max_new_tokens: int = 1024
-    top_k: int = 10
-    top_p: float = 0.95
-    typical_p: float = 0.95
-    temperature: float = 0.01
-    repetition_penalty: float = 1.03
-    streaming: bool = True
+    # Ordered by official OpenAI API documentation
+    # default values are same with
+    # https://platform.openai.com/docs/api-reference/completions/create
+    model: Optional[str] = None # for openai, not used by tgi
+    query: str # alias 'prompt'
+    best_of: Optional[int] = None
+    echo: Optional[bool] = False
+    frequency_penalty: Optional[float] = 0.0
+    logit_bias: Optional[Dict[str, float]] = None
+    logprobs: Optional[int] = None
+    max_new_tokens: Optional[int] = 16 # alias 'max_tokens'
+    n: Optional[int] = 1
+    presence_penalty: Optional[float] = 0.0
+    seed: Optional[int] = None
+    stop: Union[Optional[str], List[str], None] = None
+    streaming: Optional[bool] = False # alias 'stream'
+    stream_options: Optional[StreamOptions] = None
+    suffix: Optional[str] = None
+    temperature: Optional[float] = 1.0
+    top_p: Optional[float] = 1.0
+    user: Optional[str] = None
+
+    # tgi reference: https://huggingface.github.io/text-generation-inference/#/Text%20Generation%20Inference/generate
+    # some tgi parameters in use
+    # default values are same with
+    # https://github.com/huggingface/text-generation-inference/blob/main/router/src/lib.rs#L190
+    # max_new_tokens: Optional[int] = 100 # Priority use openai
+    top_k: Optional[int] = None
+    # top_p: Optional[float] = None # Priority use openai
+    typical_p: Optional[float] = None
+    repetition_penalty: Optional[float] = None
+
+    # vllm reference: https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/openai/protocol.py#L359
 
 
 class LLMParams(BaseDoc):

--- a/comps/llms/text-generation/vllm-xft/llm.py
+++ b/comps/llms/text-generation/vllm-xft/llm.py
@@ -1,9 +1,9 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import os
 import time
-import json
 
 from fastapi.responses import StreamingResponse
 from langsmith import traceable

--- a/comps/llms/text-generation/vllm-xft/llm.py
+++ b/comps/llms/text-generation/vllm-xft/llm.py
@@ -3,6 +3,7 @@
 
 import os
 import time
+import json
 
 from fastapi.responses import StreamingResponse
 from langsmith import traceable

--- a/comps/llms/text-generation/vllm-xft/llm.py
+++ b/comps/llms/text-generation/vllm-xft/llm.py
@@ -58,8 +58,8 @@ def llm_generate(input: LLMParamsDoc):
             chat_response = ""
             for c in completion:
                 text = c.choices[0].text
+                print(f"[llm - chat_stream] chunk: {text}")
                 yield f"data: {json.dumps(text)}\n\n"
-            print(f"[llm - chat_stream] stream response: {text}")
             yield "data: [DONE]\n\n"
 
         return StreamingResponse(stream_generator(), media_type="text/event-stream")

--- a/comps/llms/text-generation/vllm-xft/llm.py
+++ b/comps/llms/text-generation/vllm-xft/llm.py
@@ -45,7 +45,6 @@ def llm_generate(input: LLMParamsDoc):
         seed=input.seed,
         stop=input.stop,
         stream=input.streaming,
-        stream_options=input.stream_options,
         suffix=input.suffix,
         temperature=input.temperature,
         top_p=input.top_p,

--- a/comps/llms/text-generation/vllm-xft/llm.py
+++ b/comps/llms/text-generation/vllm-xft/llm.py
@@ -2,19 +2,21 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+import time
 
 from fastapi.responses import StreamingResponse
-from openai import OpenAI
 from langsmith import traceable
+from openai import OpenAI
 
 from comps import GeneratedDoc, LLMParamsDoc, ServiceType, opea_microservices, register_microservice
-import time
 
 llm_endpoint = os.getenv("vLLM_LLM_ENDPOINT", "http://localhost:18688")
 model = os.getenv("vLLM_LLM_NAME", "xft")
 client = OpenAI(
-        api_key="EMPTY",
-        base_url=llm_endpoint + "/v1",)
+    api_key="EMPTY",
+    base_url=llm_endpoint + "/v1",
+)
+
 
 @register_microservice(
     name="opea_service@llm_vllm_xft",
@@ -30,24 +32,25 @@ def llm_generate(input: LLMParamsDoc):
     global client
 
     completion = client.completions.create(
-            model=model,
-            prompt=input.query,
-            best_of=input.best_of,
-            echo=input.echo,
-            frequency_penalty=input.frequency_penalty,
-            logit_bias=input.logit_bias,
-            logprobs=input.logprobs,
-            max_tokens=input.max_new_tokens,
-            n=input.n,
-            presence_penalty=input.presence_penalty,
-            seed=input.seed,
-            stop=input.stop,
-            stream=input.streaming,
-            stream_options=input.stream_options,
-            suffix=input.suffix,
-            temperature=input.temperature,
-            top_p=input.top_p,
-            user=input.user)
+        model=model,
+        prompt=input.query,
+        best_of=input.best_of,
+        echo=input.echo,
+        frequency_penalty=input.frequency_penalty,
+        logit_bias=input.logit_bias,
+        logprobs=input.logprobs,
+        max_tokens=input.max_new_tokens,
+        n=input.n,
+        presence_penalty=input.presence_penalty,
+        seed=input.seed,
+        stop=input.stop,
+        stream=input.streaming,
+        stream_options=input.stream_options,
+        suffix=input.suffix,
+        temperature=input.temperature,
+        top_p=input.top_p,
+        user=input.user,
+    )
 
     if input.streaming:
 


### PR DESCRIPTION
## Description

1. compatible with openai/tgi/vllm `completion` request format/parameters
2. priority default values (openai > tgi > vllm). With same default value, the opea service latency is almost same with native server tgi/vllm
3. replace `from langchain_community.llms import VLLMOpenAI` with `from openai import OpenAI`, which can reduce initialization time (0.15s -> 0.01s) and only init once
4. simplify post-process for openai format response (especially remove `encode`)

