### PR TITLE
Refine the instructions to run the retriever example with qdrant

### DIFF
--- a/comps/retrievers/haystack/qdrant/README.md
+++ b/comps/retrievers/haystack/qdrant/README.md
@@ -30,17 +30,25 @@ python haystack/qdrant/retriever_qdrant.py
 
 # 2. 🚀Start Microservice with Docker (Option 2)
 
-## 2.1 Build Docker Image
+## 2.1 Setup Environment Variables
+
+```bash
+export QDRANT_HOST=${your_qdrant_host_ip}
+export QDRANT_PORT=6333
+export TEI_EMBEDDING_ENDPOINT="http://${your_ip}:6060"
+```
+
+## 2.2 Build Docker Image
 
 ```bash
 cd ../../
 docker build -t opea/retriever-qdrant:latest --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy -f comps/retrievers/haystack/qdrant/docker/Dockerfile .
 ```
 
-## 2.2 Run Docker with CLI
+## 2.3 Run Docker with CLI
 
 ```bash
-docker run -d --name="retriever-qdrant-server" -p 7000:7000 --ipc=host -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e TEI_EMBEDDING_ENDPOINT=${your_tei_endpoint} -e QDRANT_HOST=${your_qdrant_host_ip} -e QDRANT_PORT=${your_qdrant_port} opea/retriever-qdrant:latest
+docker run -d --name="retriever-qdrant-server" -p 7000:7000 --ipc=host -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e TEI_EMBEDDING_ENDPOINT=$TEI_EMBEDDING_ENDPOINT -e QDRANT_HOST=$QDRANT_HOST -e QDRANT_PORT=$QDRANT_PORT opea/retriever-qdrant:latest
 ```
 
 # 🚀3. Consume Retriever Service

--- a/comps/retrievers/haystack/qdrant/README.md
+++ b/comps/retrievers/haystack/qdrant/README.md
@@ -1,46 +1,43 @@
 # Retriever Microservice with Qdrant
 
-# 🚀Start Microservice with Python
+# 1. 🚀Start Microservice with Python (Option 1)
 
-## Install Requirements
+## 1.1 Install Requirements
 
 ```bash
 pip install -r requirements.txt
 ```
 
-## Start Qdrant Server
+## 1.2 Start Qdrant Server
 
 Please refer to this [readme](../../../vectorstores/langchain/qdrant/README.md).
 
-## Setup Environment Variables
+## 1.3 Setup Environment Variables
 
 ```bash
-export http_proxy=${your_http_proxy}
-export https_proxy=${your_https_proxy}
 export QDRANT_HOST=${your_qdrant_host_ip}
 export QDRANT_PORT=6333
 export EMBED_DIMENSION=${your_embedding_dimension}
 export INDEX_NAME=${your_index_name}
-export TEI_EMBEDDING_ENDPOINT=${your_tei_endpoint}
 ```
 
-## Start Retriever Service
+## 1.4 Start Retriever Service
 
 ```bash
 export TEI_EMBEDDING_ENDPOINT="http://${your_ip}:6060"
 python haystack/qdrant/retriever_qdrant.py
 ```
 
-# 🚀Start Microservice with Docker
+# 2. 🚀Start Microservice with Docker (Option 2)
 
-## Build Docker Image
+## 2.1 Build Docker Image
 
 ```bash
 cd ../../
 docker build -t opea/retriever-qdrant:latest --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy -f comps/retrievers/haystack/qdrant/docker/Dockerfile .
 ```
 
-## Run Docker with CLI
+## 2.2 Run Docker with CLI
 
 ```bash
 docker run -d --name="retriever-qdrant-server" -p 7000:7000 --ipc=host -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e TEI_EMBEDDING_ENDPOINT=${your_tei_endpoint} -e QDRANT_HOST=${your_qdrant_host_ip} -e QDRANT_PORT=${your_qdrant_port} opea/retriever-qdrant:latest


### PR DESCRIPTION
## Description

* Refine readme structure
* Remove repeated env variable for bare metal execution
* Add env vars settings of tei/qdrant port and align with the name while launching the docker container

## Issues

Fix the issue reported in: https://github.com/opea-project/GenAIComps/issues/360

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

N/A

## Tests

[Consume Retriever Service](https://github.com/opea-project/GenAIComps/tree/main/comps/retrievers/haystack/qdrant#3-consume-retriever-service)
