### PR TITLE
Remove redundant dependency from 'vllm-ray' comps

### DIFF
--- a/comps/llms/text-generation/vllm-ray/requirements.txt
+++ b/comps/llms/text-generation/vllm-ray/requirements.txt
@@ -3,7 +3,6 @@ fastapi
 huggingface_hub
 langchain==0.1.16
 langchain_openai
-langserve
 openai
 opentelemetry-api
 opentelemetry-exporter-otlp


### PR DESCRIPTION
## Description

`langserve` was previously removed from all `requirements.txt` files and was added to `requirements-runtime.txt`.
If there's still a need for that, it can be installed at runtime.

But looking at this `comps/llms/text-generation/vllm-ray/docker/Dockerfile.microservice` there's no `CMD` or `ENTRYPOINT` to begin with.
That means the dependency may not even be needed.

## Issues

N/A

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [Y] Bug fix (non-breaking change which fixes an issue)
- [N] New feature (non-breaking change which adds new functionality)
- [N] Breaking change (fix or feature that would break existing design and interface)
- [N] Others (enhancement, documentation, validation, etc.)

## Dependencies

None

## Tests

TBD
