### PR TITLE
fix prometheus invalid metric name

### DIFF
--- a/comps/cores/mega/http_service.py
+++ b/comps/cores/mega/http_service.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+import re
 from typing import Optional
 
 from fastapi import FastAPI
@@ -9,7 +10,7 @@ from uvicorn import Config, Server
 
 from .base_service import BaseService
 from .base_statistics import collect_all_statistics
-import re
+
 
 class HTTPService(BaseService):
     """FastAPI HTTP service based on BaseService class.
@@ -37,7 +38,7 @@ class HTTPService(BaseService):
         # remove part before '@', used by register_microservice() callers, and
         # part after '/', added by MicroService(), to get real service name, and
         # convert invalid characters to '_'
-        suffix = re.sub(r'[^a-zA-Z0-9]', '_', self.title.split("/")[0].split("@")[-1].lower())
+        suffix = re.sub(r"[^a-zA-Z0-9]", "_", self.title.split("/")[0].split("@")[-1].lower())
 
         instrumentator = Instrumentator(
             inprogress_name=f"http_requests_inprogress_{suffix}",

--- a/comps/cores/mega/http_service.py
+++ b/comps/cores/mega/http_service.py
@@ -9,7 +9,7 @@ from uvicorn import Config, Server
 
 from .base_service import BaseService
 from .base_statistics import collect_all_statistics
-
+import re
 
 class HTTPService(BaseService):
     """FastAPI HTTP service based on BaseService class.
@@ -35,8 +35,10 @@ class HTTPService(BaseService):
         self._app = self._create_app()
 
         # remove part before '@', used by register_microservice() callers, and
-        # part after '/', added by MicroService(), to get real service name
-        suffix = self.title.split("/")[0].split("@")[-1].lower()
+        # part after '/', added by MicroService(), to get real service name, and
+        # convert invalid characters to '_'
+        suffix = re.sub(r'[^a-zA-Z0-9]', '_', self.title.split("/")[0].split("@")[-1].lower())
+
         instrumentator = Instrumentator(
             inprogress_name=f"http_requests_inprogress_{suffix}",
             should_instrument_requests_inprogress=True,


### PR DESCRIPTION
## Description

Minor fix to https://github.com/opea-project/GenAIComps/pull/845

follow Underscore format that prometheus accepts

ValueError: Invalid metric name: http_requests_inprogress_comps-chat-agent

## Issues

List the issue or RFC link this PR is working on. If there is no such link, please mark it as `n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

na
## Tests

na