### PR TITLE
Revert mosec embedding microservice to  to use synchronous interface.

### DIFF
--- a/comps/embeddings/mosec/langchain/embedding_mosec.py
+++ b/comps/embeddings/mosec/langchain/embedding_mosec.py
@@ -7,6 +7,7 @@ import time
 from typing import List, Optional, Union
 
 from langchain_community.embeddings import OpenAIEmbeddings
+from langchain_community.embeddings.openai import async_embed_with_retry
 
 from comps import (
     CustomLogger,

--- a/comps/embeddings/mosec/langchain/embedding_mosec.py
+++ b/comps/embeddings/mosec/langchain/embedding_mosec.py
@@ -31,11 +31,11 @@ logflag = os.getenv("LOGFLAG", False)
 
 class MosecEmbeddings(OpenAIEmbeddings):
     async def _aget_len_safe_embeddings(
-        self, texts: List[str], *, engine: str, chunk_size: Optional[int] = None
+            self, texts: List[str], *, engine: str, chunk_size: Optional[int] = None
     ) -> List[List[float]]:
         _chunk_size = chunk_size or self.chunk_size
         batched_embeddings: List[List[float]] = []
-        response = self.client.create(input=texts, **self._invocation_params)
+        response = await async_embed_with_retry(self, input=texts, **self._invocation_params)
         if not isinstance(response, dict):
             response = response.model_dump()
         batched_embeddings.extend(r["embedding"] for r in response["data"])
@@ -45,7 +45,7 @@ class MosecEmbeddings(OpenAIEmbeddings):
         async def empty_embedding() -> List[float]:
             nonlocal _cached_empty_embedding
             if _cached_empty_embedding is None:
-                average_embedded = self.client.create(input="", **self._invocation_params)
+                average_embedded = await async_embed_with_retry(self, input="", **self._invocation_params)
                 if not isinstance(average_embedded, dict):
                     average_embedded = average_embedded.model_dump()
                 _cached_empty_embedding = average_embedded["data"][0]["embedding"]
@@ -56,6 +56,30 @@ class MosecEmbeddings(OpenAIEmbeddings):
 
         embeddings = await asyncio.gather(*[get_embedding(e) for e in batched_embeddings])
         return embeddings
+
+    def _get_len_safe_embeddings(
+            self, texts: List[str], *, engine: str, chunk_size: Optional[int] = None
+    ) -> List[List[float]]:
+        _chunk_size = chunk_size or self.chunk_size
+        batched_embeddings: List[List[float]] = []
+        response = self.client.create(input=texts, **self._invocation_params)
+        if not isinstance(response, dict):
+            response = response.model_dump()
+        batched_embeddings.extend(r["embedding"] for r in response["data"])
+
+        _cached_empty_embedding: Optional[List[float]] = None
+
+        def empty_embedding() -> List[float]:
+            nonlocal _cached_empty_embedding
+            if _cached_empty_embedding is None:
+                average_embedded = self.client.create(input="", **self._invocation_params)
+                if not isinstance(average_embedded, dict):
+                    average_embedded = average_embedded.model_dump()
+                _cached_empty_embedding = average_embedded["data"][0]["embedding"]
+            return _cached_empty_embedding
+
+        return [e if e is not None else empty_embedding() for e in batched_embeddings]
+
 
 
 @register_microservice(
@@ -68,18 +92,18 @@ class MosecEmbeddings(OpenAIEmbeddings):
     output_datatype=EmbedDoc,
 )
 @register_statistics(names=["opea_service@embedding_mosec"])
-async def embedding(
+def embedding(
     input: Union[TextDoc, EmbeddingRequest, ChatCompletionRequest]
 ) -> Union[EmbedDoc, EmbeddingResponse, ChatCompletionRequest]:
     if logflag:
         logger.info(input)
     start = time.time()
     if isinstance(input, TextDoc):
-        embed_vector = await get_embeddings(input.text)
+        embed_vector = get_embeddings(input.text)
         embedding_res = embed_vector[0] if isinstance(input.text, str) else embed_vector
         res = EmbedDoc(text=input.text, embedding=embedding_res)
     else:
-        embed_vector = await get_embeddings(input.input)
+        embed_vector = get_embeddings(input.input)
         if input.dimensions is not None:
             embed_vector = [embed_vector[i][: input.dimensions] for i in range(len(embed_vector))]
 
@@ -99,9 +123,9 @@ async def embedding(
     return res
 
 
-async def get_embeddings(text: Union[str, List[str]]) -> List[List[float]]:
+def get_embeddings(text: Union[str, List[str]]) -> List[List[float]]:
     texts = [text] if isinstance(text, str) else text
-    embed_vector = await embeddings.aembed_documents(texts)
+    embed_vector = embeddings.embed_documents(texts)
     return embed_vector
 
 


### PR DESCRIPTION
## Description

The performance of asynchronous calling method in Mosec embedding is not better than synchronous calling method, so we will revert to the original synchronous calling method.

synchronous ：
2024-12-04 17:33:09.632 | INFO     | __main__:send_concurrency_requests_zh:167 - Total Concurrency: 256
2024-12-04 17:33:09.632 | INFO     | __main__:send_concurrency_requests_zh:168 - Total Requests: 1280
2024-12-04 17:33:09.632 | INFO     | __main__:send_concurrency_requests_zh:169 - Total Test time: 13.35722827911377
2024-12-04 17:33:09.633 | INFO     | __main__:send_concurrency_requests_zh:180 - AVG total latency is 2.5386883400380613 s
2024-12-04 17:33:09.633 | INFO     | __main__:send_concurrency_requests_zh:181 - P50 total latency is 2.676561951637268 s
2024-12-04 17:33:09.633 | INFO     | __main__:send_concurrency_requests_zh:192 - P90 total latency is 2.8703201055526733 s
2024-12-04 17:33:09.634 | INFO     | __main__:send_concurrency_requests_zh:201 - P99 total latency is 2.9633608984947206 s


asynchronous :
2024-12-04 16:53:09.011 | INFO     | __main__:send_concurrency_requests_zh:167 - Total Concurrency: 256
2024-12-04 16:53:09.012 | INFO     | __main__:send_concurrency_requests_zh:168 - Total Requests: 1280
2024-12-04 16:53:09.012 | INFO     | __main__:send_concurrency_requests_zh:169 - Total Test time: 17.30679416656494
2024-12-04 16:53:09.012 | INFO     | __main__:send_concurrency_requests_zh:180 - AVG total latency is 2.7919802516698837 s
2024-12-04 16:53:09.013 | INFO     | __main__:send_concurrency_requests_zh:181 - P50 total latency is 1.953867793083191 s
2024-12-04 16:53:09.013 | INFO     | __main__:send_concurrency_requests_zh:192 - P90 total latency is 6.16189012527466 s
2024-12-04 16:53:09.013 | INFO     | __main__:send_concurrency_requests_zh:201 - P99 total latency is 11.693838047981306 s

## Issues

List the issue or RFC link this PR is working on. If there is no such link, please mark it as `n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ *] Others (enhancement, documentation, validation, etc.)

## Dependencies

 `n/a`.

## Tests

Describe the tests that you ran to verify your changes.
