### PR TITLE
Remove proxy definition from within Dockerfiles

### DIFF
--- a/comps/llms/text-generation/vllm/langchain/dependency/Dockerfile.intel_hpu
+++ b/comps/llms/text-generation/vllm/langchain/dependency/Dockerfile.intel_hpu
@@ -12,7 +12,6 @@ WORKDIR /workspace/vllm
 
 RUN pip install -v -r requirements-hpu.txt
 
-ENV no_proxy=localhost,127.0.0.1
 ENV PT_HPU_ENABLE_LAZY_COLLECTIVES=true
 
 RUN VLLM_TARGET_DEVICE=hpu python3 setup.py install
@@ -21,5 +20,4 @@ WORKDIR /workspace/
 
 RUN ln -s /workspace/vllm/tests && ln -s /workspace/vllm/examples && ln -s /workspace/vllm/benchmarks
 
-#ENTRYPOINT ["python3", "-m", "vllm.entrypoints.openai.api_server"]
 CMD ["/bin/bash"]

--- a/comps/llms/text-generation/vllm/llama_index/dependency/Dockerfile.intel_hpu
+++ b/comps/llms/text-generation/vllm/llama_index/dependency/Dockerfile.intel_hpu
@@ -19,8 +19,6 @@ RUN pip install --no-cache-dir -v git+https://github.com/HabanaAI/vllm-fork.git@
 
 RUN pip install --no-cache-dir setuptools
 
-ENV no_proxy=localhost,127.0.0.1
-
 ENV PT_HPU_LAZY_ACC_PAR_MODE=0
 
 ENV PT_HPU_ENABLE_LAZY_COLLECTIVES=true

--- a/comps/llms/text-generation/vllm/ray/dependency/Dockerfile
+++ b/comps/llms/text-generation/vllm/ray/dependency/Dockerfile
@@ -19,7 +19,6 @@ RUN pip install --no-cache-dir "ray>=2.10" "ray[serve,tune]>=2.10"
 RUN sed -i 's/#PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config && \
     service ssh restart
 
-ENV no_proxy=localhost,127.0.0.1
 ENV PYTHONPATH=$PYTHONPATH:/root:/home/user/vllm/ray
 
 # Required by DeepSpeed

--- a/comps/retrievers/neo4j/langchain/Dockerfile
+++ b/comps/retrievers/neo4j/langchain/Dockerfile
@@ -5,8 +5,6 @@ FROM python:3.11-slim
 
 ENV LANG=C.UTF-8
 
-ENV no_proxy=localhost,127.0.0.1
-
 ENV HUGGINGFACEHUB_API_TOKEN=dummy
 
 ARG ARCH="cpu"

--- a/comps/retrievers/vdms/langchain/Dockerfile
+++ b/comps/retrievers/vdms/langchain/Dockerfile
@@ -1,4 +1,3 @@
-
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
@@ -33,11 +32,6 @@ ENV PYTHONPATH=$PYTHONPATH:/home/user
 ENV HUGGINGFACEHUB_API_TOKEN=dummy
 
 ENV USECLIP 0
-
-ENV no_proxy=localhost,127.0.0.1
-
-ENV http_proxy=""
-ENV https_proxy=""
 
 WORKDIR /home/user/comps/retrievers/vdms/langchain
 

--- a/tests/agent/Dockerfile.hpu
+++ b/tests/agent/Dockerfile.hpu
@@ -6,7 +6,6 @@ WORKDIR /workspace/vllm
 
 RUN pip install -v cmake>=3.26 ninja packaging setuptools-scm>=8 wheel jinja2 -r requirements-hpu.txt
 
-ENV no_proxy=localhost,127.0.0.1
 ENV PT_HPU_ENABLE_LAZY_COLLECTIVES=true
 
 RUN VLLM_TARGET_DEVICE=hpu python3 setup.py install


### PR DESCRIPTION
## Description
This PR removes proxy definition from within Dockerfiles because they need to be provided by as `--env` when appropriate and otherwise left out in not needed.

## Issues
Having unnecessary `ENV` vars to Dockerfiles is generally a bad practice.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies
None

## Tests
CI test are sufficient.