### PR TITLE
change prompt usvc prot to 6018

### DIFF
--- a/comps/feedback_management/mongo/README.md
+++ b/comps/feedback_management/mongo/README.md
@@ -50,7 +50,7 @@ The Feedback Management microservice exposes the following API endpoints:
 
   ```bash
   curl -X 'POST' \
-    http://{host_ip}:6016/v1/feedback/create \
+    http://${host_ip}:6016/v1/feedback/create \
     -H 'accept: application/json' \
     -H 'Content-Type: application/json' \
     -d '{
@@ -89,7 +89,7 @@ The Feedback Management microservice exposes the following API endpoints:
 
   ```bash
   curl -X 'POST' \
-    http://{host_ip}:6016/v1/feedback/create \
+    http://${host_ip}:6016/v1/feedback/create \
     -H 'accept: application/json' \
     -H 'Content-Type: application/json' \
     -d '{
@@ -127,7 +127,7 @@ The Feedback Management microservice exposes the following API endpoints:
 
   ```bash
   curl -X 'POST' \
-    http://{host_ip}:6016/v1/feedback/get \
+    http://${host_ip}:6016/v1/feedback/get \
     -H 'accept: application/json' \
     -H 'Content-Type: application/json' \
     -d '{
@@ -138,7 +138,7 @@ The Feedback Management microservice exposes the following API endpoints:
 
   ```bash
   curl -X 'POST' \
-    http://{host_ip}:6016/v1/feedback/get \
+    http://${host_ip}:6016/v1/feedback/get \
     -H 'accept: application/json' \
     -H 'Content-Type: application/json' \
     -d '{
@@ -149,7 +149,7 @@ The Feedback Management microservice exposes the following API endpoints:
 
   ```bash
   curl -X 'POST' \
-    http://{host_ip}:6016/v1/feedback/delete \
+    http://${host_ip}:6016/v1/feedback/delete \
     -H 'accept: application/json' \
     -H 'Content-Type: application/json' \
     -d '{

--- a/comps/prompt_registry/mongo/README.md
+++ b/comps/prompt_registry/mongo/README.md
@@ -37,7 +37,7 @@ docker build -t opea/promptregistry-mongo-server:latest --build-arg https_proxy=
 - Run Prompt Registry microservice
 
   ```bash
-  docker run -d --name="promptregistry-mongo-server" -p 6012:6012 -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e no_proxy=$no_proxy -e MONGO_HOST=${MONGO_HOST} -e MONGO_PORT=${MONGO_PORT} -e DB_NAME=${DB_NAME} -e COLLECTION_NAME=${COLLECTION_NAME} opea/promptregistry-mongo-server:latest
+  docker run -d --name="promptregistry-mongo-server" -p 6018:6018 -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e no_proxy=$no_proxy -e MONGO_HOST=${MONGO_HOST} -e MONGO_PORT=${MONGO_PORT} -e DB_NAME=${DB_NAME} -e COLLECTION_NAME=${COLLECTION_NAME} opea/promptregistry-mongo-server:latest
   ```
 
 ---
@@ -50,7 +50,7 @@ The Prompt Registry microservice exposes the following API endpoints:
 
   ```bash
   curl -X 'POST' \
-    http://{host_ip}:6012/v1/prompt/create \
+    http://{host_ip}:6018/v1/prompt/create \
     -H 'accept: application/json' \
     -H 'Content-Type: application/json' \
     -d '{
@@ -62,7 +62,7 @@ The Prompt Registry microservice exposes the following API endpoints:
 
   ```bash
   curl -X 'POST' \
-    http://{host_ip}:6012/v1/prompt/get \
+    http://{host_ip}:6018/v1/prompt/get \
     -H 'accept: application/json' \
     -H 'Content-Type: application/json' \
     -d '{
@@ -73,7 +73,7 @@ The Prompt Registry microservice exposes the following API endpoints:
 
   ```bash
   curl -X 'POST' \
-    http://{host_ip}:6012/v1/prompt/get \
+    http://{host_ip}:6018/v1/prompt/get \
     -H 'accept: application/json' \
     -H 'Content-Type: application/json' \
     -d '{
@@ -84,7 +84,7 @@ The Prompt Registry microservice exposes the following API endpoints:
 
   ```bash
   curl -X 'POST' \
-    http://{host_ip}:6012/v1/prompt/get \
+    http://{host_ip}:6018/v1/prompt/get \
     -H 'accept: application/json' \
     -H 'Content-Type: application/json' \
     -d '{
@@ -95,7 +95,7 @@ The Prompt Registry microservice exposes the following API endpoints:
 
   ```bash
   curl -X 'POST' \
-    http://{host_ip}:6012/v1/prompt/delete \
+    http://{host_ip}:6018/v1/prompt/delete \
     -H 'accept: application/json' \
     -H 'Content-Type: application/json' \
     -d '{

--- a/comps/prompt_registry/mongo/README.md
+++ b/comps/prompt_registry/mongo/README.md
@@ -50,7 +50,7 @@ The Prompt Registry microservice exposes the following API endpoints:
 
   ```bash
   curl -X 'POST' \
-    http://{host_ip}:6018/v1/prompt/create \
+    http://${host_ip}:6018/v1/prompt/create \
     -H 'accept: application/json' \
     -H 'Content-Type: application/json' \
     -d '{
@@ -62,7 +62,7 @@ The Prompt Registry microservice exposes the following API endpoints:
 
   ```bash
   curl -X 'POST' \
-    http://{host_ip}:6018/v1/prompt/get \
+    http://${host_ip}:6018/v1/prompt/get \
     -H 'accept: application/json' \
     -H 'Content-Type: application/json' \
     -d '{
@@ -73,7 +73,7 @@ The Prompt Registry microservice exposes the following API endpoints:
 
   ```bash
   curl -X 'POST' \
-    http://{host_ip}:6018/v1/prompt/get \
+    http://${host_ip}:6018/v1/prompt/get \
     -H 'accept: application/json' \
     -H 'Content-Type: application/json' \
     -d '{
@@ -84,7 +84,7 @@ The Prompt Registry microservice exposes the following API endpoints:
 
   ```bash
   curl -X 'POST' \
-    http://{host_ip}:6018/v1/prompt/get \
+    http://${host_ip}:6018/v1/prompt/get \
     -H 'accept: application/json' \
     -H 'Content-Type: application/json' \
     -d '{
@@ -95,7 +95,7 @@ The Prompt Registry microservice exposes the following API endpoints:
 
   ```bash
   curl -X 'POST' \
-    http://{host_ip}:6018/v1/prompt/delete \
+    http://${host_ip}:6018/v1/prompt/delete \
     -H 'accept: application/json' \
     -H 'Content-Type: application/json' \
     -d '{

--- a/comps/prompt_registry/mongo/docker-compose-prompt-registry-mongo.yaml
+++ b/comps/prompt_registry/mongo/docker-compose-prompt-registry-mongo.yaml
@@ -18,7 +18,7 @@ services:
     image: opea/promptregistry-mongo:latest
     container_name: promptregistry-mongo-server
     ports:
-      - "6012:6012"
+      - "6018:6018"
     ipc: host
     environment:
       http_proxy: ${http_proxy}

--- a/comps/prompt_registry/mongo/prompt.py
+++ b/comps/prompt_registry/mongo/prompt.py
@@ -43,7 +43,7 @@ class PromptId(BaseModel):
     endpoint="/v1/prompt/create",
     host="0.0.0.0",
     input_datatype=PromptCreate,
-    port=6012,
+    port=6018,
 )
 async def create_prompt(prompt: PromptCreate):
     """Creates and stores a prompt in prompt store.
@@ -74,7 +74,7 @@ async def create_prompt(prompt: PromptCreate):
     endpoint="/v1/prompt/get",
     host="0.0.0.0",
     input_datatype=PromptId,
-    port=6012,
+    port=6018,
 )
 async def get_prompt(prompt: PromptId):
     """Retrieves prompt from prompt store based on provided PromptId or user.
@@ -110,7 +110,7 @@ async def get_prompt(prompt: PromptId):
     endpoint="/v1/prompt/delete",
     host="0.0.0.0",
     input_datatype=PromptId,
-    port=6012,
+    port=6018,
 )
 async def delete_prompt(prompt: PromptId):
     """Delete a prompt from prompt store by given PromptId.

--- a/tests/prompt_registry/test_prompt_registry_mongo.sh
+++ b/tests/prompt_registry/test_prompt_registry_mongo.sh
@@ -28,14 +28,14 @@ function build_docker_images() {
 
 function start_service() {
 
-    docker run -d --name="test-comps-promptregistry-mongo-server" -p 6012:6012 -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e no_proxy=$no_proxy -e MONGO_HOST=${MONGO_HOST} -e MONGO_PORT=${MONGO_PORT} -e DB_NAME=${DB_NAME} -e COLLECTION_NAME=${COLLECTION_NAME} opea/promptregistry-mongo-server:comps
+    docker run -d --name="test-comps-promptregistry-mongo-server" -p 6018:6018 -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e no_proxy=$no_proxy -e MONGO_HOST=${MONGO_HOST} -e MONGO_PORT=${MONGO_PORT} -e DB_NAME=${DB_NAME} -e COLLECTION_NAME=${COLLECTION_NAME} opea/promptregistry-mongo-server:comps
 
     sleep 10s
 }
 
 function validate_microservice() {
     result=$(curl -X 'POST' \
-  http://$ip_address:6012/v1/prompt/create \
+  http://$ip_address:6018/v1/prompt/create \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -d '{


### PR DESCRIPTION
## Description

6012, 6013, 6014 is used by chathistory.
6016 is used by feedback.
To avoid unnecessary confusion and conflict, change it to 6018.

## Issues

`n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Breaking change (fix or feature that would break existing design and interface)

## Dependencies

`n/a`.

## Tests

No special test steps, just follow the README
