### PR TITLE
fix asr ut on hpu

### DIFF
--- a/comps/asr/whisper/whisper_model.py
+++ b/comps/asr/whisper/whisper_model.py
@@ -148,7 +148,7 @@ class WhisperModel:
                 return_tensors="pt",
                 sampling_rate=16000,
             )
-        elif self.device == "hpu":
+        elif self.device == "hpu" and processed_inputs.input_features.shape[-1] > 3000:
             processed_inputs["input_features"] = torch.nn.functional.pad(
                 processed_inputs.input_features,
                 (0, self.hpu_max_len - processed_inputs.input_features.size(-1)),


### PR DESCRIPTION
## Description

Default input audio should not be padded otherwise will recognize nothing rather than "you". This is related to GenAIExamples UT.

## Issues

na
## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

None

## Tests

Local test