### PR TITLE
Fix Retriever qdrant issue

### DIFF
--- a/comps/retrievers/haystack/qdrant/retriever_qdrant.py
+++ b/comps/retrievers/haystack/qdrant/retriever_qdrant.py
@@ -31,7 +31,7 @@ def initialize_qdrant_retriever() -> QdrantEmbeddingRetriever:
 @traceable(run_type="retriever")
 def retrieve(input: EmbedDoc) -> SearchedDoc:
     search_res = retriever.run(query_embedding=input.embedding)["documents"]
-    searched_docs = [TextDoc(text=r.content) for r in search_res]
+    searched_docs = [TextDoc(text=r.content) for r in search_res if r.content]
     result = SearchedDoc(retrieved_docs=searched_docs, initial_query=input.text)
     return result
 


### PR DESCRIPTION
## Description

Fix Retriever qdrant issue.
Return `[]` for empty retrieved docs.

## Issues

The CI failed [here](https://github.com/opea-project/GenAIExamples/pull/569) for ChatQnA qdrant.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

None

## Tests

CI test
