### PR TITLE
Remove unused port reference

### DIFF
--- a/comps/chathistory/mongo/README.md
+++ b/comps/chathistory/mongo/README.md
@@ -37,7 +37,7 @@ docker build -t opea/chathistory-mongo-server:latest --build-arg https_proxy=$ht
 - Run the Chat History microservice
 
   ```bash
-  docker run -d --name="chathistory-mongo-server" -p 6013:6013 -p 6012:6012 -p 6014:6014 -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e no_proxy=$no_proxy -e MONGO_HOST=${MONGO_HOST} -e MONGO_PORT=${MONGO_PORT} -e DB_NAME=${DB_NAME} -e COLLECTION_NAME=$ {COLLECTION_NAME} opea/chathistory-mongo-server:latest
+  docker run -d --name="chathistory-mongo-server" -p 6012:6012 -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e no_proxy=$no_proxy -e MONGO_HOST=${MONGO_HOST} -e MONGO_PORT=${MONGO_PORT} -e DB_NAME=${DB_NAME} -e COLLECTION_NAME=$ {COLLECTION_NAME} opea/chathistory-mongo-server:latest
   ```
 
 ---


### PR DESCRIPTION
## Description

After #449 , ports 6013/6014 are no longer needed, remove them from the docker run command.