### PR TITLE
Modify docker image name for vllm-hpu

### DIFF
--- a/.github/workflows/docker/compose/llms-compose.yaml
+++ b/.github/workflows/docker/compose/llms-compose.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # this file should be run in the root of the repo
-# images used by GenAIExamples: llm-tgi,llm-ollama,llm-docsum-tgi,llm-faqgen-tgi,llm-vllm,llm-vllm-hpu,llm-vllm-ray,llm-vllm-ray-hpu
+# images used by GenAIExamples: llm-tgi,llm-ollama,llm-docsum-tgi,llm-faqgen-tgi,llm-vllm,vllm-hpu,llm-vllm-ray,vllm-ray-hpu
 services:
   llm-tgi:
     build:
@@ -24,15 +24,15 @@ services:
     build:
       dockerfile: comps/llms/text-generation/vllm/docker/Dockerfile.microservice
     image: ${REGISTRY:-opea}/llm-vllm:${TAG:-latest}
-  llm-vllm-hpu:
+  vllm-hpu:
     build:
       dockerfile: comps/llms/text-generation/vllm/docker/Dockerfile.hpu
-    image: ${REGISTRY:-opea}/llm-vllm-hpu:${TAG:-latest}
+    image: ${REGISTRY:-opea}/vllm-hpu:${TAG:-latest}
   llm-vllm-ray:
     build:
       dockerfile: comps/llms/text-generation/vllm-ray/docker/Dockerfile.microservice
     image: ${REGISTRY:-opea}/llm-vllm-ray:${TAG:-latest}
-  llm-vllm-ray-hpu:
+  vllm-ray-hpu:
     build:
       dockerfile: comps/llms/text-generation/vllm-ray/docker/Dockerfile.vllmray
-    image: ${REGISTRY:-opea}/llm-vllm-ray-hpu:${TAG:-latest}
+    image: ${REGISTRY:-opea}/vllm-ray-hpu:${TAG:-latest}


### PR DESCRIPTION
The vllm image for xeon is opea/vllm, which is the backend of opea/llm-vllm. The llm means microservice layer for vllm. To be consistent, hpu image should be renamed as opea/vllm-hpu, remove the llm prefix.

## Description

See https://github.com/opea-project/GenAIExamples/pull/728