### PR TITLE
Add output evaluation for guardrails

### DIFF
--- a/comps/guardrails/llama_guard/README.md
+++ b/comps/guardrails/llama_guard/README.md
@@ -36,7 +36,7 @@ pip install -r requirements.txt
 export HF_TOKEN=${your_hf_api_token}
 export LANGCHAIN_TRACING_V2=true
 export LANGCHAIN_API_KEY=${your_langchain_api_key}
-export LANGCHAIN_PROJECT="opea/gaurdrails"
+export LANGCHAIN_PROJECT="opea/guardrails"
 volume=$PWD/data
 model_id="meta-llama/Meta-Llama-Guard-2-8B"
 docker pull ghcr.io/huggingface/tgi-gaudi:2.0.1

--- a/comps/guardrails/llama_guard/guardrails_tgi.py
+++ b/comps/guardrails/llama_guard/guardrails_tgi.py
@@ -71,7 +71,6 @@ def safety_guard(input: Union[GeneratedDoc, TextDoc]) -> TextDoc:
         messages = [{"role": "user", "content": input.text}]
     response_input_guard = llm_engine_hf.invoke(messages).content
 
-    # response_input_guard = llm_engine_hf.invoke([{"role": input.role, "content": input.text}]).content
     if "unsafe" in response_input_guard:
         unsafe_dict = get_unsafe_dict(llm_engine_hf.model_id)
         policy_violation_level = response_input_guard.split("\n")[1].strip()

--- a/comps/guardrails/llama_guard/guardrails_tgi.py
+++ b/comps/guardrails/llama_guard/guardrails_tgi.py
@@ -2,13 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import os
+from typing import List, Union
 
 from langchain_community.utilities.requests import JsonRequestsWrapper
 from langchain_huggingface import ChatHuggingFace
 from langchain_huggingface.llms import HuggingFaceEndpoint
 from langsmith import traceable
 
-from comps import ServiceType, TextDoc, opea_microservices, register_microservice
+from comps import GeneratedDoc, ServiceType, TextDoc, opea_microservices, register_microservice
 
 DEFAULT_MODEL = "meta-llama/LlamaGuard-7b"
 
@@ -59,12 +60,18 @@ def get_tgi_service_model_id(endpoint_url, default=DEFAULT_MODEL):
     endpoint="/v1/guardrails",
     host="0.0.0.0",
     port=9090,
-    input_datatype=TextDoc,
+    input_datatype=Union[GeneratedDoc, TextDoc],
     output_datatype=TextDoc,
 )
 @traceable(run_type="llm")
-def safety_guard(input: TextDoc) -> TextDoc:
-    response_input_guard = llm_engine_hf.invoke([{"role": "user", "content": input.text}]).content
+def safety_guard(input: Union[GeneratedDoc, TextDoc]) -> TextDoc:
+    if isinstance(input, GeneratedDoc):
+        messages = [{"role": "user", "content": input.prompt}, {"role": "assistant", "content": input.text}]
+    else:
+        messages = [{"role": "user", "content": input.text}]
+    response_input_guard = llm_engine_hf.invoke(messages).content
+
+    # response_input_guard = llm_engine_hf.invoke([{"role": input.role, "content": input.text}]).content
     if "unsafe" in response_input_guard:
         unsafe_dict = get_unsafe_dict(llm_engine_hf.model_id)
         policy_violation_level = response_input_guard.split("\n")[1].strip()
@@ -75,7 +82,6 @@ def safety_guard(input: TextDoc) -> TextDoc:
         )
     else:
         res = TextDoc(text=input.text)
-
     return res
 
 

--- a/comps/guardrails/llama_guard/requirements.txt
+++ b/comps/guardrails/llama_guard/requirements.txt
@@ -1,6 +1,7 @@
 docarray[full]
 fastapi
-huggingface_hub
+# Fix for issue with langchain-huggingface not using InferenceClient `base_url` kwarg
+huggingface-hub<=0.24.0
 langchain-community
 langchain-huggingface
 langsmith

--- a/tests/test_guardrails_llama_guard.sh
+++ b/tests/test_guardrails_llama_guard.sh
@@ -25,7 +25,6 @@ function start_service() {
     sleep 4m
     docker run -d --name="test-guardrails-langchain-service" -p 9090:9090 --ipc=host -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e no_proxy=$no_proxy -e SAFETY_GUARD_MODEL_ID=$SAFETY_GUARD_MODEL_ID -e SAFETY_GUARD_ENDPOINT=$SAFETY_GUARD_ENDPOINT -e HUGGINGFACEHUB_API_TOKEN=$HF_TOKEN opea/guardrails-tgi:latest
     sleep 10s
-
     echo "Microservice started"
 }
 


### PR DESCRIPTION
## Description

This PR attempts to reduce latency by allowing safeguard microservice to be at end of DAG and process safety of both input and output with single query. This means you can structure the DAG as follows to reduce latency of RAG flow:

```python
        self.megaservice.add(embedding).add(retriever).add(rerank).add(llm).add(guardrails)
        self.megaservice.flow_to(embedding, retriever)
        self.megaservice.flow_to(retriever, rerank)
        self.megaservice.flow_to(rerank, llm)
        self.megaservice.flow_to(llm, guardrails)
        self.gateway = ChatQnAGateway(megaservice=self.megaservice, host="0.0.0.0", port=self.port)
```       

Currently our implementation only supports single input safeguarding. But the chat Messages API (`v1/chat/completion`) will allow for templating for both "user" inputs and "assistant" output. with a single query. This PR adds the ability to send a list of both "user" and "assistant" messages for safeguarding. Since LLM  outputs both "prompt and "text" with `GeneratedDoc` this means you can feed output directly into guardrails microservice.


```bash
curl http://localhost:9090/v1/guardrails \
  -X POST \
  -d '{
    "prompt" : "How do you buy a tiger in the US",
    "text" : "Yes! Buy a tiger in the US.",
    "parameters":{"max_new_tokens":32}
  }
```

However it maintains backwards compatibility with following DAG:

```python
        self.megaservice.add(guardrail_in).add(embedding).add(retriever).add(rerank).add(llm).add(guardrail_out)
        self.megaservice.flow_to(guardrail_in, embedding)
        self.megaservice.flow_to(embedding, retriever)
        self.megaservice.flow_to(retriever, rerank)
        self.megaservice.flow_to(rerank, llm)
        self.megaservice.flow_to(llm, guardrail_out)
        self.gateway = ChatQnAGateway(megaservice=self.megaservice, host="0.0.0.0", port=self.port)
``` 

It also can be queried with just text:

```bash
curl http://localhost:9090/v1/guardrails \
  -X POST \
  -d '{
    "text" : "How do you buy a tiger in the US",
    "parameters":{"max_new_tokens":32}
  }
```

## Issues

`n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

Changed to `hugingface_hub<=0.24.0.` because `HugingFaceEndpoint` does it assigns both `endpoint_url` or `repo_id` to  `InferenceClient.model` attribute. But this is a bug since  `hugingface_hub>0.24.0.` introduces a  `base_url` kwarg for `InferenceClient` to be used.

## Tests

Ran the following

```
docker run -d --name="guardrails-tgi-server" -p 9090:9090 --ipc=host -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e no_proxy=$no_proxy -e SAFETY_GUARD_ENDPOINT=${SAFETY_GUARD_ENDPOINT} -e HUGGINGFACEHUB_API_TOKEN=${HUGGINGFACEHUB_API_TOKEN} opea/guardrails-tgi:latest
```

```bash
curl http://localhost:9090/v1/guardrails   -X POST   -d '{
    "messages":[{"role": "user", "text" : "How do you buy a tiger in the US?"}],
    "parameters":{"max_new_tokens":32}
  }'   -H 'Content-Type: application/json'
```

Output:

```
{"downstream_black_list":[".*"],"id":"6e70dcfa9db13087fc390d84c7869e7a","text":"Violated policies: Violent Crimes, please check your input."}
```

