### PR TITLE
[tests] normalize embedding and reranking endpoint docker image name

### DIFF
--- a/comps/embeddings/langchain-mosec/README.md
+++ b/comps/embeddings/langchain-mosec/README.md
@@ -1,7 +1,7 @@
 # build Mosec endpoint docker image
 
 ```
-docker build --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy -t langchain-mosec:latest -f comps/embeddings/langchain-mosec/mosec-docker/Dockerfile .
+docker build --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy -t opea/embedding-langchain-mosec-endpoint:latest -f comps/embeddings/langchain-mosec/mosec-docker/Dockerfile .
 ```
 
 # build embedding microservice docker image
@@ -13,7 +13,7 @@ docker build --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_p
 # launch Mosec endpoint docker container
 
 ```
-docker run -d --name="embedding-langchain-mosec-endpoint" -p 6001:8000  langchain-mosec:latest
+docker run -d --name="embedding-langchain-mosec-endpoint" -p 6001:8000  opea/embedding-langchain-mosec-endpoint:latest
 ```
 
 # launch embedding microservice docker container

--- a/comps/reranks/langchain-mosec/README.md
+++ b/comps/reranks/langchain-mosec/README.md
@@ -1,7 +1,7 @@
 # build reranking Mosec endpoint docker image
 
 ```
-docker build --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy -t reranking-langchain-mosec:latest -f comps/reranks/langchain-mosec/mosec-docker/Dockerfile .
+docker build --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy -t opea/reranking-langchain-mosec-endpoint:latest -f comps/reranks/langchain-mosec/mosec-docker/Dockerfile .
 ```
 
 # build reranking microservice docker image
@@ -13,7 +13,7 @@ docker build --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_p
 # launch Mosec endpoint docker container
 
 ```
-docker run -d --name="reranking-langchain-mosec-endpoint" -p 6001:8000  reranking-langchain-mosec:latest
+docker run -d --name="reranking-langchain-mosec-endpoint" -p 6001:8000  opea/reranking-langchain-mosec-endpoint:latest
 ```
 
 # launch embedding microservice docker container

--- a/tests/test_embeddings_langchain-mosec.sh
+++ b/tests/test_embeddings_langchain-mosec.sh
@@ -10,7 +10,7 @@ ip_address=$(hostname -I | awk '{print $1}')
 function build_mosec_docker_images() {
     cd $WORKPATH
     echo $(pwd)
-    docker build --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy --no-cache -t langchain-mosec:comps -f comps/embeddings/langchain-mosec/mosec-docker/Dockerfile .
+    docker build --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy --no-cache -t opea/embedding-langchain-mosec-endpoint:comps -f comps/embeddings/langchain-mosec/mosec-docker/Dockerfile .
 }
 
 function build_docker_images() {
@@ -23,7 +23,7 @@ function start_service() {
     mosec_endpoint=5001
     model="BAAI/bge-large-en-v1.5"
     unset http_proxy
-    docker run -d --name="test-comps-embedding-langchain-mosec-endpoint" -p $mosec_endpoint:8000  langchain-mosec:comps
+    docker run -d --name="test-comps-embedding-langchain-mosec-endpoint" -p $mosec_endpoint:8000  opea/embedding-langchain-mosec-endpoint:comps
     export MOSEC_EMBEDDING_ENDPOINT="http://${ip_address}:${mosec_endpoint}"
     mosec_service_port=5002
     docker run -d --name="test-comps-embedding-langchain-mosec-server" -e http_proxy=$http_proxy -e https_proxy=$https_proxy -p ${mosec_service_port}:6000 --ipc=host -e MOSEC_EMBEDDING_ENDPOINT=$MOSEC_EMBEDDING_ENDPOINT  opea/embedding-langchain-mosec:comps

--- a/tests/test_reranks_langchain-mosec.sh
+++ b/tests/test_reranks_langchain-mosec.sh
@@ -10,7 +10,7 @@ ip_address=$(hostname -I | awk '{print $1}')
 function build_mosec_docker_images() {
     cd $WORKPATH
     echo $(pwd)
-    docker build --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy --no-cache -t reranking-langchain-mosec:comps -f comps/reranks/langchain-mosec/mosec-docker/Dockerfile .
+    docker build --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy --no-cache -t opea/reranking-langchain-mosec-endpoint:comps -f comps/reranks/langchain-mosec/mosec-docker/Dockerfile .
 }
 
 function build_docker_images() {
@@ -23,7 +23,7 @@ function start_service() {
     mosec_endpoint=5006
     model="BAAI/bge-reranker-large"
     unset http_proxy
-    docker run -d --name="test-comps-reranking-langchain-mosec-endpoint" -p $mosec_endpoint:8000  reranking-langchain-mosec:comps
+    docker run -d --name="test-comps-reranking-langchain-mosec-endpoint" -p $mosec_endpoint:8000  opea/reranking-langchain-mosec-endpoint:comps
     export MOSEC_RERANKING_ENDPOINT="http://${ip_address}:${mosec_endpoint}"
     mosec_service_port=5007
     docker run -d --name="test-comps-reranking-langchain-mosec-server" -e http_proxy=$http_proxy -e https_proxy=$https_proxy -p ${mosec_service_port}:8000 --ipc=host -e MOSEC_RERANKING_ENDPOINT=$MOSEC_RERANKING_ENDPOINT  opea/reranking-langchain-mosec:comps


### PR DESCRIPTION
## Description

Modify the docker image name of embedding and reranking, normalized with prefix "opea/".

## Issues

`n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [*] Others (enhancement, documentation, validation, etc.)

## Dependencies

N/A.

## Tests

N/A.
