### PR TITLE
Exclude yield/reply time from first token latency metric

### DIFF
--- a/comps/cores/mega/orchestrator.py
+++ b/comps/cores/mega/orchestrator.py
@@ -237,8 +237,8 @@ class ServiceOrchestrator(DAG):
                                     )
                                     token_start = time.time()
                             else:
-                                yield chunk
                                 token_start = self.metrics.token_update(token_start, is_first)
+                                yield chunk
                             is_first = False
                     self.metrics.request_update(req_start)
                     self.metrics.pending_update(False)
@@ -306,7 +306,7 @@ class ServiceOrchestrator(DAG):
         suffix = "\n\n"
         tokens = re.findall(r"\s?\S+\s?", sentence, re.UNICODE)
         for token in tokens:
-            yield prefix + repr(token.replace("\\n", "\n").encode("utf-8")) + suffix
             token_start = self.metrics.token_update(token_start, is_first)
+            yield prefix + repr(token.replace("\\n", "\n").encode("utf-8")) + suffix
         if is_last:
             yield "data: [DONE]\n\n"


### PR DESCRIPTION
## Description

While metrics are OK for small number of requests, when megaservice is handling many (hundreds of) _parallel_ requests, it was reporting clearly (~10%) larger first token latency, than the client receiving the tokens from the megaservice.

Changing timings to be done before token is yielded, means that reported first token latency can be slightly shorter than it actually is. However, testing with ChatQnA shows latencies to be clearly closer to ones seen by the client (within couple of percent) and typically smaller (i.e. logical).

## Issues

First token latency inaccuracy.    Number being larger than what client sees is obviously incorrect, which throws doubt also on other metrics.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

`n/a`

## Tests

Tested manually with HPA scaled ChatQnA, with benchmark constantly sending (up to 1000) parallel requests.

## Notes

Doing the metrics timing after yielding the token, meant that also time for sending the reply to the client and waiting that to complete, was included to the token time.

I suspect that with lot of parallel requests, processing often had switched to other megaservice request processing threads, and getting control back to yielding thread, or function context, could be delayed much longer than what sending the response to client takes.