### PR TITLE
Update Nginx default set

### DIFF
--- a/comps/nginx/nginx.conf.template
+++ b/comps/nginx/nginx.conf.template
@@ -10,6 +10,12 @@ server {
         alias  /usr/share/nginx/html/index.html;
     }
 
+    proxy_connect_timeout 600;
+    proxy_send_timeout 600;
+    proxy_read_timeout 600;
+    send_timeout 600;
+    client_max_body_size 10G;
+
     location / {
         proxy_pass http://${FRONTEND_SERVICE_IP}:${FRONTEND_SERVICE_PORT};
         proxy_set_header Host $host;


### PR DESCRIPTION
Update Nginx default setting

Nginx default file size is 1MB, change to 10GB.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Others (enhancement, documentation, validation, etc.)

## Tests

Upload 2MB files successfully.
It failed to upload the 2MB file without this PR.
