### PR TITLE
Fix llm not recognizing pydantic tool definition for dict types

### DIFF
--- a/comps/agent/langchain/src/tools.py
+++ b/comps/agent/langchain/src/tools.py
@@ -9,7 +9,7 @@ import sys
 import yaml
 from langchain.tools import BaseTool, StructuredTool
 from langchain_community.agent_toolkits.load_tools import load_tools
-from pydantic import BaseModel, Field, create_model
+from pydantic.v1 import BaseModel, Field, create_model
 
 
 def generate_request_function(url):


### PR DESCRIPTION
## Description

When using `pydantic` imports for `BaseModel, Field, create_model` (which is v2) in GenAIComps/comps/agent/langchain/src/tools.py file, LLM generates incorrect tool arg types for `dict[str, str]` schema type. Changing to use imports from `pydantic.v1` generates correct schema. Possibly due to `ChatOpenAI` using pydantic.v1.

Is it possible to change to use `pydantic.v1` in this file?

## Issues

`n/a`

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Tests

Using `BaseModel, Field, create_model` imports from pydantic:
Observed pydantic validation errors before entering tool.
![image](https://github.com/user-attachments/assets/cf450892-e0c7-4bce-aab8-4c53e22f039f)

Using `BaseModel, Field, create_model` imports from pydantic.v1:
Observe `params` to print as str type.
![image](https://github.com/user-attachments/assets/4d304e9e-097e-4be9-a3d3-4a24752075ff)
