### PR TITLE
Add local_embedding return 768 length to align with chatqna example

### DIFF
--- a/comps/embeddings/langchain/local_embedding_768.py
+++ b/comps/embeddings/langchain/local_embedding_768.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from langchain_community.embeddings import HuggingFaceBgeEmbeddings
+
+from comps import EmbedDoc768, ServiceType, TextDoc, opea_microservices, opea_telemetry, register_microservice
+
+
+@register_microservice(
+    name="opea_service@local_embedding",
+    service_type=ServiceType.EMBEDDING,
+    endpoint="/v1/embeddings",
+    host="0.0.0.0",
+    port=6000,
+    input_datatype=TextDoc,
+    output_datatype=EmbedDoc768,
+)
+@opea_telemetry
+def embedding(input: TextDoc) -> EmbedDoc768:
+    embed_vector = embeddings.embed_query(input.text)
+    res = EmbedDoc768(text=input.text, embedding=embed_vector)
+    return res
+
+
+if __name__ == "__main__":
+    embeddings = HuggingFaceBgeEmbeddings(model_name="BAAI/bge-base-en-v1.5")
+    opea_microservices["opea_service@local_embedding"].start()


### PR DESCRIPTION
## Description

Add a new local_embedding file which returns 768 embedding length instead of 1024 and use BAAI/bge-base-en-v1.5

## Issues

the local_embedding return and redis_retriever is not compatible at this moment.  

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

No

## Tests

No
