### PR TITLE
Enable Parameter k for Web Retriever

### DIFF
--- a/comps/web_retrievers/chroma/langchain/retriever_chroma.py
+++ b/comps/web_retrievers/chroma/langchain/retriever_chroma.py
@@ -73,7 +73,7 @@ async def web_retrieve(input: EmbedDoc) -> SearchedDoc:
     embedding = input.embedding
 
     # Google Search the results, parse the htmls
-    search_results = get_urls(query)
+    search_results = get_urls(query=query, num_search_result=input.k)
     urls_to_look = []
     for res in search_results:
         if res.get("link", None):
@@ -94,7 +94,7 @@ async def web_retrieve(input: EmbedDoc) -> SearchedDoc:
     dump_docs(unique_documents)
 
     # Do the retrieval
-    search_res = await vector_db.asimilarity_search_by_vector(embedding=embedding)
+    search_res = await vector_db.asimilarity_search_by_vector(embedding=embedding, k=input.k)
 
     searched_docs = []
 


### PR DESCRIPTION
## Description

enable parameter k to get web resources of num k.

## Issues

By default, web retriever gets only one web resource, which will cause the empty result if any exception occurs.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

None

## Tests

Local tested