### PR TITLE
missing dollar sign in check script for hyperlinks?

### DIFF
--- a/.github/workflows/pr-dockerfile-path-scan.yaml
+++ b/.github/workflows/pr-dockerfile-path-scan.yaml
@@ -178,7 +178,7 @@ jobs:
           fail="FALSE"
           merged_commit=$(git log -1 --format='%H')
           changed_files="$(git diff --name-status --diff-filter=ARM ${{ github.event.pull_request.base.sha }} ${merged_commit} | awk '/\.md$/ {print $NF}')"
-          if  [ -n "changed_files" ]; then
+          if  [ -n "$changed_files" ]; then
             for changed_file in $changed_files; do
               echo $changed_file
               url_lines=$(grep -H -Eo '\]\(http[s]?://[^)]+\)' "$changed_file" | grep -Ev 'GenAIComps/blob/main')


### PR DESCRIPTION
## Description

Possibly missing dollar sign in check script for hyperlinks in pr readmes

## Issues

My pr https://github.com/opea-project/GenAIComps/pull/775 ran into error when checking hyperlinks in README.md, even after removing all "http" keywords

Reason may be the missing dollar sign for the "changed_files" variable.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

n/a

## Tests

n/a