### PR TITLE
fix HuggingFaceEmbedding deprecated in favor of HuggingFaceInferenceAPIEmbedding

### DIFF
--- a/comps/embeddings/llama_index/local_embedding.py
+++ b/comps/embeddings/llama_index/local_embedding.py
@@ -2,10 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from langsmith import traceable
-from llama_index.embeddings.huggingface_api import (
-    HuggingFaceInferenceAPIEmbedding,
-)
-
+from llama_index.embeddings.huggingface_api import HuggingFaceInferenceAPIEmbedding
 
 from comps import EmbedDoc, ServiceType, TextDoc, opea_microservices, register_microservice
 

--- a/comps/embeddings/llama_index/local_embedding.py
+++ b/comps/embeddings/llama_index/local_embedding.py
@@ -2,7 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from langsmith import traceable
-from llama_index.embeddings.huggingface import HuggingFaceEmbedding
+from llama_index.embeddings.huggingface_api import (
+    HuggingFaceInferenceAPIEmbedding,
+)
+
 
 from comps import EmbedDoc, ServiceType, TextDoc, opea_microservices, register_microservice
 
@@ -24,5 +27,5 @@ def embedding(input: TextDoc) -> EmbedDoc:
 
 
 if __name__ == "__main__":
-    embeddings = HuggingFaceEmbedding(model_name="BAAI/bge-large-en-v1.5")
+    embeddings = HuggingFaceInferenceAPIEmbedding(model_name="BAAI/bge-large-en-v1.5")
     opea_microservices["opea_service@local_embedding"].start()

--- a/comps/embeddings/llama_index/requirements.txt
+++ b/comps/embeddings/llama_index/requirements.txt
@@ -2,6 +2,7 @@ docarray[full]
 fastapi
 huggingface_hub
 langsmith
+llama-index-embeddings-huggingface-api
 llama-index-embeddings-text-embeddings-inference
 opentelemetry-api
 opentelemetry-exporter-otlp


### PR DESCRIPTION
HuggingFaceEmbeddings is deprecated in favor of 'HuggingFaceInferenceAPIEmbedding'

https://github.com/run-llama/llama_index/blob/1abbc5a8eb5135eb695138caebfb573f7a10e5d3/llama-index-integrations/embeddings/llama-index-embeddings-huggingface/llama_index/embeddings/huggingface/base.py#L279

## Dependencies
llama-index-embeddings-huggingface-api
