### PR TITLE
Revise TTS, SpeechT5Model to end the last audio chunk at the correct punctuation mark location

### DIFF
--- a/comps/tts/speecht5/speecht5_model.py
+++ b/comps/tts/speecht5/speecht5_model.py
@@ -75,6 +75,8 @@ class SpeechT5Model:
             if last_punc_idx != -1:
                 last_chunk = last_chunk[: last_punc_idx + 1]
                 res.append(last_chunk[: last_punc_idx + 1])
+            else:
+                res.append(last_chunk)
         res = [i + "." for i in res]  # avoid unexpected end of sequence
         return res
 

--- a/comps/tts/speecht5/speecht5_model.py
+++ b/comps/tts/speecht5/speecht5_model.py
@@ -69,7 +69,12 @@ class SpeechT5Model:
                 cur_end = idx
             idx += 1
         # deal with the last sequence
-        res.append(text[cur_start:idx])
+        if cur_start < len(text):
+            last_chunk = text[cur_start:]
+            last_punc_idx = max([last_chunk.rfind(punc) for punc in hitted_ends[:-1]]) # exclude " "
+            if last_punc_idx != -1:
+                last_chunk = last_chunk[: last_punc_idx + 1]
+                res.append(last_chunk[: last_punc_idx + 1])
         res = [i + "." for i in res]  # avoid unexpected end of sequence
         return res
 


### PR DESCRIPTION
## Description

Revise TTS microservice,  by configging `split_long_text_into_batch` function of the `SpeechT5Model` to end the last audio chunk at the correct punctuation mark location and discard parts that will break sentence continuity

## Issues

n/a

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

N/A

## Tests
```
User Query: tell us about inflation in the us in the past few years

AI Answer: Inflation in the United States over the past few years has been relatively low and stable. According to the U.S. Bureau of Labor Statistics, the Consumer Price Index (CPI) measures the change in prices for a fixed basket of goods and services purchased by consumers. The CPI is a
```
In the above test case, the revised version of TTS will not include "The CPI is a" in the last audio chunk and end at the last punctuation mark "."  
This revision feeds to the `t2s` function only whole sentences/phrases without breaking the sentence continuity. The resulting generated audio will be more natural.

