### PR TITLE
[Dataprep] Reduce Upload File Time Consumption

### DIFF
--- a/comps/dataprep/milvus/langchain/requirements.txt
+++ b/comps/dataprep/milvus/langchain/requirements.txt
@@ -27,3 +27,4 @@ shortuuid
 tiktoken
 unstructured[all-docs]==0.15.7
 uvicorn
+pytesseract

--- a/comps/dataprep/milvus/langchain/requirements.txt
+++ b/comps/dataprep/milvus/langchain/requirements.txt
@@ -20,6 +20,7 @@ Pillow
 prometheus-fastapi-instrumentator
 pymupdf
 pyspark
+pytesseract
 python-docx
 python-pptx
 sentence_transformers
@@ -27,4 +28,3 @@ shortuuid
 tiktoken
 unstructured[all-docs]==0.15.7
 uvicorn
-pytesseract

--- a/comps/dataprep/neo4j/langchain/requirements.txt
+++ b/comps/dataprep/neo4j/langchain/requirements.txt
@@ -28,4 +28,4 @@ sentence_transformers
 shortuuid
 unstructured[all-docs]==0.15.7
 uvicorn
-
+pytesseract

--- a/comps/dataprep/neo4j/langchain/requirements.txt
+++ b/comps/dataprep/neo4j/langchain/requirements.txt
@@ -22,10 +22,10 @@ pandas
 Pillow
 prometheus-fastapi-instrumentator
 pymupdf
+pytesseract
 python-docx
 python-pptx
 sentence_transformers
 shortuuid
 unstructured[all-docs]==0.15.7
 uvicorn
-pytesseract

--- a/comps/dataprep/pgvector/langchain/requirements.txt
+++ b/comps/dataprep/pgvector/langchain/requirements.txt
@@ -20,6 +20,7 @@ prometheus-fastapi-instrumentator
 psycopg2-binary
 pymupdf
 pyspark
+pytesseract
 python-docx
 python-multipart
 python-pptx
@@ -28,4 +29,3 @@ shortuuid
 tiktoken
 unstructured[all-docs]==0.15.7
 uvicorn
-pytesseract

--- a/comps/dataprep/pgvector/langchain/requirements.txt
+++ b/comps/dataprep/pgvector/langchain/requirements.txt
@@ -28,4 +28,4 @@ shortuuid
 tiktoken
 unstructured[all-docs]==0.15.7
 uvicorn
-
+pytesseract

--- a/comps/dataprep/pinecone/langchain/requirements.txt
+++ b/comps/dataprep/pinecone/langchain/requirements.txt
@@ -28,3 +28,4 @@ sentence_transformers
 shortuuid
 unstructured[all-docs]==0.15.7
 uvicorn
+pytesseract

--- a/comps/dataprep/pinecone/langchain/requirements.txt
+++ b/comps/dataprep/pinecone/langchain/requirements.txt
@@ -21,6 +21,7 @@ pinecone-client
 prometheus-fastapi-instrumentator
 pymupdf
 pyspark
+pytesseract
 python-bidi==0.4.2
 python-docx
 python-pptx
@@ -28,4 +29,3 @@ sentence_transformers
 shortuuid
 unstructured[all-docs]==0.15.7
 uvicorn
-pytesseract

--- a/comps/dataprep/qdrant/langchain/requirements.txt
+++ b/comps/dataprep/qdrant/langchain/requirements.txt
@@ -25,3 +25,4 @@ sentence_transformers
 shortuuid
 unstructured[all-docs]==0.15.7
 uvicorn
+pytesseract

--- a/comps/dataprep/qdrant/langchain/requirements.txt
+++ b/comps/dataprep/qdrant/langchain/requirements.txt
@@ -18,6 +18,7 @@ pandas
 Pillow
 prometheus-fastapi-instrumentator
 pymupdf
+pytesseract
 python-docx
 python-pptx
 qdrant-client
@@ -25,4 +26,3 @@ sentence_transformers
 shortuuid
 unstructured[all-docs]==0.15.7
 uvicorn
-pytesseract

--- a/comps/dataprep/redis/langchain/requirements.txt
+++ b/comps/dataprep/redis/langchain/requirements.txt
@@ -19,6 +19,7 @@ Pillow
 prometheus-fastapi-instrumentator
 pymupdf
 pyspark
+pytesseract
 python-bidi
 python-docx
 python-pptx
@@ -27,4 +28,3 @@ sentence_transformers
 shortuuid
 unstructured[all-docs]
 uvicorn
-pytesseract

--- a/comps/dataprep/redis/langchain/requirements.txt
+++ b/comps/dataprep/redis/langchain/requirements.txt
@@ -27,3 +27,4 @@ sentence_transformers
 shortuuid
 unstructured[all-docs]
 uvicorn
+pytesseract

--- a/comps/dataprep/redis/langchain_ray/requirements.txt
+++ b/comps/dataprep/redis/langchain_ray/requirements.txt
@@ -16,6 +16,7 @@ Pillow
 prometheus-fastapi-instrumentator
 pyarrow
 pymupdf
+pytesseract
 python-bidi==0.4.2
 python-docx
 python-multipart
@@ -27,4 +28,3 @@ shortuuid
 unstructured[all-docs]==0.15.7
 uvicorn
 virtualenv
-pytesseract

--- a/comps/dataprep/redis/langchain_ray/requirements.txt
+++ b/comps/dataprep/redis/langchain_ray/requirements.txt
@@ -27,3 +27,4 @@ shortuuid
 unstructured[all-docs]==0.15.7
 uvicorn
 virtualenv
+pytesseract

--- a/comps/dataprep/redis/llama_index/requirements.txt
+++ b/comps/dataprep/redis/llama_index/requirements.txt
@@ -10,10 +10,10 @@ opentelemetry-api
 opentelemetry-exporter-otlp
 opentelemetry-sdk
 prometheus-fastapi-instrumentator
+pytesseract
 python-bidi==0.4.2
 python-multipart
 redis
 sentence_transformers
 shortuuid
 uvicorn
-pytesseract

--- a/comps/dataprep/redis/llama_index/requirements.txt
+++ b/comps/dataprep/redis/llama_index/requirements.txt
@@ -16,3 +16,4 @@ redis
 sentence_transformers
 shortuuid
 uvicorn
+pytesseract

--- a/comps/dataprep/utils.py
+++ b/comps/dataprep/utils.py
@@ -23,7 +23,6 @@ from urllib.parse import urlparse, urlunparse
 import cairosvg
 import docx
 import docx2txt
-import easyocr
 import fitz
 import numpy as np
 import pandas as pd
@@ -31,7 +30,6 @@ import pptx
 import requests
 import yaml
 from bs4 import BeautifulSoup
-from docx import Document as DDocument
 from langchain import LLMChain, PromptTemplate
 from langchain_community.document_loaders import (
     UnstructuredHTMLLoader,
@@ -40,7 +38,9 @@ from langchain_community.document_loaders import (
     UnstructuredXMLLoader,
 )
 from langchain_community.llms import HuggingFaceEndpoint
-from PIL import Image
+from concurrent.futures import ThreadPoolExecutor, as_completed
+import cv2
+import pytesseract
 
 from comps import CustomLogger
 
@@ -112,36 +112,39 @@ def get_separators():
     return separators
 
 
-def load_pdf(pdf_path):
-    """Load the pdf file."""
-    doc = fitz.open(pdf_path)
-    reader = easyocr.Reader(["en"], gpu=False)
-    result = ""
-    for i in range(doc.page_count):
-        page = doc.load_page(i)
-        pagetext = page.get_text().strip()
-        if pagetext:
-            if pagetext.endswith("!") or pagetext.endswith("?") or pagetext.endswith("."):
-                result = result + pagetext
-            else:
-                result = result + pagetext + "."
-        if len(doc.get_page_images(i)) > 0:
-            for img in doc.get_page_images(i):
-                if img:
-                    pageimg = ""
-                    xref = img[0]
-                    img_data = doc.extract_image(xref)
-                    img_bytes = img_data["image"]
-                    pil_image = Image.open(io.BytesIO(img_bytes))
-                    img = np.array(pil_image)
-                    img_result = reader.readtext(img, paragraph=True, detail=0)
-                    pageimg = pageimg + ", ".join(img_result).strip()
-                    if pageimg.endswith("!") or pageimg.endswith("?") or pageimg.endswith("."):
-                        pass
-                    else:
-                        pageimg = pageimg + "."
-                result = result + pageimg
+def process_page(doc, idx):
+    page = doc.load_page(idx)
+    pagetext = page.get_text().strip()
+    result = pagetext if pagetext.endswith(('!', '?', '.')) else pagetext + "."
+
+    page_images = doc.get_page_images(idx)
+    if page_images:
+        for img_index, img in enumerate(page_images):
+            xref = img[0]
+            img_data = doc.extract_image(xref)
+            img_bytes = img_data["image"]
+
+            # process images
+            img_array = cv2.imdecode(np.frombuffer(img_bytes, np.uint8), cv2.IMREAD_COLOR)
+            img_result = pytesseract.image_to_string(img_array, lang='eng', config='--psm 6')
+            
+            # add results
+            pageimg = img_result.strip()
+            pageimg += "" if pageimg.endswith(('!', '?', '.')) else "."
+            result += pageimg
     return result
+
+def load_pdf(pdf_path):
+    doc = fitz.open(pdf_path)
+    results = []
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        futures = [executor.submit(process_page, doc, i) for i in range(doc.page_count)]
+        for future in as_completed(futures):
+            results.append(future.result())
+            
+    combined_result = "".join(results)
+    return combined_result
 
 
 def load_html(html_path):

--- a/comps/dataprep/vdms/langchain/requirements.txt
+++ b/comps/dataprep/vdms/langchain/requirements.txt
@@ -35,3 +35,4 @@ tzlocal
 unstructured[all-docs]==0.11.5
 uvicorn
 vdms
+pytesseract

--- a/comps/dataprep/vdms/langchain/requirements.txt
+++ b/comps/dataprep/vdms/langchain/requirements.txt
@@ -23,6 +23,7 @@ Pillow
 prometheus-fastapi-instrumentator
 pymupdf
 pyspark
+pytesseract
 python-bidi==0.4.2
 python-docx
 python-pptx
@@ -35,4 +36,3 @@ tzlocal
 unstructured[all-docs]==0.11.5
 uvicorn
 vdms
-pytesseract


### PR DESCRIPTION
## Description

File upload time too long according to feedback by customers.
Refine dataprep util with opencv and multithreading.
Time reduction:
- Load File: reduce by 70%~83%, depends on network and hardware
- Bottleneck of Save to DB: blocked by the performance of TEI service

## Issues

n/a

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

Add `pytesseract` in requirements.txt.

## Tests

Local tested.
- Time comsumption on Xeon:

| file size | origin | func1 | func2 | refined |
| -- | -- | -- | -- | -- |
| load document | 8.119s | 8.917s | 3.039s | 1.368s |
| save batch into db | 12.492s | 14.456s | 13.055s | 12.802s |
| total | 20.725s | 23.404s | 16.166s | 14.196s |

- Time comsumption on Gaudi:

| file size | origin | fun1 | func2 | refined |
| -- | -- | -- | -- | -- |
| load document | 8.47s | 11.268s | 4.164s | 2.523s |
| save batch into db | 1.123s | 1.287s | 1.285s | 1.272s |
| total | 9.613s | 12.621s | 5.462s | 3.806s |
