### PR TITLE
Add cmds to restart ollama service and add proxy settings while launching docker

### DIFF
--- a/comps/llms/text-generation/ollama/README.md
+++ b/comps/llms/text-generation/ollama/README.md
@@ -64,7 +64,7 @@ docker build --no-cache -t opea/llm-ollama:latest --build-arg https_proxy=$https
 # Run the Ollama Microservice
 
 ```bash
-docker run --network host opea/llm-ollama:latest
+docker run --network host -e http_proxy=$http_proxy -e https_proxy=$https_proxy opea/llm-ollama:latest
 ```
 
 # Consume the Ollama Microservice

--- a/comps/llms/text-generation/ollama/README.md
+++ b/comps/llms/text-generation/ollama/README.md
@@ -15,17 +15,25 @@ Follow [these instructions](https://github.com/ollama/ollama) to set up and run 
 Note:
 Special settings are necessary to pull models behind the proxy.
 
-```bash
-sudo vim /etc/systemd/system/ollama.service
-```
+- Step1: Modify the ollama service configure file.
 
-Add your proxy to the above configure file.
+  ```bash
+  sudo vim /etc/systemd/system/ollama.service
+  ```
 
-```markdown
-[Service]
-Environment="http_proxy=${your_proxy}"
-Environment="https_proxy=${your_proxy}"
-```
+  Add your proxy to the above configure file.
+
+  ```markdown
+  [Service]
+  Environment="http_proxy=${your_proxy}"
+  Environment="https_proxy=${your_proxy}"
+  ```
+
+- Step2: Restart the ollama service.
+  ```bash
+  sudo systemctl daemon-reload
+  sudo systemctl restart ollama
+  ```
 
 ## Usage
 


### PR DESCRIPTION
## Description

* Add commands to restart the ollama service. Otherwise, the proxy setting in the ollama.service file will not take effect before pulling the model with ollama.
* Add proxy settings while launching the opea-ollama docker container.

## Issues

Found issues while verifying the ollama example during supporting the issue reported in https://github.com/opea-project/GenAIComps/issues/367. 

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

N/A

## Tests

Ollama example on llama3.
