### PR TITLE
[Enhence] Increase mosec_embedding forward timeout to support high concurrency cases

### DIFF
--- a/comps/embeddings/langchain-mosec/README.md
+++ b/comps/embeddings/langchain-mosec/README.md
@@ -19,7 +19,7 @@ docker run -d --name="embedding-langchain-mosec-endpoint" -p 6001:8000  langchai
 # launch embedding microservice docker container
 
 ```
-export MOSEC_EMBEDDING_ENDPOINT=http://127.0.0.1:6001
+export MOSEC_EMBEDDING_ENDPOINT=http://{mosec_embedding_host_ip}:6001
 docker run -d --name="embedding-langchain-mosec-server" -e http_proxy=$http_proxy -e https_proxy=$https_proxy -p 6000:6000 --ipc=host -e MOSEC_EMBEDDING_ENDPOINT=$MOSEC_EMBEDDING_ENDPOINT opea/embedding-langchain-mosec:latest
 ```
 

--- a/comps/embeddings/langchain-mosec/mosec-docker/server-ipex.py
+++ b/comps/embeddings/langchain-mosec/mosec-docker/server-ipex.py
@@ -113,8 +113,9 @@ class Embedding(Worker):
 if __name__ == "__main__":
     MAX_BATCH_SIZE = int(os.environ.get("MAX_BATCH_SIZE", 128))
     MAX_WAIT_TIME = int(os.environ.get("MAX_WAIT_TIME", 10))
+    MAX_FORWARD_TIMEOUT = int(os.environ.get("FORWARD_TIMEOUT", 60))
     server = Server()
-    emb = Runtime(Embedding, max_batch_size=MAX_BATCH_SIZE, max_wait_time=MAX_WAIT_TIME, timeout=60)
+    emb = Runtime(Embedding, max_batch_size=MAX_BATCH_SIZE, max_wait_time=MAX_WAIT_TIME, timeout=MAX_FORWARD_TIMEOUT)
     server.register_runtime(
         {
             "/v1/embeddings": [emb],

--- a/comps/embeddings/langchain-mosec/mosec-docker/server-ipex.py
+++ b/comps/embeddings/langchain-mosec/mosec-docker/server-ipex.py
@@ -114,7 +114,7 @@ if __name__ == "__main__":
     MAX_BATCH_SIZE = int(os.environ.get("MAX_BATCH_SIZE", 128))
     MAX_WAIT_TIME = int(os.environ.get("MAX_WAIT_TIME", 10))
     server = Server()
-    emb = Runtime(Embedding, max_batch_size=MAX_BATCH_SIZE, max_wait_time=MAX_WAIT_TIME)
+    emb = Runtime(Embedding, max_batch_size=MAX_BATCH_SIZE, max_wait_time=MAX_WAIT_TIME, timeout=60)
     server.register_runtime(
         {
             "/v1/embeddings": [emb],


### PR DESCRIPTION
## Description

[Enhence] Increate mosec_embedding forward timeout to support high concurrency cases

ref: 
* https://mosecorg.github.io/mosec/reference/interface.html
* https://github.com/mosecorg/mosec/pull/321
* https://github.com/mosecorg/mosec/issues/298

## Issues

avoid timeout issues if high concurrency.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

N/A

## Tests

![image](https://github.com/user-attachments/assets/6c2d42ad-2160-49a5-9934-07c6f200e242)

