### PR TITLE
switch to using upstream 'tgi-gaudi' on HuggingFace

### DIFF
--- a/.github/workflows/_comps-workflow.yml
+++ b/.github/workflows/_comps-workflow.yml
@@ -67,7 +67,7 @@ jobs:
 
           cd ${{ github.workspace }}
           if [[ $(grep -c "llava-tgi:" ${docker_compose_yml}) != 0 ]]; then
-              git clone https://github.com/huggingface/tei-gaudi && cd tgi-gaudi && git checkout v2.0.4 && cd ../
+              git clone https://github.com/huggingface/tgi-gaudi && cd tgi-gaudi && git checkout v2.0.4 && cd ../
           fi
           if [[ $(grep -c "vllm-openvino:" ${docker_compose_yml}) != 0 ]]; then
               git clone https://github.com/vllm-project/vllm.git vllm-openvino

--- a/.github/workflows/_comps-workflow.yml
+++ b/.github/workflows/_comps-workflow.yml
@@ -66,9 +66,6 @@ jobs:
           fi
 
           cd ${{ github.workspace }}
-          if [[ $(grep -c "llava-tgi:" ${docker_compose_yml}) != 0 ]]; then
-              git clone https://github.com/huggingface/tgi-gaudi && cd tgi-gaudi && git checkout v2.0.4 && cd ../
-          fi
           if [[ $(grep -c "vllm-openvino:" ${docker_compose_yml}) != 0 ]]; then
               git clone https://github.com/vllm-project/vllm.git vllm-openvino
           fi

--- a/.github/workflows/_comps-workflow.yml
+++ b/.github/workflows/_comps-workflow.yml
@@ -67,7 +67,7 @@ jobs:
 
           cd ${{ github.workspace }}
           if [[ $(grep -c "llava-tgi:" ${docker_compose_yml}) != 0 ]]; then
-              git clone https://github.com/yuanwu2017/tgi-gaudi.git && cd tgi-gaudi && git checkout v2.0.4 && cd ../
+              git clone https://github.com/huggingface/tei-gaudi && cd tgi-gaudi && git checkout v2.0.4 && cd ../
           fi
           if [[ $(grep -c "vllm-openvino:" ${docker_compose_yml}) != 0 ]]; then
               git clone https://github.com/vllm-project/vllm.git vllm-openvino

--- a/.github/workflows/docker/compose/lvms-compose-cd.yaml
+++ b/.github/workflows/docker/compose/lvms-compose-cd.yaml
@@ -21,8 +21,3 @@ services:
     build:
       dockerfile: comps/lvms/Dockerfile_tgi
     image: ${REGISTRY:-opea}/lvm-tgi:${TAG:-latest}
-  llava-tgi:
-    build:
-      context: tgi-gaudi
-      dockerfile: Dockerfile
-    image: ${REGISTRY:-opea}/llava-tgi:${TAG:-latest}

--- a/tests/test_lvms_tgi_llava_next.sh
+++ b/tests/test_lvms_tgi_llava_next.sh
@@ -10,16 +10,6 @@ ip_address=$(hostname -I | awk '{print $1}')
 function build_docker_images() {
     cd $WORKPATH
     echo $(pwd)
-    git clone https://github.com/huggingface/tgi-gaudi && cd tgi-gaudi && git checkout v2.0.4
-    docker build --no-cache -t opea/llava-tgi:comps .
-    if [ $? -ne 0 ]; then
-        echo "opea/llava-tgi built fail"
-        exit 1
-    else
-        echo "opea/llava-tgi built successful"
-    fi
-
-    cd ..
     docker build --no-cache -t opea/lvm-tgi:comps -f comps/lvms/Dockerfile_tgi .
     if [ $? -ne 0 ]; then
         echo "opea/lvm-tgi built fail"
@@ -32,7 +22,7 @@ function build_docker_images() {
 function start_service() {
     unset http_proxy
     model="llava-hf/llava-v1.6-mistral-7b-hf"
-    docker run -d --name="test-comps-lvm-llava-tgi" -e http_proxy=$http_proxy -e https_proxy=$https_proxy -p 5027:80 --runtime=habana -e PT_HPU_ENABLE_LAZY_COLLECTIVES=true -e SKIP_TOKENIZER_IN_TGI=true -e HABANA_VISIBLE_DEVICES=all  -e OMPI_MCA_btl_vader_single_copy_mechanism=none --cap-add=sys_nice --ipc=host opea/llava-tgi:comps --model-id $model --max-input-tokens 4096 --max-total-tokens 8192
+    docker run -d --name="test-comps-lvm-llava-tgi" -e http_proxy=$http_proxy -e https_proxy=$https_proxy -p 5027:80 --runtime=habana -e PT_HPU_ENABLE_LAZY_COLLECTIVES=true -e SKIP_TOKENIZER_IN_TGI=true -e HABANA_VISIBLE_DEVICES=all  -e OMPI_MCA_btl_vader_single_copy_mechanism=none --cap-add=sys_nice --ipc=host ghcr.io/huggingface/tgi-gaudi:2.0.4 --model-id $model --max-input-tokens 4096 --max-total-tokens 8192
     docker run -d --name="test-comps-lvm-tgi" -e LVM_ENDPOINT=http://$ip_address:5027 -e http_proxy=$http_proxy -e https_proxy=$https_proxy -p 5028:9399 --ipc=host opea/lvm-tgi:comps
     sleep 3m
 }

--- a/tests/test_lvms_tgi_llava_next.sh
+++ b/tests/test_lvms_tgi_llava_next.sh
@@ -10,7 +10,7 @@ ip_address=$(hostname -I | awk '{print $1}')
 function build_docker_images() {
     cd $WORKPATH
     echo $(pwd)
-    git clone https://github.com/huggingface/tei-gaudi && cd tgi-gaudi && git checkout v2.0.4
+    git clone https://github.com/huggingface/tgi-gaudi && cd tgi-gaudi && git checkout v2.0.4
     docker build --no-cache -t opea/llava-tgi:comps .
     if [ $? -ne 0 ]; then
         echo "opea/llava-tgi built fail"

--- a/tests/test_lvms_tgi_llava_next.sh
+++ b/tests/test_lvms_tgi_llava_next.sh
@@ -10,7 +10,7 @@ ip_address=$(hostname -I | awk '{print $1}')
 function build_docker_images() {
     cd $WORKPATH
     echo $(pwd)
-    git clone https://github.com/yuanwu2017/tgi-gaudi.git && cd tgi-gaudi && git checkout v2.0.4
+    git clone https://github.com/huggingface/tei-gaudi && cd tgi-gaudi && git checkout v2.0.4
     docker build --no-cache -t opea/llava-tgi:comps .
     if [ $? -ne 0 ]; then
         echo "opea/llava-tgi built fail"


### PR DESCRIPTION
## Description
- This PR switches from personal forks to upstream repo and if needed makes adjustments as a patch
- It als eliminates building the container `opea/llava-tgi:comps` from scratch during testing and instead uses the prebuilt container: `ghcr.io/huggingface/tgi-gaudi:2.0.4`

## Issues
N/A

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [N] Bug fix (non-breaking change which fixes an issue)
- [N] New feature (non-breaking change which adds new functionality)
- [N] Breaking change (fix or feature that would break existing design and interface)
- [Y] Others (enhancement, documentation, validation, etc.)

## Dependencies
None

## Tests
There's a CI for this
