### PR TITLE
Fix web_retriever batch size issue

### DIFF
--- a/comps/web_retrievers/chroma/langchain/retriever_chroma.py
+++ b/comps/web_retrievers/chroma/langchain/retriever_chroma.py
@@ -52,7 +52,15 @@ def parse_htmls(docs):
 
 
 def dump_docs(docs):
-    vector_db.add_documents(docs)
+    batch_size = 32
+    doc_size = len(docs)
+    if doc_size > 32:
+        cur_idx = 0
+        while cur_idx < doc_size:
+            vector_db.add_documents(docs[cur_idx: min(cur_idx+batch_size, doc_size)])
+            cur_idx += batch_size
+    else:
+        vector_db.add_documents(docs)
 
 
 @register_microservice(

--- a/comps/web_retrievers/chroma/langchain/retriever_chroma.py
+++ b/comps/web_retrievers/chroma/langchain/retriever_chroma.py
@@ -53,14 +53,8 @@ def parse_htmls(docs):
 
 def dump_docs(docs):
     batch_size = 32
-    doc_size = len(docs)
-    if doc_size > 32:
-        cur_idx = 0
-        while cur_idx < doc_size:
-            vector_db.add_documents(docs[cur_idx: min(cur_idx+batch_size, doc_size)])
-            cur_idx += batch_size
-    else:
-        vector_db.add_documents(docs)
+    for i in range(0, len(docs), batch_size):
+        vector_db.add_documents(docs[i:i + batch_size])
 
 
 @register_microservice(

--- a/comps/web_retrievers/chroma/langchain/retriever_chroma.py
+++ b/comps/web_retrievers/chroma/langchain/retriever_chroma.py
@@ -54,7 +54,7 @@ def parse_htmls(docs):
 def dump_docs(docs):
     batch_size = 32
     for i in range(0, len(docs), batch_size):
-        vector_db.add_documents(docs[i:i + batch_size])
+        vector_db.add_documents(docs[i : i + batch_size])
 
 
 @register_microservice(


### PR DESCRIPTION
## Description

Fix web_retriever batch size issue.
The `Chroma.add_documents` function has the batch_size limitation of 32.
This PR limit the batch size of documents when adding documents into db.

## Issues

n/a

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

None

## Tests

Local tested.
