### PR TITLE
Remove 'vim' from Dockerfiles

### DIFF
--- a/.github/workflows/docker/ut.dockerfile
+++ b/.github/workflows/docker/ut.dockerfile
@@ -10,12 +10,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
     aspell \
     aspell-en \
     build-essential \
+    git \
     python3 \
-    python3-pip \
     python3-dev \
     python3-distutils \
-    git \
-    vim \
+    python3-pip \
     wget
 
 RUN ln -sf $(which python3) /usr/bin/python

--- a/comps/dataprep/multimodal/redis/langchain/Dockerfile
+++ b/comps/dataprep/multimodal/redis/langchain/Dockerfile
@@ -9,11 +9,10 @@ ARG ARCH="cpu"
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
     build-essential \
+    default-jre \
     libgl1-mesa-glx \
     libjemalloc-dev \
-    default-jre \
-    wget \
-    vim
+    wget
 
 # Install ffmpeg static build
 RUN cd /root && wget https://johnvansickle.com/ffmpeg/builds/ffmpeg-git-amd64-static.tar.xz && \
@@ -34,4 +33,3 @@ ENV PYTHONPATH=$PYTHONPATH:/home/user
 WORKDIR /home/user/comps/dataprep/multimodal/redis/langchain
 
 ENTRYPOINT ["python", "prepare_videodoc_redis.py"]
-

--- a/comps/dataprep/vdms/langchain/Dockerfile
+++ b/comps/dataprep/vdms/langchain/Dockerfile
@@ -11,8 +11,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missin
     build-essential \
     libcairo2-dev \
     libgl1-mesa-glx \
-    libjemalloc-dev \
-    vim
+    libjemalloc-dev
 
 RUN useradd -m -s /bin/bash user && \
     mkdir -p /home/user && \

--- a/comps/dataprep/vdms/multimodal_langchain/Dockerfile
+++ b/comps/dataprep/vdms/multimodal_langchain/Dockerfile
@@ -1,4 +1,3 @@
-
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
@@ -12,8 +11,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missin
     build-essential \
     libcairo2-dev \
     libgl1-mesa-glx \
-    libjemalloc-dev \
-    vim
+    libjemalloc-dev
 
 RUN useradd -m -s /bin/bash user && \
     mkdir -p /home/user && \

--- a/comps/embeddings/multimodal/multimodal_langchain/Dockerfile
+++ b/comps/embeddings/multimodal/multimodal_langchain/Dockerfile
@@ -1,4 +1,3 @@
-
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
@@ -6,8 +5,7 @@ FROM python:3.11-slim
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
     libgl1-mesa-glx \
-    libjemalloc-dev \
-    vim
+    libjemalloc-dev
 
 RUN useradd -m -s /bin/bash user && \
     mkdir -p /home/user && \

--- a/comps/embeddings/multimodal_clip/Dockerfile
+++ b/comps/embeddings/multimodal_clip/Dockerfile
@@ -7,8 +7,7 @@ ARG ARCH="cpu"
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
     libgl1-mesa-glx \
-    libjemalloc-dev \
-    vim
+    libjemalloc-dev
 
 RUN useradd -m -s /bin/bash user && \
     mkdir -p /home/user && \

--- a/comps/intent_detection/langchain/Dockerfile
+++ b/comps/intent_detection/langchain/Dockerfile
@@ -5,8 +5,7 @@ FROM python:3.11-slim
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
     libgl1-mesa-glx \
-    libjemalloc-dev \
-    vim
+    libjemalloc-dev
 
 RUN useradd -m -s /bin/bash user && \
     mkdir -p /home/user && \

--- a/comps/retrievers/multimodal/redis/langchain/Dockerfile
+++ b/comps/retrievers/multimodal/redis/langchain/Dockerfile
@@ -7,8 +7,7 @@ ARG ARCH="cpu"
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
     libgl1-mesa-glx \
-    libjemalloc-dev \
-    vim
+    libjemalloc-dev
 
 RUN useradd -m -s /bin/bash user && \
     mkdir -p /home/user && \

--- a/comps/retrievers/pathway/langchain/Dockerfile
+++ b/comps/retrievers/pathway/langchain/Dockerfile
@@ -1,4 +1,3 @@
-
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
@@ -8,8 +7,7 @@ ARG ARCH="cpu"
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
     libgl1-mesa-glx \
-    libjemalloc-dev \
-    vim
+    libjemalloc-dev
 
 RUN useradd -m -s /bin/bash user && \
     mkdir -p /home/user && \

--- a/comps/retrievers/vdms/langchain/Dockerfile
+++ b/comps/retrievers/vdms/langchain/Dockerfile
@@ -1,4 +1,3 @@
-
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
@@ -7,10 +6,9 @@ FROM python:3.11-slim
 ARG ARCH="cpu"
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
-    libgl1-mesa-glx \
-    libjemalloc-dev \
     iputils-ping \
-    vim
+    libgl1-mesa-glx \
+    libjemalloc-dev
 
 RUN useradd -m -s /bin/bash user && \
     mkdir -p /home/user && \


### PR DESCRIPTION
## Description
This PR removes 'vim' from all Dockerfiles with the repo

## Issues
Having unnecessary libraries leads to large containers that take longer to download

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies
None

## Tests
CI test are sufficient.
