### PR TITLE
Fix wrong endpoint for tei embedding gaudi wrapper

### DIFF
--- a/comps/embeddings/tei/langchain/README.md
+++ b/comps/embeddings/tei/langchain/README.md
@@ -42,7 +42,7 @@ curl localhost:$your_port/v1/embeddings \
 Start the embedding service with the TEI_EMBEDDING_ENDPOINT.
 
 ```bash
-export TEI_EMBEDDING_ENDPOINT="http://localhost:$yourport/v1/embeddings"
+export TEI_EMBEDDING_ENDPOINT="http://localhost:$yourport"
 export TEI_EMBEDDING_MODEL_NAME="BAAI/bge-large-en-v1.5"
 python embedding_tei.py
 ```
@@ -71,7 +71,7 @@ curl localhost:$your_port/embed/v1/embeddings \
 Export the `TEI_EMBEDDING_ENDPOINT` for later usage:
 
 ```bash
-export TEI_EMBEDDING_ENDPOINT="http://localhost:$yourport/v1/embeddings"
+export TEI_EMBEDDING_ENDPOINT="http://localhost:$yourport"
 export TEI_EMBEDDING_MODEL_NAME="BAAI/bge-large-en-v1.5"
 ```
 

--- a/comps/embeddings/tei/langchain/embedding_tei.py
+++ b/comps/embeddings/tei/langchain/embedding_tei.py
@@ -74,7 +74,7 @@ async def aembed_query(request: Dict, async_client: AsyncInferenceClient) -> Uni
 
 def get_async_inference_client(access_token: str) -> AsyncInferenceClient:
     headers = {"Authorization": f"Bearer {access_token}"} if access_token else {}
-    return AsyncInferenceClient(model=TEI_EMBEDDING_ENDPOINT, token=HUGGINGFACEHUB_API_TOKEN, headers=headers)
+    return AsyncInferenceClient(model=f"{TEI_EMBEDDING_ENDPOINT}/v1/embeddings", token=HUGGINGFACEHUB_API_TOKEN, headers=headers)
 
 
 if __name__ == "__main__":

--- a/tests/embeddings/test_embeddings_tei_langchain.sh
+++ b/tests/embeddings/test_embeddings_tei_langchain.sh
@@ -24,7 +24,7 @@ function start_service() {
     model="BAAI/bge-base-en-v1.5"
     unset http_proxy
     docker run -d --name="test-comps-embedding-tei-endpoint" -p $tei_endpoint:80 -v ./data:/data --pull always ghcr.io/huggingface/text-embeddings-inference:cpu-1.5 --model-id $model
-    export TEI_EMBEDDING_ENDPOINT="http://${ip_address}:${tei_endpoint}/v1/embeddings"
+    export TEI_EMBEDDING_ENDPOINT="http://${ip_address}:${tei_endpoint}"
     tei_service_port=5002
     docker run -d --name="test-comps-embedding-tei-server" -e LOGFLAG=True -e http_proxy=$http_proxy -e https_proxy=$https_proxy -p ${tei_service_port}:6000 --ipc=host -e TEI_EMBEDDING_ENDPOINT=$TEI_EMBEDDING_ENDPOINT  opea/embedding-tei:comps
     sleep 3m


### PR DESCRIPTION
## Description

access to embedding wrapper should use /v1/embeddings with {"input", "xxx"}

access to / should use {"inputs": "xxx"} but return are not openai compatible

```python
>>> TEI_EMBEDDING_ENDPOINT
'http://localhost:8090/v1/embeddings'
>>> client = AsyncInferenceClient(model=TEI_EMBEDDING_ENDPOINT, token=HUGGINGFACEHUB_API_TOKEN)
>>> rr=asyncio.run(client.post(json={"input": "Explain the OPEA project"}))
>>> rr
b'{"object":"list","data":[{"object":"embedding","embedding":[-0.0006848863,-0.015310476,-0.037823148,0.011144044,0.042748522,0.0222726,-0.0041277106,0.052072655,-0.011957196,-0.010230217,0.006164461,-0.004530414,-0.07267249,0.036800902,-0.00455364
```


## Issues

https://github.com/opea-project/GenAIExamples/issues/1263

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

None
## Tests

UT