### PR TITLE
Remote TGI/TGI services with OAuth Client Credentials authentication

### DIFF
--- a/comps/cores/mega/utils.py
+++ b/comps/cores/mega/utils.py
@@ -7,7 +7,9 @@ import os
 import random
 from socket import AF_INET, SOCK_STREAM, socket
 from typing import List, Optional, Union
+
 import requests
+
 from .logger import CustomLogger
 
 
@@ -184,24 +186,24 @@ def random_port() -> Optional[int]:
         unassigned_ports.clear()
         return _random_port()
 
+
 def get_access_token(token_url: str, client_id: str, client_secret: str) -> str:
     """Get access token using OAuth client credentials flow."""
     logger = CustomLogger("tgi_or_tei_service_auth")
     data = {
-        'client_id': client_id,
-        'client_secret': client_secret,
-        'grant_type': 'client_credentials',
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "grant_type": "client_credentials",
     }
-    headers = {
-        'Content-Type': 'application/x-www-form-urlencoded'
-    }
+    headers = {"Content-Type": "application/x-www-form-urlencoded"}
     response = requests.post(token_url, data=data, headers=headers)
     if response.status_code == 200:
         token_info = response.json()
-        return token_info.get('access_token', '')
+        return token_info.get("access_token", "")
     else:
         logger.error(f"Failed to retrieve access token: {response.status_code}, {response.text}")
-        return ''
+        return ""
+
 
 class SafeContextManager:
     """This context manager ensures that the `__exit__` method of the

--- a/comps/cores/mega/utils.py
+++ b/comps/cores/mega/utils.py
@@ -7,6 +7,8 @@ import os
 import random
 from socket import AF_INET, SOCK_STREAM, socket
 from typing import List, Optional, Union
+import requests
+from .logger import CustomLogger
 
 
 def is_port_free(host: str, port: int) -> bool:
@@ -182,6 +184,24 @@ def random_port() -> Optional[int]:
         unassigned_ports.clear()
         return _random_port()
 
+def get_access_token(token_url: str, client_id: str, client_secret: str) -> str:
+    """Get access token using OAuth client credentials flow."""
+    logger = CustomLogger("tgi_or_tei_service_auth")
+    data = {
+        'client_id': client_id,
+        'client_secret': client_secret,
+        'grant_type': 'client_credentials',
+    }
+    headers = {
+        'Content-Type': 'application/x-www-form-urlencoded'
+    }
+    response = requests.post(token_url, data=data, headers=headers)
+    if response.status_code == 200:
+        token_info = response.json()
+        return token_info.get('access_token', '')
+    else:
+        logger.error(f"Failed to retrieve access token: {response.status_code}, {response.text}")
+        return ''
 
 class SafeContextManager:
     """This context manager ensures that the `__exit__` method of the

--- a/comps/embeddings/tei/langchain/embedding_tei.py
+++ b/comps/embeddings/tei/langchain/embedding_tei.py
@@ -3,10 +3,10 @@
 
 import os
 import time
-from typing import Union
+import json
+from typing import Union, List
 
-from langchain_huggingface import HuggingFaceEndpointEmbeddings
-
+from huggingface_hub import AsyncInferenceClient
 from comps import (
     CustomLogger,
     EmbedDoc,
@@ -23,10 +23,17 @@ from comps.cores.proto.api_protocol import (
     EmbeddingResponse,
     EmbeddingResponseData,
 )
+from comps.cores.mega.utils import get_access_token
 
 logger = CustomLogger("embedding_tei_langchain")
 logflag = os.getenv("LOGFLAG", False)
 
+# Environment variables
+HUGGINGFACEHUB_API_TOKEN = os.getenv("HUGGINGFACEHUB_API_TOKEN")
+TOKEN_URL = os.getenv("TOKEN_URL")
+CLIENTID = os.getenv("CLIENTID")
+CLIENT_SECRET = os.getenv("CLIENT_SECRET")
+TEI_EMBEDDING_ENDPOINT = os.getenv("TEI_EMBEDDING_ENDPOINT", "http://localhost:8080")
 
 @register_microservice(
     name="opea_service@embedding_tei_langchain",
@@ -40,13 +47,15 @@ async def embedding(
     input: Union[TextDoc, EmbeddingRequest, ChatCompletionRequest]
 ) -> Union[EmbedDoc, EmbeddingResponse, ChatCompletionRequest]:
     start = time.time()
+    access_token = get_access_token(TOKEN_URL, CLIENTID, CLIENT_SECRET) if TOKEN_URL and CLIENTID and CLIENT_SECRET else None
+    async_client = get_async_inference_client(access_token)
     if logflag:
         logger.info(input)
     if isinstance(input, TextDoc):
-        embed_vector = await embeddings.aembed_query(input.text)
+        embed_vector = await aembed_query(input.text, async_client)
         res = EmbedDoc(text=input.text, embedding=embed_vector)
     else:
-        embed_vector = await embeddings.aembed_query(input.input)
+        embed_vector = await aembed_query(input.input, async_client)
         if input.dimensions is not None:
             embed_vector = embed_vector[: input.dimensions]
 
@@ -63,9 +72,26 @@ async def embedding(
         logger.info(res)
     return res
 
+async def aembed_query(text: str, async_client: AsyncInferenceClient, model_kwargs=None, task=None) -> List[float]:
+    response = (await aembed_documents([text], async_client, model_kwargs=model_kwargs, task=task))[0]
+    return response
+
+async def aembed_documents(texts: List[str], async_client: AsyncInferenceClient, model_kwargs=None, task=None) -> List[List[float]]:
+    texts = [text.replace("\n", " ") for text in texts]
+    _model_kwargs = model_kwargs or {}
+    responses = await async_client.post(
+        json={"inputs": texts, **_model_kwargs}, task=task
+    )
+    return json.loads(responses.decode())
+
+def get_async_inference_client(access_token: str) -> AsyncInferenceClient:
+    headers = {"Authorization": f"Bearer {access_token}"} if access_token else {}
+    return AsyncInferenceClient(
+        model=TEI_EMBEDDING_ENDPOINT,
+        token=HUGGINGFACEHUB_API_TOKEN,
+        headers=headers
+    )
 
 if __name__ == "__main__":
-    tei_embedding_endpoint = os.getenv("TEI_EMBEDDING_ENDPOINT", "http://localhost:8080")
-    embeddings = HuggingFaceEndpointEmbeddings(model=tei_embedding_endpoint)
     logger.info("TEI Gaudi Embedding initialized.")
     opea_microservices["opea_service@embedding_tei_langchain"].start()

--- a/comps/llms/faq-generation/tgi/langchain/llm.py
+++ b/comps/llms/faq-generation/tgi/langchain/llm.py
@@ -11,10 +11,15 @@ from langchain.text_splitter import CharacterTextSplitter
 from langchain_community.llms import HuggingFaceEndpoint
 
 from comps import CustomLogger, GeneratedDoc, LLMParamsDoc, ServiceType, opea_microservices, register_microservice
+from comps.cores.mega.utils import get_access_token
 
 logger = CustomLogger("llm_faqgen")
 logflag = os.getenv("LOGFLAG", False)
 
+# Environment variables
+TOKEN_URL = os.getenv("TOKEN_URL")
+CLIENTID = os.getenv("CLIENTID")
+CLIENT_SECRET = os.getenv("CLIENT_SECRET")
 
 def post_process_text(text: str):
     if text == " ":
@@ -37,6 +42,10 @@ def post_process_text(text: str):
 async def llm_generate(input: LLMParamsDoc):
     if logflag:
         logger.info(input)
+    access_token = get_access_token(TOKEN_URL, CLIENTID, CLIENT_SECRET) if TOKEN_URL and CLIENTID and CLIENT_SECRET else None
+    server_kwargs = {}
+    if access_token:
+        server_kwargs["headers"] = {"Authorization": f"Bearer {access_token}"}
     llm = HuggingFaceEndpoint(
         endpoint_url=llm_endpoint,
         max_new_tokens=input.max_tokens,
@@ -46,6 +55,7 @@ async def llm_generate(input: LLMParamsDoc):
         temperature=input.temperature,
         repetition_penalty=input.repetition_penalty,
         streaming=input.streaming,
+        server_kwargs=server_kwargs
     )
     templ = """Create a concise FAQs (frequently asked questions and answers) for following text:
         TEXT: {text}

--- a/comps/llms/faq-generation/tgi/langchain/llm.py
+++ b/comps/llms/faq-generation/tgi/langchain/llm.py
@@ -21,6 +21,7 @@ TOKEN_URL = os.getenv("TOKEN_URL")
 CLIENTID = os.getenv("CLIENTID")
 CLIENT_SECRET = os.getenv("CLIENT_SECRET")
 
+
 def post_process_text(text: str):
     if text == " ":
         return "data: @#$\n\n"
@@ -42,7 +43,9 @@ def post_process_text(text: str):
 async def llm_generate(input: LLMParamsDoc):
     if logflag:
         logger.info(input)
-    access_token = get_access_token(TOKEN_URL, CLIENTID, CLIENT_SECRET) if TOKEN_URL and CLIENTID and CLIENT_SECRET else None
+    access_token = (
+        get_access_token(TOKEN_URL, CLIENTID, CLIENT_SECRET) if TOKEN_URL and CLIENTID and CLIENT_SECRET else None
+    )
     server_kwargs = {}
     if access_token:
         server_kwargs["headers"] = {"Authorization": f"Bearer {access_token}"}
@@ -55,7 +58,7 @@ async def llm_generate(input: LLMParamsDoc):
         temperature=input.temperature,
         repetition_penalty=input.repetition_penalty,
         streaming=input.streaming,
-        server_kwargs=server_kwargs
+        server_kwargs=server_kwargs,
     )
     templ = """Create a concise FAQs (frequently asked questions and answers) for following text:
         TEXT: {text}

--- a/comps/llms/summarization/tgi/langchain/llm.py
+++ b/comps/llms/summarization/tgi/langchain/llm.py
@@ -58,17 +58,15 @@ async def llm_generate(input: LLMParamsDoc):
     if logflag:
         logger.info("After prompting:")
         logger.info(prompt)
-    
-    access_token = get_access_token(TOKEN_URL, CLIENTID, CLIENT_SECRET) if TOKEN_URL and CLIENTID and CLIENT_SECRET else None
+
+    access_token = (
+        get_access_token(TOKEN_URL, CLIENTID, CLIENT_SECRET) if TOKEN_URL and CLIENTID and CLIENT_SECRET else None
+    )
     headers = {}
     if access_token:
         headers = {"Authorization": f"Bearer {access_token}"}
     llm_endpoint = os.getenv("TGI_LLM_ENDPOINT", "http://localhost:8080")
-    llm = AsyncInferenceClient(
-        model=llm_endpoint,
-        timeout=600,
-        headers=headers
-    )
+    llm = AsyncInferenceClient(model=llm_endpoint, timeout=600, headers=headers)
 
     text_generation = await llm.text_generation(
         prompt=prompt,

--- a/comps/llms/summarization/tgi/langchain/llm.py
+++ b/comps/llms/summarization/tgi/langchain/llm.py
@@ -8,15 +8,15 @@ from huggingface_hub import AsyncInferenceClient
 from langchain.prompts import PromptTemplate
 
 from comps import CustomLogger, GeneratedDoc, LLMParamsDoc, ServiceType, opea_microservices, register_microservice
+from comps.cores.mega.utils import get_access_token
 
 logger = CustomLogger("llm_docsum")
 logflag = os.getenv("LOGFLAG", False)
 
-llm_endpoint = os.getenv("TGI_LLM_ENDPOINT", "http://localhost:8080")
-llm = AsyncInferenceClient(
-    model=llm_endpoint,
-    timeout=600,
-)
+# Environment variables
+TOKEN_URL = os.getenv("TOKEN_URL")
+CLIENTID = os.getenv("CLIENTID")
+CLIENT_SECRET = os.getenv("CLIENT_SECRET")
 
 templ_en = """Write a concise summary of the following:
 
@@ -45,7 +45,6 @@ templ_zh = """请简要概括以下内容:
 async def llm_generate(input: LLMParamsDoc):
     if logflag:
         logger.info(input)
-
     if input.language in ["en", "auto"]:
         templ = templ_en
     elif input.language in ["zh"]:
@@ -59,6 +58,17 @@ async def llm_generate(input: LLMParamsDoc):
     if logflag:
         logger.info("After prompting:")
         logger.info(prompt)
+    
+    access_token = get_access_token(TOKEN_URL, CLIENTID, CLIENT_SECRET) if TOKEN_URL and CLIENTID and CLIENT_SECRET else None
+    headers = {}
+    if access_token:
+        headers = {"Authorization": f"Bearer {access_token}"}
+    llm_endpoint = os.getenv("TGI_LLM_ENDPOINT", "http://localhost:8080")
+    llm = AsyncInferenceClient(
+        model=llm_endpoint,
+        timeout=600,
+        headers=headers
+    )
 
     text_generation = await llm.text_generation(
         prompt=prompt,

--- a/comps/llms/text-generation/tgi/llm.py
+++ b/comps/llms/text-generation/tgi/llm.py
@@ -23,16 +23,17 @@ from comps import (
     statistics_dict,
 )
 from comps.cores.proto.api_protocol import ChatCompletionRequest
+from comps.cores.mega.utils import get_access_token
 
 logger = CustomLogger("llm_tgi")
 logflag = os.getenv("LOGFLAG", False)
 
-llm_endpoint = os.getenv("TGI_LLM_ENDPOINT", "http://localhost:8080")
-llm = AsyncInferenceClient(
-    model=llm_endpoint,
-    timeout=600,
-)
+# Environment variables
+TOKEN_URL = os.getenv("TOKEN_URL")
+CLIENTID = os.getenv("CLIENTID")
+CLIENT_SECRET = os.getenv("CLIENT_SECRET")
 
+llm_endpoint = os.getenv("TGI_LLM_ENDPOINT", "http://localhost:8080")
 
 @register_microservice(
     name="opea_service@llm_tgi",
@@ -45,6 +46,14 @@ llm = AsyncInferenceClient(
 async def llm_generate(input: Union[LLMParamsDoc, ChatCompletionRequest, SearchedDoc]):
     if logflag:
         logger.info(input)
+    
+    access_token = get_access_token(TOKEN_URL, CLIENTID, CLIENT_SECRET) if TOKEN_URL and CLIENTID and CLIENT_SECRET else None
+    headers = {}
+    if access_token:
+        headers = {"Authorization": f"Bearer {access_token}"}
+
+    llm = AsyncInferenceClient(model=llm_endpoint,timeout=600, headers=headers)
+
     prompt_template = None
     if not isinstance(input, SearchedDoc) and input.chat_template:
         prompt_template = PromptTemplate.from_template(input.chat_template)

--- a/comps/llms/text-generation/tgi/llm.py
+++ b/comps/llms/text-generation/tgi/llm.py
@@ -22,8 +22,8 @@ from comps import (
     register_statistics,
     statistics_dict,
 )
-from comps.cores.proto.api_protocol import ChatCompletionRequest
 from comps.cores.mega.utils import get_access_token
+from comps.cores.proto.api_protocol import ChatCompletionRequest
 
 logger = CustomLogger("llm_tgi")
 logflag = os.getenv("LOGFLAG", False)
@@ -34,6 +34,7 @@ CLIENTID = os.getenv("CLIENTID")
 CLIENT_SECRET = os.getenv("CLIENT_SECRET")
 
 llm_endpoint = os.getenv("TGI_LLM_ENDPOINT", "http://localhost:8080")
+
 
 @register_microservice(
     name="opea_service@llm_tgi",
@@ -46,13 +47,15 @@ llm_endpoint = os.getenv("TGI_LLM_ENDPOINT", "http://localhost:8080")
 async def llm_generate(input: Union[LLMParamsDoc, ChatCompletionRequest, SearchedDoc]):
     if logflag:
         logger.info(input)
-    
-    access_token = get_access_token(TOKEN_URL, CLIENTID, CLIENT_SECRET) if TOKEN_URL and CLIENTID and CLIENT_SECRET else None
+
+    access_token = (
+        get_access_token(TOKEN_URL, CLIENTID, CLIENT_SECRET) if TOKEN_URL and CLIENTID and CLIENT_SECRET else None
+    )
     headers = {}
     if access_token:
         headers = {"Authorization": f"Bearer {access_token}"}
 
-    llm = AsyncInferenceClient(model=llm_endpoint,timeout=600, headers=headers)
+    llm = AsyncInferenceClient(model=llm_endpoint, timeout=600, headers=headers)
 
     prompt_template = None
     if not isinstance(input, SearchedDoc) and input.chat_template:

--- a/comps/reranks/tei/reranking_tei.py
+++ b/comps/reranks/tei/reranking_tei.py
@@ -18,14 +18,13 @@ from comps import (
     register_statistics,
     statistics_dict,
 )
+from comps.cores.mega.utils import get_access_token
 from comps.cores.proto.api_protocol import (
     ChatCompletionRequest,
     RerankingRequest,
     RerankingResponse,
     RerankingResponseData,
 )
-from comps.cores.mega.utils import get_access_token
-
 
 logger = CustomLogger("reranking_tei")
 logflag = os.getenv("LOGFLAG", False)
@@ -34,6 +33,7 @@ logflag = os.getenv("LOGFLAG", False)
 TOKEN_URL = os.getenv("TOKEN_URL")
 CLIENTID = os.getenv("CLIENTID")
 CLIENT_SECRET = os.getenv("CLIENT_SECRET")
+
 
 @register_microservice(
     name="opea_service@reranking_tei",
@@ -52,7 +52,9 @@ async def reranking(
         logger.info(input)
     start = time.time()
     reranking_results = []
-    access_token = get_access_token(TOKEN_URL, CLIENTID, CLIENT_SECRET) if TOKEN_URL and CLIENTID and CLIENT_SECRET else None
+    access_token = (
+        get_access_token(TOKEN_URL, CLIENTID, CLIENT_SECRET) if TOKEN_URL and CLIENTID and CLIENT_SECRET else None
+    )
     if input.retrieved_docs:
         docs = [doc.text for doc in input.retrieved_docs]
         url = tei_reranking_endpoint + "/rerank"


### PR DESCRIPTION
## Description

To support remote TGI/TEI endpoints instead of running it locally along with if these endpoints are protected with OAuth Client Credentials flow.

## Issues

n/a

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

Added get_access_token method in utils.py to get the OAuth Client Credentials flow by taking parameters clientid, clientsecret and tokenurl from environment variables. Using utils.py so that the fucntion can be reused in multiple places.

Added authentication i.e Authorization header to pass the token in multiple components like embedding, llm-faqgen, llm-sumarization, llm-text-generation and reranking files. These components uses the common get_access_token method from utils.

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
