### PR TITLE
🐛 bugfix : Retrieval on llm-vllm service not working

### DIFF
--- a/comps/llms/text-generation/vllm/langchain/llm.py
+++ b/comps/llms/text-generation/vllm/langchain/llm.py
@@ -128,7 +128,7 @@ def llm_generate(input: Union[LLMParamsDoc, ChatCompletionRequest, SearchedDoc])
                 prompt = ChatTemplate.generate_rag_prompt(input.query, input.documents)
 
         new_input = LLMParamsDoc(query=prompt)
-        
+
         if input.streaming:
 
             async def stream_generator():

--- a/comps/llms/text-generation/vllm/langchain/llm.py
+++ b/comps/llms/text-generation/vllm/langchain/llm.py
@@ -26,11 +26,8 @@ logflag = os.getenv("LOGFLAG", False)
 
 llm_endpoint = os.getenv("vLLM_ENDPOINT", "http://localhost:8008")
 model_name = os.getenv("LLM_MODEL", "meta-llama/Meta-Llama-3-8B-Instruct")
-llm = VLLMOpenAI(
-    openai_api_key="EMPTY",
-    openai_api_base=llm_endpoint + "/v1",
-    model_name=model_name
-)
+llm = VLLMOpenAI(openai_api_key="EMPTY", openai_api_base=llm_endpoint + "/v1", model_name=model_name)
+
 
 @opea_telemetry
 def post_process_text(text: str):

--- a/comps/llms/text-generation/vllm/langchain/llm.py
+++ b/comps/llms/text-generation/vllm/langchain/llm.py
@@ -127,11 +127,13 @@ def llm_generate(input: Union[LLMParamsDoc, ChatCompletionRequest, SearchedDoc])
                 # use rag default template
                 prompt = ChatTemplate.generate_rag_prompt(input.query, input.documents)
 
+        new_input = LLMParamsDoc(query=prompt)
+        
         if input.streaming:
 
             async def stream_generator():
                 chat_response = ""
-                async for text in llm.astream(input.query, **parameters):
+                async for text in llm.astream(new_input.query, **parameters):
                     chat_response += text
                     chunk_repr = repr(text.encode("utf-8"))
                     if logflag:
@@ -144,7 +146,7 @@ def llm_generate(input: Union[LLMParamsDoc, ChatCompletionRequest, SearchedDoc])
             return StreamingResponse(stream_generator(), media_type="text/event-stream")
 
         else:
-            response = llm.invoke(input.query, **parameters)
+            response = llm.invoke(new_input.query, **parameters)
             if logflag:
                 logger.info(response)
 

--- a/comps/llms/text-generation/vllm/langchain/llm.py
+++ b/comps/llms/text-generation/vllm/langchain/llm.py
@@ -26,8 +26,11 @@ logflag = os.getenv("LOGFLAG", False)
 
 llm_endpoint = os.getenv("vLLM_ENDPOINT", "http://localhost:8008")
 model_name = os.getenv("LLM_MODEL", "meta-llama/Meta-Llama-3-8B-Instruct")
-llm = VLLMOpenAI(openai_api_key="EMPTY", openai_api_base=llm_endpoint + "/v1", model_name=model_name)
-
+llm = VLLMOpenAI(
+    openai_api_key="EMPTY",
+    openai_api_base=llm_endpoint + "/v1",
+    model_name=model_name
+)
 
 @opea_telemetry
 def post_process_text(text: str):
@@ -57,13 +60,6 @@ def llm_generate(input: Union[LLMParamsDoc, ChatCompletionRequest, SearchedDoc])
     if not isinstance(input, SearchedDoc) and input.chat_template:
         prompt_template = PromptTemplate.from_template(input.chat_template)
         input_variables = prompt_template.input_variables
-    parameters = {
-        "max_tokens": input.max_tokens,
-        "top_p": input.top_p,
-        "temperature": input.temperature,
-        "frequency_penalty": input.frequency_penalty,
-        "presence_penalty": input.presence_penalty,
-    }
 
     if isinstance(input, SearchedDoc):
         if logflag:
@@ -80,6 +76,14 @@ def llm_generate(input: Union[LLMParamsDoc, ChatCompletionRequest, SearchedDoc])
 
         # use default llm parameter for inference
         new_input = LLMParamsDoc(query=prompt)
+
+        parameters = {
+            "max_tokens": new_input.max_tokens,
+            "top_p": new_input.top_p,
+            "temperature": new_input.temperature,
+            "frequency_penalty": new_input.frequency_penalty,
+            "presence_penalty": new_input.presence_penalty,
+        }
 
         if logflag:
             logger.info(f"[ SearchedDoc ] final input: {new_input}")
@@ -112,6 +116,14 @@ def llm_generate(input: Union[LLMParamsDoc, ChatCompletionRequest, SearchedDoc])
             logger.info("[ LLMParamsDoc ] input from rerank microservice")
 
         prompt = input.query
+
+        parameters = {
+            "max_tokens": input.max_tokens,
+            "top_p": input.top_p,
+            "temperature": input.temperature,
+            "frequency_penalty": input.frequency_penalty,
+            "presence_penalty": input.presence_penalty,
+        }
 
         if prompt_template:
             if sorted(input_variables) == ["context", "question"]:

--- a/comps/llms/text-generation/vllm/langchain/llm.py
+++ b/comps/llms/text-generation/vllm/langchain/llm.py
@@ -127,13 +127,11 @@ def llm_generate(input: Union[LLMParamsDoc, ChatCompletionRequest, SearchedDoc])
                 # use rag default template
                 prompt = ChatTemplate.generate_rag_prompt(input.query, input.documents)
 
-        new_input = LLMParamsDoc(query=prompt)
-
         if input.streaming:
 
             async def stream_generator():
                 chat_response = ""
-                async for text in llm.astream(new_input.query, **parameters):
+                async for text in llm.astream(prompt, **parameters):
                     chat_response += text
                     chunk_repr = repr(text.encode("utf-8"))
                     if logflag:
@@ -146,7 +144,7 @@ def llm_generate(input: Union[LLMParamsDoc, ChatCompletionRequest, SearchedDoc])
             return StreamingResponse(stream_generator(), media_type="text/event-stream")
 
         else:
-            response = llm.invoke(new_input.query, **parameters)
+            response = llm.invoke(prompt, **parameters)
             if logflag:
                 logger.info(response)
 


### PR DESCRIPTION
## Description

This PR introduces fix for a issue identified while using `llm-vllm` microservice for RAG context retrieval.

## Issues

 ChatQnA application, when deployed with `llm-vllm` microservice to get inference from vLLM, was seen to be not able to provide answers based on documents being uploaded. This was the case despite merging PR #687, which was created to introduce this RAG capability for `llm-vllm` microservice.

Issue was fixed after minor updates in `llm.py`, to provide the generated RAG prompt as a parameter while invoking llm inferences.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

NA : No New dependencies

## Tests
Manual tests to validate retrieval from uploaded documents. 
