### PR TITLE
fix retriever and reranker to process chat completion request

### DIFF
--- a/comps/cores/mega/gateway.py
+++ b/comps/cores/mega/gateway.py
@@ -773,7 +773,7 @@ class RetrievalToolGateway(Gateway):
             host,
             port,
             str(MegaServiceEndpoint.RETRIEVALTOOL),
-            Union[TextDoc, EmbeddingRequest, ChatCompletionRequest],
+            Union[TextDoc, ChatCompletionRequest],
             Union[RerankedDoc, LLMParamsDoc],
         )
 
@@ -789,7 +789,7 @@ class RetrievalToolGateway(Gateway):
 
         data = await request.json()
         query = None
-        for key, TypeClass in zip(["text", "input", "messages"], [TextDoc, EmbeddingRequest, ChatCompletionRequest]):
+        for key, TypeClass in zip(["text", "messages"], [TextDoc, ChatCompletionRequest]):
             query, chat_request = parser_input(data, TypeClass, key)
             if query is not None:
                 break

--- a/comps/reranks/tei/reranking_tei.py
+++ b/comps/reranks/tei/reranking_tei.py
@@ -41,8 +41,8 @@ CLIENT_SECRET = os.getenv("CLIENT_SECRET")
     endpoint="/v1/reranking",
     host="0.0.0.0",
     port=8000,
-    input_datatype=SearchedDoc,
-    output_datatype=LLMParamsDoc,
+    input_datatype=Union[SearchedDoc, RerankingRequest, ChatCompletionRequest],
+    output_datatype=Union[LLMParamsDoc, RerankingResponse, ChatCompletionRequest],
 )
 @register_statistics(names=["opea_service@reranking_tei"])
 async def reranking(

--- a/comps/retrievers/redis/langchain/retriever_redis.py
+++ b/comps/retrievers/redis/langchain/retriever_redis.py
@@ -26,6 +26,7 @@ from comps.cores.proto.api_protocol import (
     RetrievalRequest,
     RetrievalResponse,
     RetrievalResponseData,
+    EmbeddingResponse,
 )
 
 logger = CustomLogger("retriever_redis")
@@ -54,12 +55,25 @@ async def retrieve(
     else:
         if isinstance(input, EmbedDoc):
             query = input.text
+            embedding_data_input = input.embedding
         else:
             # for RetrievalRequest, ChatCompletionRequest
             query = input.input
+            if isinstance(input.embedding, EmbeddingResponse):
+                embeddings= input.embedding.data
+                embedding_data_input = []
+                for emb in embeddings:
+                    # each emb is EmbeddingResponseData
+                    # print("Embedding data: ", emb.embedding)
+                    # print("Embedding data length: ",len(emb.embedding))
+                    embedding_data_input.append(emb.embedding)
+                # print("All Embedding data length: ",len(embedding_data_input))
+            else:
+                embedding_data_input = input.embedding
+
         # if the Redis index has data, perform the search
         if input.search_type == "similarity":
-            search_res = await vector_db.asimilarity_search_by_vector(embedding=input.embedding, k=input.k)
+            search_res = await vector_db.asimilarity_search_by_vector(embedding=embedding_data_input, k=input.k)
         elif input.search_type == "similarity_distance_threshold":
             if input.distance_threshold is None:
                 raise ValueError("distance_threshold must be provided for " + "similarity_distance_threshold retriever")

--- a/comps/retrievers/redis/langchain/retriever_redis.py
+++ b/comps/retrievers/redis/langchain/retriever_redis.py
@@ -23,10 +23,10 @@ from comps import (
 )
 from comps.cores.proto.api_protocol import (
     ChatCompletionRequest,
+    EmbeddingResponse,
     RetrievalRequest,
     RetrievalResponse,
     RetrievalResponseData,
-    EmbeddingResponse,
 )
 
 logger = CustomLogger("retriever_redis")
@@ -60,7 +60,7 @@ async def retrieve(
             # for RetrievalRequest, ChatCompletionRequest
             query = input.input
             if isinstance(input.embedding, EmbeddingResponse):
-                embeddings= input.embedding.data
+                embeddings = input.embedding.data
                 embedding_data_input = []
                 for emb in embeddings:
                     # each emb is EmbeddingResponseData


### PR DESCRIPTION
## Description
When testing DocIndexRetriever with user input k and top_n as ChatCompletionRequest, I identified two errors:
1. retriever redis: previously if input is chat completion request, since the embedding is EmbeddingResponse, it cannot be processed by the vector db, so need to add additional steps to get the embedding vectors out from the EmbeddingResponse.
2. reranker tei: previously input_type is fixed as SearchedDoc, so if the input is ChatCompletionRequest, the microservice will return error 422 unprocessable entity.

As a result of these 2 errors, the DocIndexRetriever fails when user send ChatCompletionRequest.

This PR fixes the issues above. 

## Issues

List the issue or RFC link this PR is working on. If there is no such link, please mark it as `n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

retriever and reranker unit tests, DocIndexRetriever example tests.
