### PR TITLE
Remove unused imports from reranks

### DIFF
--- a/comps/reranks/mosec/langchain/dependency/server-ipex.py
+++ b/comps/reranks/mosec/langchain/dependency/server-ipex.py
@@ -4,17 +4,16 @@
 import json
 import os
 from os import environ
-from typing import Any, Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import intel_extension_for_pytorch as ipex
 import numpy as np
 import torch
 from mosec import Server, Worker
-from mosec.mixin import TypedMsgPackMixin
 from msgspec import Struct
 from sentence_transformers import CrossEncoder
 from torch.utils.data import DataLoader
-from tqdm.autonotebook import tqdm, trange
+from tqdm.autonotebook import tqdm
 
 DEFAULT_MODEL = "/home/user/bge-reranker-large"
 

--- a/comps/reranks/tei/local_reranking.py
+++ b/comps/reranks/tei/local_reranking.py
@@ -10,7 +10,6 @@ from comps import (
     RerankedDoc,
     SearchedDoc,
     ServiceType,
-    TextDoc,
     opea_microservices,
     register_microservice,
 )

--- a/comps/reranks/tei/local_reranking.py
+++ b/comps/reranks/tei/local_reranking.py
@@ -5,14 +5,7 @@ import os
 
 from sentence_transformers import CrossEncoder
 
-from comps import (
-    CustomLogger,
-    RerankedDoc,
-    SearchedDoc,
-    ServiceType,
-    opea_microservices,
-    register_microservice,
-)
+from comps import CustomLogger, RerankedDoc, SearchedDoc, ServiceType, opea_microservices, register_microservice
 
 logger = CustomLogger("local_reranking")
 logflag = os.getenv("LOGFLAG", False)

--- a/comps/reranks/tei/reranking_tei.py
+++ b/comps/reranks/tei/reranking_tei.py
@@ -1,10 +1,8 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import heapq
 import json
 import os
-import re
 import time
 from typing import Union
 


### PR DESCRIPTION
## Description

Remove unused python imports from reranks modules.

## Issues

n/a

## Type of change

- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

n/a

## Tests

linting