### PR TITLE
doc: fix missing references to README.md

### DIFF
--- a/LEGAL_INFORMATION.md
+++ b/LEGAL_INFORMATION.md
@@ -9,9 +9,9 @@ Generative AI Components is licensed under [Apache License Version 2.0](http://w
 This software includes components that have separate copyright notices and licensing terms.
 Your use of the source code for these components is subject to the terms and conditions of the following licenses.
 
-- [Third Party Programs](/third-party-programs.txt)
+- [Third Party Programs](third-party-programs.txt)
 
-See the accompanying [license](/LICENSE) file for full license text and copyright notices.
+See the accompanying [license](LICENSE) file for full license text and copyright notices.
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,6 @@
-<div align="center">
-
 # Generative AI Components (GenAIComps)
 
-<p align="center">
-<b>Build Enterprise-grade Generative AI Applications with Microservice Architecture</b>
-</p>
-
-<div align="left">
+**Build Enterprise-grade Generative AI Applications with Microservice Architecture**
 
 This initiative empowers the development of high-quality Generative AI applications for enterprises via microservices, simplifying the scaling and deployment process for production. It abstracts away infrastructure complexities, facilitating the seamless development and deployment of Enterprise AI services.
 
@@ -159,4 +153,4 @@ Thank you for being a part of this journey. We can't wait to see what we can ach
 
 - [Code of Conduct](https://github.com/opea-project/docs/tree/main/community/CODE_OF_CONDUCT.md)
 - [Security Policy](https://github.com/opea-project/docs/tree/main/community/SECURITY.md)
-- [Legal Information](/LEGAL_INFORMATION.md)
+- [Legal Information](LEGAL_INFORMATION.md)

--- a/comps/cores/telemetry/README.md
+++ b/comps/cores/telemetry/README.md
@@ -102,7 +102,7 @@ def your_sync_func():
 
 ### Visualize metrics
 
-Please refer to [OPEA grafana](https://github.com/opea-project/GenAIEval/tree/main/evals/benchmark/grafana) to get the details of Prometheus and Grafana server setup. The Grafana dashboard JSON files are also provided under [OPEA grafana](https://github.com/opea-project/GenAIEval/tree/main/evals/benchmark/grafana) to visualize the metrics.
+Please refer to [OPEA grafana](https://github.com/opea-project/GenAIEval/tree/main/evals/benchmark/grafana/README.md) to get the details of Prometheus and Grafana server setup. The Grafana dashboard JSON files are also provided under [OPEA grafana](https://github.com/opea-project/GenAIEval/tree/main/evals/benchmark/grafana) to visualize the metrics.
 
 ### Visualize tracing
 

--- a/comps/nginx/README.md
+++ b/comps/nginx/README.md
@@ -15,7 +15,7 @@ docker build -t opea/nginx:latest --build-arg https_proxy=$https_proxy --build-a
 
 To use Nginx for service forwarding, users need to setup environment variables first. The variables set here will be substituted in `nginx.conf.template`.
 
-For example, if you want to use Nginx to forward the frontend, backend services of a [ChatQnA](https://github.com/opea-project/GenAIExamples/tree/main/ChatQnA) example, setup environment variables as below.
+For example, if you want to use Nginx to forward the frontend, backend services of a [ChatQnA](https://github.com/opea-project/GenAIExamples/tree/main/ChatQnA/README.md) example, setup environment variables as below.
 
 ```bash
 export FRONTEND_SERVICE_IP=${your_frontend_service_ip}


### PR DESCRIPTION
Cross-repo references using an URL that only has the folder name cause links in the github.io site to go to the github.com site.  Most of these uses want to link to the documentation (README.md) so add that where appropriate so links in the github.io site stay there.
