### PR TITLE
Architecture specific args for a few containers

### DIFF
--- a/comps/guardrails/pii_detection/docker/Dockerfile
+++ b/comps/guardrails/pii_detection/docker/Dockerfile
@@ -1,8 +1,9 @@
-
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 FROM python:3.11-slim
+
+ARG ARCH="cpu"  # Set this to "cpu" or "gpu"
 
 ENV LANG C.UTF-8
 
@@ -21,7 +22,11 @@ USER user
 COPY comps /home/user/comps
 
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
-    pip install --no-cache-dir -r /home/user/comps/guardrails/pii_detection/requirements.txt
+if [ ${ARCH} = "cpu" ]; then \
+      pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r /home/user/comps/guardrails/pii_detection/requirements.txt; \
+    else \
+      pip install --no-cache-dir -r /home/user/comps/guardrails/pii_detection/requirements.txt; \
+    fi
 
 ENV PYTHONPATH=$PYTHONPATH:/home/user
 

--- a/comps/knowledgegraphs/langchain/docker/Dockerfile
+++ b/comps/knowledgegraphs/langchain/docker/Dockerfile
@@ -1,8 +1,9 @@
-
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 FROM langchain/langchain:latest
+
+ARG ARCH="cpu"  # Set this to "cpu" or "gpu"
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
     libgl1-mesa-glx \
@@ -18,7 +19,11 @@ COPY comps /home/user/comps
 USER user
 
 RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir -r /home/user/comps/knowledgegraphs/requirements.txt
+if [ ${ARCH} = "cpu" ]; then \
+      pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r /home/user/comps/knowledgegraphs/requirements.txt; \
+    else \
+      pip install --no-cache-dir -r /home/user/comps/knowledgegraphs/requirements.txt; \
+    fi
 
 ENV PYTHONPATH=$PYTHONPATH:/home/user
 

--- a/comps/web_retrievers/langchain/chroma/docker/Dockerfile
+++ b/comps/web_retrievers/langchain/chroma/docker/Dockerfile
@@ -1,8 +1,9 @@
-
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 FROM langchain/langchain:latest
+
+ARG ARCH="cpu"  # Set this to "cpu" or "gpu"
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
     libgl1-mesa-glx \
@@ -12,7 +13,11 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missin
 COPY comps /home/user/comps
 
 RUN pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir -r /home/user/comps/web_retrievers/langchain/chroma/requirements.txt
+    if [ ${ARCH} = "cpu" ]; then \
+      pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r /home/user/comps/web_retrievers/langchain/chroma/requirements.txt; \
+    else \
+      pip install --no-cache-dir -r /home/user/comps/web_retrievers/langchain/chroma/requirements.txt; \
+    fi
 
 ENV PYTHONPATH=$PYTHONPATH:/home/user
 


### PR DESCRIPTION
## Description

This PR adds optional `build-arg`'s for the following Dockerfiles:
```
- comps/guardrails/pii_detection/docker/Dockerfile
- comps/knowledgegraphs/langchain/docker/Dockerfile
- comps/web_retrievers/langchain/chroma/docker/Dockerfile
```

## Issues

Current Dockerfiles always defaults to `gpu` Torch installation while `CPU` users might not necessarily need extra packages. This had the advantage of building smaller containers for CPU users and faster builds.

For users interested to do `gpu` builds, all they need to do is build this image this way for example:
```
docker build --build-arg ARCH='gpu' -f comps/guardrails/pii_detection/docker/Dockerfile . -t opea/guardrails-pii-detection:latest
```

## Type of change

List the type of change like below. Please delete options that are not relevant.

- extra `build-arg` option `ARCH` to build a few of our containers for either CPU or GPU where applicable.

## Dependencies

None
