### PR TITLE
Bugfix for follow-up query with a .png image

### DIFF
--- a/comps/dataprep/multimodal/redis/langchain/multimodal_utils.py
+++ b/comps/dataprep/multimodal/redis/langchain/multimodal_utils.py
@@ -250,7 +250,7 @@ def extract_frames_and_generate_captions(
     # Set up location to store frames and annotations
     os.makedirs(output_dir, exist_ok=True)
     os.makedirs(os.path.join(output_dir, "frames"), exist_ok=True)
-    is_video = os.path.splitext(video_path)[-1] == '.mp4'
+    is_video = os.path.splitext(video_path)[-1] == ".mp4"
 
     # Load video and get fps
     vidcap = cv2.VideoCapture(video_path)

--- a/comps/dataprep/multimodal/redis/langchain/multimodal_utils.py
+++ b/comps/dataprep/multimodal/redis/langchain/multimodal_utils.py
@@ -250,6 +250,7 @@ def extract_frames_and_generate_captions(
     # Set up location to store frames and annotations
     os.makedirs(output_dir, exist_ok=True)
     os.makedirs(os.path.join(output_dir, "frames"), exist_ok=True)
+    is_video = os.path.splitext(video_path)[-1] == '.mp4'
 
     # Load video and get fps
     vidcap = cv2.VideoCapture(video_path)
@@ -294,8 +295,8 @@ def extract_frames_and_generate_captions(
                     "video_name": os.path.basename(video_path),
                     "b64_img_str": b64_img_str,
                     "caption": text,
-                    "time": mid_time_ms,
-                    "frame_no": frame_no,
+                    "time": mid_time_ms if is_video else 0.0,
+                    "frame_no": frame_no if is_video else 0,
                     "sub_video_id": idx,
                 }
             )


### PR DESCRIPTION
## Description

Fixes a bug in the `dataprep-multimodal-redis` microservice where non-zero time metadata was being stored for .png images. This was resulting in an exception `ValueError: invalid literal for int()` being thrown and displayed in the MultimodalQnA UI during follow-up queries.

## Issues

Related to the [Image_and_Audio_Support_in_MultimodalQnA RFC](https://github.com/opea-project/docs/blob/main/community/rfcs/24-10-02-GenAIExamples-001-Image_and_Audio_Support_in_MultimodalQnA.md)

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

N/A

## Tests

N/A
