### PR TITLE
Update to remove warnings when building Dockerfiles due to unsafe syntax

### DIFF
--- a/comps/asr/Dockerfile
+++ b/comps/asr/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM python:3.11-slim
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 COPY comps /home/comps
 

--- a/comps/dataprep/milvus/docker/Dockerfile
+++ b/comps/dataprep/milvus/docker/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM python:3.11-slim
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 ARG ARCH="cpu"
 

--- a/comps/dataprep/pgvector/langchain/docker/Dockerfile
+++ b/comps/dataprep/pgvector/langchain/docker/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM python:3.11-slim
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 ARG ARCH="cpu"
 

--- a/comps/dataprep/pinecone/docker/Dockerfile
+++ b/comps/dataprep/pinecone/docker/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM python:3.11-slim
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
     build-essential \

--- a/comps/dataprep/qdrant/docker/Dockerfile
+++ b/comps/dataprep/qdrant/docker/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM python:3.11-slim
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 ARG ARCH="cpu"
 

--- a/comps/dataprep/redis/langchain/docker/Dockerfile
+++ b/comps/dataprep/redis/langchain/docker/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM python:3.11-slim
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 ARG ARCH="cpu"
 

--- a/comps/dataprep/redis/langchain_ray/docker/Dockerfile
+++ b/comps/dataprep/redis/langchain_ray/docker/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM python:3.11-slim
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 ARG ARCH="cpu"
 

--- a/comps/dataprep/redis/llama_index/docker/Dockerfile
+++ b/comps/dataprep/redis/llama_index/docker/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM python:3.11-slim
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 ARG ARCH="cpu"
 

--- a/comps/guardrails/langchain/docker/Dockerfile
+++ b/comps/guardrails/langchain/docker/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM langchain/langchain:latest
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 ARG ARCH="cpu"
 

--- a/comps/guardrails/pii_detection/docker/Dockerfile
+++ b/comps/guardrails/pii_detection/docker/Dockerfile
@@ -5,7 +5,7 @@ FROM python:3.11-slim
 
 ARG ARCH="cpu"  # Set this to "cpu" or "gpu"
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
     build-essential \

--- a/comps/llms/utils/lm-eval/Dockerfile.cpu
+++ b/comps/llms/utils/lm-eval/Dockerfile.cpu
@@ -3,7 +3,7 @@ FROM ubuntu:${UBUNTU_VER} as devel
 
 ARG REPO_COMPS=https://github.com/opea-project/GenAIComps.git
 ARG BRANCH=main
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
     aspell \

--- a/comps/reranks/fastrag/docker/Dockerfile
+++ b/comps/reranks/fastrag/docker/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM python:3.10-slim
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
     libgl1-mesa-glx \

--- a/comps/reranks/tei/docker/Dockerfile
+++ b/comps/reranks/tei/docker/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM python:3.11-slim
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 ARG ARCH="cpu"
 

--- a/comps/retrievers/langchain/milvus/docker/Dockerfile
+++ b/comps/retrievers/langchain/milvus/docker/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM python:3.11-slim
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 ARG ARCH="cpu"
 

--- a/comps/tts/Dockerfile
+++ b/comps/tts/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM python:3.11-slim
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 COPY comps /home/comps
 


### PR DESCRIPTION
## Description

Update Dockerfiles to fix syntax warning when building files

## Issues

https://github.com/opea-project/GenAIComps/issues/326

## Type of change
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

None

## Tests

Build all Dockerfiles locally using docker on Ubuntu 22.04.4.  
