### PR TITLE
gpt-sovits: Run as normal user

### DIFF
--- a/comps/tts/gpt-sovits/Dockerfile
+++ b/comps/tts/gpt-sovits/Dockerfile
@@ -25,8 +25,10 @@ RUN mv pretrained_models/*  GPT-SoVITS/GPT_SoVITS/pretrained_models/ && \
     python -m nltk.downloader averaged_perceptron_tagger_eng cmudict
 
 RUN mv GPT-SoVITS /home/user/
+RUN mv /root/nltk_data /home/user/
+RUN chown -R user /home/user/
 
-# USER user
+USER user
 # ENV LANG=C.UTF-8
 
 WORKDIR /home/user/GPT-SoVITS


### PR DESCRIPTION
## Description

Make gpt-sovits to run as normal user as all other opea container images.

## Issues

#838

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
