### PR TITLE
Quickfix: Replace fastapi dep with fastapi[standard]

### DIFF
--- a/comps/agent/langchain/requirements.txt
+++ b/comps/agent/langchain/requirements.txt
@@ -3,7 +3,7 @@ docarray[full]
 
 #used by tools
 duckduckgo-search
-fastapi
+fastapi[standard]
 huggingface_hub
 langchain #==0.1.12
 langchain-huggingface

--- a/comps/asr/requirements.txt
+++ b/comps/asr/requirements.txt
@@ -1,6 +1,6 @@
 datasets
 docarray[full]
-fastapi
+fastapi[standard]
 opentelemetry-api
 opentelemetry-exporter-otlp
 opentelemetry-sdk

--- a/comps/dataprep/milvus/requirements.txt
+++ b/comps/dataprep/milvus/requirements.txt
@@ -3,7 +3,7 @@ cairosvg
 docarray[full]
 docx2txt
 easyocr
-fastapi
+fastapi[standard]
 huggingface_hub
 langchain
 langchain-community

--- a/comps/dataprep/pgvector/langchain/requirements.txt
+++ b/comps/dataprep/pgvector/langchain/requirements.txt
@@ -3,7 +3,7 @@ cairosvg
 docarray[full]
 docx2txt
 easyocr
-fastapi
+fastapi[standard]
 huggingface_hub
 langchain
 langchain-community

--- a/comps/dataprep/pinecone/requirements.txt
+++ b/comps/dataprep/pinecone/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4
 docarray[full]
 easyocr
-fastapi
+fastapi[standard]
 huggingface_hub
 langchain
 langchain-community

--- a/comps/dataprep/qdrant/requirements.txt
+++ b/comps/dataprep/qdrant/requirements.txt
@@ -3,7 +3,7 @@ cairosvg
 docarray[full]
 docx2txt
 easyocr
-fastapi
+fastapi[standard]
 huggingface_hub
 langchain
 langchain-community

--- a/comps/dataprep/redis/langchain/requirements.txt
+++ b/comps/dataprep/redis/langchain/requirements.txt
@@ -3,7 +3,7 @@ cairosvg
 docarray[full]
 docx2txt
 easyocr
-fastapi
+fastapi[standard]
 huggingface_hub
 langchain
 langchain-community

--- a/comps/dataprep/redis/langchain_ray/requirements.txt
+++ b/comps/dataprep/redis/langchain_ray/requirements.txt
@@ -3,7 +3,7 @@ cairosvg
 docarray[full]
 docx2txt
 easyocr
-fastapi
+fastapi[standard]
 huggingface_hub
 langchain
 langchain-community

--- a/comps/dataprep/redis/llama_index/requirements.txt
+++ b/comps/dataprep/redis/llama_index/requirements.txt
@@ -1,5 +1,5 @@
 docarray[full]
-fastapi
+fastapi[standard]
 huggingface_hub
 langsmith
 llama-index 

--- a/comps/embeddings/langchain-mosec/requirements.txt
+++ b/comps/embeddings/langchain-mosec/requirements.txt
@@ -1,5 +1,5 @@
 docarray[full]
-fastapi
+fastapi[standard]
 langchain
 langchain_community
 openai

--- a/comps/embeddings/langchain/requirements.txt
+++ b/comps/embeddings/langchain/requirements.txt
@@ -1,5 +1,5 @@
 docarray[full]
-fastapi
+fastapi[standard]
 huggingface_hub
 langchain
 langsmith

--- a/comps/embeddings/llama_index/requirements.txt
+++ b/comps/embeddings/llama_index/requirements.txt
@@ -1,5 +1,5 @@
 docarray[full]
-fastapi
+fastapi[standard]
 huggingface_hub
 langsmith
 llama-index-embeddings-text-embeddings-inference

--- a/comps/guardrails/pii_detection/requirements.txt
+++ b/comps/guardrails/pii_detection/requirements.txt
@@ -3,7 +3,7 @@ detect_secrets
 docarray[full]
 easyocr
 einops
-fastapi
+fastapi[standard]
 gibberish-detector
 huggingface_hub
 langchain

--- a/comps/guardrails/requirements.txt
+++ b/comps/guardrails/requirements.txt
@@ -1,5 +1,5 @@
 docarray[full]
-fastapi
+fastapi[standard]
 huggingface_hub
 langchain-community
 langchain-huggingface

--- a/comps/knowledgegraphs/requirements.txt
+++ b/comps/knowledgegraphs/requirements.txt
@@ -2,7 +2,7 @@ beautifulsoup4
 docarray
 docarray[full]
 easyocr
-fastapi
+fastapi[standard]
 huggingface_hub
 langchain
 langchain_community==0.2.5

--- a/comps/llms/faq-generation/tgi/requirements.txt
+++ b/comps/llms/faq-generation/tgi/requirements.txt
@@ -1,5 +1,5 @@
 docarray[full]
-fastapi
+fastapi[standard]
 huggingface_hub
 langchain==0.1.16
 langserve

--- a/comps/llms/requirements.txt
+++ b/comps/llms/requirements.txt
@@ -1,5 +1,5 @@
 docarray[full]
-fastapi
+fastapi[standard]
 huggingface_hub
 langchain==0.1.16
 opentelemetry-api

--- a/comps/llms/summarization/tgi/requirements.txt
+++ b/comps/llms/summarization/tgi/requirements.txt
@@ -1,5 +1,5 @@
 docarray[full]
-fastapi
+fastapi[standard]
 huggingface_hub
 langchain #==0.1.12
 langchain-huggingface

--- a/comps/llms/text-generation/native/requirements.txt
+++ b/comps/llms/text-generation/native/requirements.txt
@@ -1,5 +1,5 @@
 docarray[full]
-fastapi
+fastapi[standard]
 langsmith
 opentelemetry-api
 opentelemetry-exporter-otlp

--- a/comps/llms/text-generation/ollama/requirements.txt
+++ b/comps/llms/text-generation/ollama/requirements.txt
@@ -1,5 +1,5 @@
 docarray[full]
-fastapi
+fastapi[standard]
 huggingface_hub
 langchain==0.1.16
 langsmith

--- a/comps/llms/text-generation/tgi/requirements.txt
+++ b/comps/llms/text-generation/tgi/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp
 docarray[full]
-fastapi
+fastapi[standard]
 httpx
 huggingface_hub
 langsmith

--- a/comps/llms/text-generation/vllm-ray/requirements.txt
+++ b/comps/llms/text-generation/vllm-ray/requirements.txt
@@ -1,5 +1,5 @@
 docarray[full]
-fastapi
+fastapi[standard]
 huggingface_hub
 langchain==0.1.16
 langchain_openai

--- a/comps/llms/text-generation/vllm-xft/requirements.txt
+++ b/comps/llms/text-generation/vllm-xft/requirements.txt
@@ -1,5 +1,5 @@
 docarray[full]
-fastapi
+fastapi[standard]
 langchain==0.1.16
 langsmith
 opentelemetry-api

--- a/comps/llms/text-generation/vllm/requirements.txt
+++ b/comps/llms/text-generation/vllm/requirements.txt
@@ -1,5 +1,5 @@
 docarray[full]
-fastapi
+fastapi[standard]
 huggingface_hub
 langchain==0.1.16
 opentelemetry-api

--- a/comps/lvms/requirements.txt
+++ b/comps/lvms/requirements.txt
@@ -1,6 +1,6 @@
 datasets
 docarray[full]
-fastapi
+fastapi[standard]
 opentelemetry-api
 opentelemetry-exporter-otlp
 opentelemetry-sdk

--- a/comps/ragas/tgi/requirements.txt
+++ b/comps/ragas/tgi/requirements.txt
@@ -1,6 +1,6 @@
 datasets
 docarray[full]
-fastapi
+fastapi[standard]
 huggingface_hub
 langchain==0.1.16
 langsmith

--- a/comps/reranks/fastrag/requirements.txt
+++ b/comps/reranks/fastrag/requirements.txt
@@ -1,5 +1,5 @@
 docarray[full]
-fastapi
+fastapi[standard]
 haystack-ai
 langchain
 langsmith

--- a/comps/reranks/langchain-mosec/requirements.txt
+++ b/comps/reranks/langchain-mosec/requirements.txt
@@ -1,5 +1,5 @@
 docarray[full]
-fastapi
+fastapi[standard]
 langchain
 langchain_community
 openai

--- a/comps/reranks/requirements.txt
+++ b/comps/reranks/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp
 docarray[full]
-fastapi
+fastapi[standard]
 httpx
 langsmith
 opentelemetry-api

--- a/comps/retrievers/haystack/qdrant/requirements.txt
+++ b/comps/retrievers/haystack/qdrant/requirements.txt
@@ -1,6 +1,6 @@
 docarray[full]
 easyocr
-fastapi
+fastapi[standard]
 haystack-ai==2.2.4
 langchain_community
 langsmith

--- a/comps/retrievers/langchain/milvus/requirements.txt
+++ b/comps/retrievers/langchain/milvus/requirements.txt
@@ -1,7 +1,7 @@
 beautifulsoup4
 docarray[full]
 easyocr
-fastapi
+fastapi[standard]
 frontend==0.0.3
 huggingface_hub
 langchain

--- a/comps/retrievers/langchain/pgvector/requirements.txt
+++ b/comps/retrievers/langchain/pgvector/requirements.txt
@@ -1,6 +1,6 @@
 docarray[full]
 easyocr
-fastapi
+fastapi[standard]
 langchain_community
 langsmith
 opentelemetry-api

--- a/comps/retrievers/langchain/redis/requirements.txt
+++ b/comps/retrievers/langchain/redis/requirements.txt
@@ -1,6 +1,6 @@
 docarray[full]
 easyocr
-fastapi
+fastapi[standard]
 langchain_community
 langsmith
 opentelemetry-api

--- a/comps/retrievers/llamaindex/requirements.txt
+++ b/comps/retrievers/llamaindex/requirements.txt
@@ -1,7 +1,7 @@
 aiohttp
 docarray[full]
 easyocr
-fastapi
+fastapi[standard]
 httpx
 langsmith
 llama-index-vector-stores-redis

--- a/comps/tts/requirements.txt
+++ b/comps/tts/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp
 docarray[full]
-fastapi
+fastapi[standard]
 opentelemetry-api
 opentelemetry-exporter-otlp
 opentelemetry-sdk

--- a/comps/web_retrievers/langchain/chroma/requirements.txt
+++ b/comps/web_retrievers/langchain/chroma/requirements.txt
@@ -1,7 +1,7 @@
 bs4
 chromadb
 docarray[full]
-fastapi
+fastapi[standard]
 google-api-python-client>=2.100.0
 html2text
 langchain-huggingface

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp
 docarray
-fastapi
+fastapi[standard]
 httpx
 opentelemetry-api
 opentelemetry-exporter-otlp


### PR DESCRIPTION
## Description

`fastapi` is now an alias for `fastapi-slim` as per the release of [version 1.112](https://github.com/fastapi/fastapi/releases/tag/0.112.0). 

> Before this, fastapi would include the standard dependencies, with Uvicorn and the fastapi-cli, etc.
And fastapi-slim would not include those standard dependencies.
Now fastapi doesn't include those standard dependencies unless you install with pip install "fastapi[standard]".



## Issues

#395 

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

N/A

## Tests

N/A
