### PR TITLE
Return Mega/Micro Service Version number at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,26 @@ class ExampleService:
         self.megaservice.flow_to(embedding, llm)
 ```
 
+self.gateway = ChatQnAGateway(megaservice=self.megaservice, host="0.0.0.0", port=self.port)
+
+````
+
+## Check Mega/Micro Service health status and version number
+
+Use below command to check Mega/Micro Service status.
+
+```bash
+curl http://${your_ip}:${service_port}/v1/health_check\
+  -X GET \
+  -H 'Content-Type: application/json'
+````
+
+Users should get output like below example if Mega/Micro Service works correctly.
+
+```bash
+{"Service Title":"ChatQnAGateway/MicroService","Version":"1.0","Service Description":"OPEA Microservice Infrastructure"}
+```
+
 ## Contributing to OPEA
 
 Welcome to the OPEA open-source community! We are thrilled to have you here and excited about the potential contributions you can bring to the OPEA platform. Whether you are fixing bugs, adding new GenAI components, improving documentation, or sharing your unique use cases, your contributions are invaluable.

--- a/comps/cores/mega/http_service.py
+++ b/comps/cores/mega/http_service.py
@@ -72,7 +72,9 @@ class HTTPService(BaseService):
         )
         async def _health_check():
             """Get the health status of this GenAI microservice."""
-            return {"Service Title": self.title, "Service Description": self.description}
+            from comps.version import __version__
+
+            return {"Service Title": self.title, "Version": __version__, "Service Description": self.description}
 
         @app.get("/health")
         async def _health() -> Response:

--- a/tests/cores/mega/test_microservice.py
+++ b/tests/cores/mega/test_microservice.py
@@ -47,7 +47,8 @@ class TestMicroService(unittest.TestCase):
 
         response = self.client.get("/v1/health_check")
         self.assertEqual(
-            response.json(), {"Service Title": "s1", "Service Description": "OPEA Microservice Infrastructure"}
+            response.json(),
+            {"Service Title": "s1", "Version": "1.2", "Service Description": "OPEA Microservice Infrastructure"},
         )
 
         response = self.client.get("/v1/sum")


### PR DESCRIPTION
## Description

For those running Mega/Micro Service, users might need to understand its version for debugging or runtime issues.
Therefore, add a method to get version number at runtime

## Issues

 `n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

NA

## Tests

Manually test on AWS Xeon instance
