### PR TITLE
Replace HTTP "inprogress" gauge with megaservice "request_pending" one

### DIFF
--- a/comps/cores/mega/http_service.py
+++ b/comps/cores/mega/http_service.py
@@ -35,18 +35,7 @@ class HTTPService(BaseService):
         self.uvicorn_kwargs = uvicorn_kwargs or {}
         self.cors = cors
         self._app = self._create_app()
-
-        # remove part before '@', used by register_microservice() callers, and
-        # part after '/', added by MicroService(), to get real service name, and
-        # convert invalid characters to '_'
-        suffix = re.sub(r"[^a-zA-Z0-9]", "_", self.title.split("/")[0].split("@")[-1].lower())
-
-        instrumentator = Instrumentator(
-            inprogress_name=f"http_requests_inprogress_{suffix}",
-            should_instrument_requests_inprogress=True,
-            inprogress_labels=True,
-        )
-        instrumentator.instrument(self._app).expose(self._app)
+        Instrumentator().instrument(self._app).expose(self._app)
 
     @property
     def app(self):

--- a/comps/cores/telemetry/README.md
+++ b/comps/cores/telemetry/README.md
@@ -9,9 +9,10 @@ OPEA Comps currently provides telemetry functionalities for metrics and tracing 
 OPEA microservice metrics are exported in Prometheus format under `/metrics` endpoint.
 
 They come in several categories:
-* HTTP request metrics are exposed by every OPEA microservice using the [prometheus-fastapi-instrumentator](https://github.com/trallnag/prometheus-fastapi-instrumentator)
-* Megaservices export additional metrics for application end-to-end load / performance
-* Inferencing microservices such as TGI, vLLM, TEI provide their own metrics
+
+- HTTP request metrics are exposed by every OPEA microservice using the [prometheus-fastapi-instrumentator](https://github.com/trallnag/prometheus-fastapi-instrumentator)
+- Megaservices export additional metrics for application end-to-end load / performance
+- Inferencing microservices such as TGI, vLLM, TEI provide their own metrics
 
 They can be fetched e.g. with `curl`:
 
@@ -43,14 +44,15 @@ Most of them are histogram metrics.
 ### Megaservice E2E metrics
 
 Applications' megaservice `ServiceOrchectrator` provides following metrics:
-* `megaservice_first_token_latency`: time to first token (TTFT)
-* `megaservice_inter_token_latency`: inter-token latency (ITL ~ TPOT)
-* `megaservice_request_latency`: whole request E2E latency = TTFT + ITL * tokens
-* `megaservice_request_pending`: how many LLM requests are still in progress
+
+- `megaservice_first_token_latency`: time to first token (TTFT)
+- `megaservice_inter_token_latency`: inter-token latency (ITL ~ TPOT)
+- `megaservice_request_latency`: whole request E2E latency = TTFT + ITL \* tokens
+- `megaservice_request_pending`: how many LLM requests are still in progress
 
 Latency ones are histogram metrics i.e. include count, total value and set of value buckets for each item.
 
-They are available only for _streaming_ requests using LLM.  Pending count accounts for all requests.
+They are available only for _streaming_ requests using LLM. Pending count accounts for all requests.
 
 ### Inferencing Metrics
 

--- a/comps/cores/telemetry/README.md
+++ b/comps/cores/telemetry/README.md
@@ -6,21 +6,22 @@ OPEA Comps currently provides telemetry functionalities for metrics and tracing 
 
 ## Metrics
 
-OPEA microservice metrics are exported in Prometheus format and are divided into two categories: general metrics and specific metrics.
+OPEA microservice metrics are exported in Prometheus format under `/metrics` endpoint.
 
-General metrics, such as `http_requests_total`, `http_request_size_bytes`, are exposed by every microservice endpoint using the [prometheus-fastapi-instrumentator](https://github.com/trallnag/prometheus-fastapi-instrumentator).
+They come in several categories:
+* HTTP request metrics are exposed by every OPEA microservice using the [prometheus-fastapi-instrumentator](https://github.com/trallnag/prometheus-fastapi-instrumentator)
+* Megaservices export additional metrics for application end-to-end load / performance
+* Inferencing microservices such as TGI, vLLM, TEI provide their own metrics
 
-Specific metrics are the built-in metrics exposed under `/metrics` by each specific microservices such as TGI, vLLM, TEI and others. Both types of the metrics adhere to the Prometheus format.
-
-### General Metrics
-
-To access the general metrics of each microservice, you can use `curl` as follows:
+They can be fetched e.g. with `curl`:
 
 ```bash
 curl localhost:{port of your service}/metrics
 ```
 
-Then you will see Prometheus format metrics printed out as follows:
+### HTTP Metrics
+
+Metrics output looks following:
 
 ```yaml
 HELP http_requests_total Total number of requests by method, status and handler.
@@ -37,9 +38,21 @@ http_request_size_bytes_sum{handler="/v1/chatqna"} 128.0
 ...
 ```
 
-### Specific Metrics
+Most of them are histogram metrics.
 
-To access the metrics exposed by each specific microservice, ensure that you check the specific port and your port mapping to reach the `/metrics` endpoint correctly.
+### Megaservice E2E metrics
+
+Applications' megaservice `ServiceOrchectrator` provides following metrics:
+* `megaservice_first_token_latency`: time to first token (TTFT)
+* `megaservice_inter_token_latency`: inter-token latency (ITL ~ TPOT)
+* `megaservice_request_latency`: whole request E2E latency = TTFT + ITL * tokens
+* `megaservice_request_pending`: how many LLM requests are still in progress
+
+Latency ones are histogram metrics i.e. include count, total value and set of value buckets for each item.
+
+They are available only for _streaming_ requests using LLM.  Pending count accounts for all requests.
+
+### Inferencing Metrics
 
 For example, you can `curl localhost:6006/metrics` to retrieve the TEI embedding metrics, and the output should look like follows:
 
@@ -65,6 +78,8 @@ te_request_inference_duration_bucket{le="0.000015000000000000002"} 0
 te_request_inference_duration_bucket{le="0.000022500000000000005"} 0
 te_request_inference_duration_bucket{le="0.00003375000000000001"} 0
 ```
+
+### Metrics collection
 
 These metrics can be scraped by the Prometheus server into a time-series database and further visualized using Grafana.
 


### PR DESCRIPTION
## Description

This new metric matches better the earlier added (LLM usage specific) request latency one, and does _not_ have the issues that the `inprogress` metric for `prometheus-fastapi-instrumentator`  in `HttpService` did:
* Create extra instances which have to be differentiated e.g. for CI:
  * See: https://github.com/opea-project/GenAIComps/pull/845#issuecomment-2452219683
* Rely on metric instance (name) differentiator coming through obscure kwargs call-chain:
   * `name` => `Gateway` => `MicroService` => `HttpService` => `BaseService` => `HttpService.title`
* Create separate `inprogress` metrics also for metric and health queries

I.e. it does not create useless extra metrics, and it's a bit easier to reason how & why it works.

(This reverts the "inprogress" metric part of commit a6998a1dbdc9f88a5c4.)

## Issues

`n/a`.

## Type of change

- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

`n/a`.

## Tests

I've manually tested that the new metric works, and provides same gauge values as the old one.