### PR TITLE
align asr output and llm input without using orchestrator

### DIFF
--- a/comps/asr/asr.py
+++ b/comps/asr/asr.py
@@ -11,7 +11,7 @@ import requests
 from comps import (
     Base64ByteStrDoc,
     ServiceType,
-    TextDoc,
+    LLMParamsDoc,
     opea_microservices,
     register_microservice,
     register_statistics,
@@ -26,7 +26,7 @@ from comps import (
     host="0.0.0.0",
     port=9099,
     input_datatype=Base64ByteStrDoc,
-    output_datatype=TextDoc,
+    output_datatype=LLMParamsDoc,
 )
 @register_statistics(names=["opea_service@asr"])
 async def audio_to_text(audio: Base64ByteStrDoc):
@@ -37,7 +37,7 @@ async def audio_to_text(audio: Base64ByteStrDoc):
     response = requests.post(url=f"{asr_endpoint}/v1/asr", data=json.dumps(inputs), proxies={"http": None})
 
     statistics_dict["opea_service@asr"].append_latency(time.time() - start, None)
-    return TextDoc(text=response.json()["asr_result"])
+    return LLMParamsDoc(query=response.json()["asr_result"])
 
 
 if __name__ == "__main__":

--- a/comps/cores/mega/orchestrator.py
+++ b/comps/cores/mega/orchestrator.py
@@ -131,13 +131,6 @@ class ServiceOrchestrator(DAG):
 
             return StreamingResponse(generate(), media_type="text/event-stream"), cur_node
         else:
-            if (
-                self.services[cur_node].service_type == ServiceType.LLM
-                and runtime_graph.predecessors(cur_node)
-                and "asr" in runtime_graph.predecessors(cur_node)[0]
-            ):
-                inputs["query"] = inputs["text"]
-                del inputs["text"]
             async with session.post(endpoint, json=inputs) as response:
                 print(response.status)
                 return await response.json(), cur_node


### PR DESCRIPTION
## Description

align asr output and llm input without using orchestrator, allow k8s to use directly

## Issues

[340](https://github.com/opea-project/GenAIComps/issues/340)

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

None
## Tests

existing CI