### PR TITLE
Fix units of incorrect caption timestamps

### DIFF
--- a/comps/dataprep/multimodal/redis/langchain/multimodal_utils.py
+++ b/comps/dataprep/multimodal/redis/langchain/multimodal_utils.py
@@ -269,7 +269,7 @@ def extract_frames_and_generate_captions(
             idx += 1
 
             mid_time = vidcap.get(cv2.CAP_PROP_POS_MSEC)
-            mid_time_ms = mid_time * 1000
+            mid_time_ms = mid_time  # Already in ms
 
             frame_no = curr_frame
             frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)


### PR DESCRIPTION
## Description

Fixes a bug in caption generation for videos. The timestamp was unnecessarily multiplied by 1000, which when passed to the MultimodalQnA UI was causing the video clip to not be displayed.

## Issues

[MultimodalQnA Images & Video Enhancements RFC](https://github.com/opea-project/docs/blob/main/community/rfcs/24-10-02-GenAIExamples-001-Image_and_Audio_Support_in_MultimodalQnA.md)

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

N/A

## Tests

N/A
