### PR TITLE
add 'no-cache-dir' to all pip installs

### DIFF
--- a/comps/asr/whisper/Dockerfile
+++ b/comps/asr/whisper/Dockerfile
@@ -15,7 +15,7 @@ COPY comps /home/user/comps
 
 RUN pip install --no-cache-dir --upgrade pip && \
     if [ "${ARCH}" = "cpu" ]; then \
-        pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu ; \
+        pip install --no-cache-dir torch torchvision --index-url https://download.pytorch.org/whl/cpu ; \
         pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r /home/user/comps/asr/whisper/requirements.txt ; \
     else \
         pip install --no-cache-dir -r /home/user/comps/asr/whisper/requirements.txt ; \

--- a/comps/asr/whisper/dependency/Dockerfile
+++ b/comps/asr/whisper/dependency/Dockerfile
@@ -3,7 +3,6 @@
 
 FROM python:3.11-slim
 
-
 RUN useradd -m -s /bin/bash user && \
     mkdir -p /home/user && \
     chown -R user /home/user/
@@ -23,7 +22,7 @@ USER user
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r /home/user/comps/asr/whisper/requirements.txt && \
     if [ "${ARCH}" = "cpu" ]; then \
-        pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu ; \
+        pip install --no-cache-dir torch torchvision --index-url https://download.pytorch.org/whl/cpu ; \
         pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r /home/user/comps/asr/whisper/requirements.txt ; \
     else \
         pip install --no-cache-dir -r /home/user/comps/asr/whisper/requirements.txt ; \

--- a/comps/dataprep/vdms/langchain/Dockerfile
+++ b/comps/dataprep/vdms/langchain/Dockerfile
@@ -23,7 +23,7 @@ USER user
 COPY comps /home/user/comps
 
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
-    if [ ${ARCH} = "cpu" ]; then pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu; fi && \
+    if [ ${ARCH} = "cpu" ]; then pip install --no-cache-dir torch torchvision --index-url https://download.pytorch.org/whl/cpu; fi && \
     pip install --no-cache-dir -r /home/user/comps/dataprep/vdms/langchain/requirements.txt
 
 ENV PYTHONPATH=/home/user

--- a/comps/dataprep/vdms/multimodal_langchain/Dockerfile
+++ b/comps/dataprep/vdms/multimodal_langchain/Dockerfile
@@ -1,4 +1,3 @@
-
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
@@ -24,7 +23,7 @@ USER user
 COPY comps /home/user/comps
 
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
-    if [ ${ARCH} = "cpu" ]; then pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu; fi && \
+    if [ ${ARCH} = "cpu" ]; then pip install --no-cache-dir torch torchvision --index-url https://download.pytorch.org/whl/cpu; fi && \
     pip install --no-cache-dir -r /home/user/comps/dataprep/vdms/multimodal_langchain/requirements.txt
 
 ENV PYTHONPATH=/home/user

--- a/comps/embeddings/multimodal_clip/Dockerfile
+++ b/comps/embeddings/multimodal_clip/Dockerfile
@@ -19,7 +19,7 @@ USER user
 COPY comps /home/user/comps
 
 RUN pip install --no-cache-dir --upgrade pip && \
-    if [ ${ARCH} = "cpu" ]; then pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu; fi && \
+    if [ ${ARCH} = "cpu" ]; then pip install --no-cache-dir torch torchvision --index-url https://download.pytorch.org/whl/cpu; fi && \
     pip install --no-cache-dir -r /home/user/comps/embeddings/multimodal_clip/requirements.txt
 
 ENV PYTHONPATH=$PYTHONPATH:/home/user

--- a/comps/image2video/dependency/Dockerfile
+++ b/comps/image2video/dependency/Dockerfile
@@ -12,7 +12,7 @@ COPY comps /home/comps
 
 RUN apt-get update && apt-get install python3-opencv -y && \
     pip install --no-cache-dir --upgrade pip && \
-    if [ ${ARCH} = "cpu" ]; then pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu; fi && \
+    if [ ${ARCH} = "cpu" ]; then pip install --no-cache-dir torch torchvision --index-url https://download.pytorch.org/whl/cpu; fi && \
     pip install --no-cache-dir -r /home/comps/image2video/dependency/requirements.txt
 
 ENV PYTHONPATH=$PYTHONPATH:/home

--- a/comps/llms/text-generation/vllm/langchain/dependency/Dockerfile.intel_hpu
+++ b/comps/llms/text-generation/vllm/langchain/dependency/Dockerfile.intel_hpu
@@ -10,7 +10,7 @@ RUN git clone https://github.com/HabanaAI/vllm-fork.git /workspace/vllm
 
 WORKDIR /workspace/vllm
 
-RUN pip install -v -r requirements-hpu.txt
+RUN pip install --no-cache-dir -v -r requirements-hpu.txt
 
 ENV no_proxy=localhost,127.0.0.1
 ENV PT_HPU_ENABLE_LAZY_COLLECTIVES=true
@@ -21,5 +21,4 @@ WORKDIR /workspace/
 
 RUN ln -s /workspace/vllm/tests && ln -s /workspace/vllm/examples && ln -s /workspace/vllm/benchmarks
 
-#ENTRYPOINT ["python3", "-m", "vllm.entrypoints.openai.api_server"]
 CMD ["/bin/bash"]

--- a/comps/lvms/llama-vision/Dockerfile
+++ b/comps/lvms/llama-vision/Dockerfile
@@ -23,7 +23,7 @@ COPY comps /home/user/comps
 
 RUN cd /home/user/comps/lvms/llama-vision/ && \
     pip install --no-cache-dir -r requirements.txt  && \
-    pip install --upgrade Pillow
+    pip install --no-cache-dir --upgrade Pillow
 
 ENV PYTHONPATH=/root:/home/user
 

--- a/comps/lvms/llama-vision/Dockerfile_guard
+++ b/comps/lvms/llama-vision/Dockerfile_guard
@@ -23,7 +23,7 @@ COPY comps /home/user/comps
 
 RUN cd /home/user/comps/lvms/llama-vision/ && \
     pip install --no-cache-dir -r requirements.txt  && \
-    pip install --upgrade Pillow
+    pip install --no-cache-dir --upgrade Pillow
 
 ENV PYTHONPATH=/root:/home/user
 

--- a/comps/lvms/llama-vision/Dockerfile_tp
+++ b/comps/lvms/llama-vision/Dockerfile_tp
@@ -19,13 +19,13 @@ RUN git lfs install
 
 COPY comps /home/user/comps
 
-RUN pip install git+https://github.com/HabanaAI/DeepSpeed.git@1.17.1
-RUN pip install git+https://github.com/huggingface/optimum-habana@v1.13.2
+RUN pip install --no-cache-dir git+https://github.com/HabanaAI/DeepSpeed.git@1.17.1
+RUN pip install --no-cache-dir git+https://github.com/huggingface/optimum-habana@v1.13.2
 
 RUN cd /home/user/comps/lvms/llama-vision/  \
     pip install --no-cache-dir --upgrade pip && \
     bash update && \
-    pip install -r /home/user/comps/lvms/llama-vision/requirements_tp.txt
+    pip install --no-cache-dir -r /home/user/comps/lvms/llama-vision/requirements_tp.txt
 
 ENV PYTHONPATH=/root:/home/user
 

--- a/comps/retrievers/multimodal/redis/langchain/Dockerfile
+++ b/comps/retrievers/multimodal/redis/langchain/Dockerfile
@@ -19,7 +19,7 @@ COPY comps /home/user/comps
 USER user
 
 RUN pip install --no-cache-dir --upgrade pip && \
-    if [ ${ARCH} = "cpu" ]; then pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu; fi && \
+    if [ ${ARCH} = "cpu" ]; then pip install --no-cache-dir torch torchvision --index-url https://download.pytorch.org/whl/cpu; fi && \
     pip install --no-cache-dir -r /home/user/comps/retrievers/multimodal/redis/langchain/requirements.txt
 
 ENV PYTHONPATH=$PYTHONPATH:/home/user

--- a/comps/retrievers/vdms/langchain/Dockerfile
+++ b/comps/retrievers/vdms/langchain/Dockerfile
@@ -1,4 +1,3 @@
-
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
@@ -20,13 +19,13 @@ COPY comps /home/user/comps
 
 USER user
 RUN pip install --no-cache-dir --upgrade pip && \
-    if [ ${ARCH} = "cpu" ]; then pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu; fi && \
+    if [ ${ARCH} = "cpu" ]; then pip install --no-cache-dir torch torchvision --index-url https://download.pytorch.org/whl/cpu; fi && \
     pip install --no-cache-dir -r /home/user/comps/retrievers/vdms/langchain/requirements.txt
 
-RUN pip install -U langchain
-RUN pip install -U langchain-community
-
-RUN pip install --upgrade huggingface-hub
+RUN pip install --no-cache-dir -U \
+    huggingface-hub \
+    langchain \
+    langchain-community
 
 ENV PYTHONPATH=$PYTHONPATH:/home/user
 

--- a/comps/text2image/Dockerfile
+++ b/comps/text2image/Dockerfile
@@ -11,7 +11,8 @@ ARG ARCH="cpu"
 COPY comps /home/comps
 
 RUN pip install --no-cache-dir --upgrade pip && \
-    if [ ${ARCH} = "cpu" ]; then pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu; fi && \
+    if [ ${ARCH} = "cpu" ]; then 
+      pip install --no-cache-dir torch torchvision --index-url https://download.pytorch.org/whl/cpu; fi && \
     pip install --no-cache-dir -r /home/comps/text2image/requirements.txt
 
 ENV PYTHONPATH=$PYTHONPATH:/home

--- a/comps/text2image/Dockerfile
+++ b/comps/text2image/Dockerfile
@@ -11,7 +11,7 @@ ARG ARCH="cpu"
 COPY comps /home/comps
 
 RUN pip install --no-cache-dir --upgrade pip && \
-    if [ ${ARCH} = "cpu" ]; then 
+    if [ ${ARCH} = "cpu" ]; then \
       pip install --no-cache-dir torch torchvision --index-url https://download.pytorch.org/whl/cpu; fi && \
     pip install --no-cache-dir -r /home/comps/text2image/requirements.txt
 

--- a/tests/agent/Dockerfile.hpu
+++ b/tests/agent/Dockerfile.hpu
@@ -4,7 +4,7 @@ COPY ./ /workspace/vllm
 
 WORKDIR /workspace/vllm
 
-RUN pip install -v cmake>=3.26 ninja packaging setuptools-scm>=8 wheel jinja2 -r requirements-hpu.txt
+RUN pip install --no-cache-dir -v cmake>=3.26 ninja packaging setuptools-scm>=8 wheel jinja2 -r requirements-hpu.txt
 
 ENV no_proxy=localhost,127.0.0.1
 ENV PT_HPU_ENABLE_LAZY_COLLECTIVES=true

--- a/tests/embeddings/test_embeddings_tei_langchain.sh
+++ b/tests/embeddings/test_embeddings_tei_langchain.sh
@@ -69,7 +69,7 @@ function main() {
     start_service
 
     validate_microservice
-    pip install openai
+    pip install -no-cache-dir openai
     validate_microservice_with_openai
 
     stop_docker

--- a/tests/llms/test_llms_text-generation_tgi.sh
+++ b/tests/llms/test_llms_text-generation_tgi.sh
@@ -80,7 +80,7 @@ function main() {
     stop_docker
     build_docker_images
 
-    pip install openai
+    pip install --no-cache-dir openai
 
     llm_models=(
     Intel/neural-chat-7b-v3-3


### PR DESCRIPTION
## Description
This PR ensures all `pip` installs have a `--no-cache-dir` option.

## Issues
Installing `pip` packages without this option will store everything in `.cache` and leads to large containers that take longer to download.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies
None

## Tests
CI test are sufficient.