### PR TITLE
Using habana docker 1.16.1 everywhere

### DIFF
--- a/.github/workflows/scripts/freeze_images.sh
+++ b/.github/workflows/scripts/freeze_images.sh
@@ -6,7 +6,6 @@
 declare -A dict
 dict["langchain/langchain"]="docker://docker.io/langchain/langchain"
 dict["vault.habana.ai/gaudi-docker/1.16.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.2"]="docker://vault.habana.ai/gaudi-docker/1.16.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.2"
-dict["vault.habana.ai/gaudi-docker/1.16.0/ubuntu22.04/habanalabs/pytorch-installer-2.2.2"]="docker://vault.habana.ai/gaudi-docker/1.16.0/ubuntu22.04/habanalabs/pytorch-installer-2.2.2"
 
 function get_latest_version() {
     repo_image=$1

--- a/comps/llms/text-generation/native/docker/Dockerfile
+++ b/comps/llms/text-generation/native/docker/Dockerfile
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # HABANA environment
-FROM vault.habana.ai/gaudi-docker/1.16.0/ubuntu22.04/habanalabs/pytorch-installer-2.2.2:latest as hpu
+FROM vault.habana.ai/gaudi-docker/1.16.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.2:latest as hpu
 
 ENV LANG=en_US.UTF-8
 ARG REPO=https://github.com/huggingface/optimum-habana.git

--- a/comps/llms/text-generation/vllm-ray/docker/Dockerfile.vllmray
+++ b/comps/llms/text-generation/vllm-ray/docker/Dockerfile.vllmray
@@ -1,8 +1,7 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-# FROM vault.habana.ai/gaudi-docker/1.15.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.0:latest
-FROM vault.habana.ai/gaudi-docker/1.16.0/ubuntu22.04/habanalabs/pytorch-installer-2.2.2:latest
+FROM vault.habana.ai/gaudi-docker/1.16.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.2:latest
 
 ENV LANG=en_US.UTF-8
 

--- a/comps/llms/text-generation/vllm/docker/Dockerfile.hpu
+++ b/comps/llms/text-generation/vllm/docker/Dockerfile.hpu
@@ -1,5 +1,4 @@
-# FROM vault.habana.ai/gaudi-docker/1.15.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.0:latest
-FROM vault.habana.ai/gaudi-docker/1.16.0/ubuntu22.04/habanalabs/pytorch-installer-2.2.2:latest
+FROM vault.habana.ai/gaudi-docker/1.16.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.2:latest
 RUN useradd -m -s /bin/bash user && \
     mkdir -p /home/user && \
     chown -R user /home/user/


### PR DESCRIPTION
## Description

This PR proposes using `vault.habana.ai/gaudi-docker/1.16.1/ubuntu22.04/habanalabs/pytorch-installer-2.2.2:latest` across the board.

## Issues

N/A

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [N/A] Bug fix (non-breaking change which fixes an issue)
- [N/A] New feature (non-breaking change which adds new functionality)
- [N/A] Breaking change (fix or feature that would break existing design and interface)
- [X] Others (enhancement, documentation, validation, etc.)

## Dependencies

None.

## Tests

This change won't affect CIs.