### PR TITLE
add opentelemetry tracing into OPEA DAG and couple microservices code path related to ChatQnA

### DIFF
--- a/comps/cores/mega/orchestrator.py
+++ b/comps/cores/mega/orchestrator.py
@@ -16,6 +16,7 @@ from prometheus_client import Gauge, Histogram
 from pydantic import BaseModel
 
 from ..proto.docarray import LLMParams
+from ..telemetry.opea_telemetry import opea_telemetry
 from .constants import ServiceType
 from .dag import DAG
 from .logger import CustomLogger
@@ -80,6 +81,7 @@ class ServiceOrchestrator(DAG):
             logger.error(e)
             return False
 
+    @opea_telemetry
     async def schedule(self, initial_inputs: Dict | BaseModel, llm_parameters: LLMParams = LLMParams(), **kwargs):
         req_start = time.time()
         self.metrics.pending_update(True)
@@ -166,6 +168,7 @@ class ServiceOrchestrator(DAG):
             all_outputs.update(result_dict[prev_node])
         return all_outputs
 
+    @opea_telemetry
     async def execute(
         self,
         session: aiohttp.client.ClientSession,
@@ -208,6 +211,7 @@ class ServiceOrchestrator(DAG):
                 hitted_ends = [".", "?", "!", "。", "，", "！"]
                 downstream_endpoint = self.services[downstream[0]].endpoint_path
 
+            @opea_telemetry
             def generate():
                 token_start = req_start
                 if response:
@@ -301,6 +305,7 @@ class ServiceOrchestrator(DAG):
             chunk_str = chunk_str[: -len(suffix)]
         return chunk_str
 
+    @opea_telemetry
     def token_generator(self, sentence: str, token_start: float, is_first: bool, is_last: bool) -> str:
         prefix = "data: "
         suffix = "\n\n"

--- a/comps/cores/mega/orchestrator.py
+++ b/comps/cores/mega/orchestrator.py
@@ -216,14 +216,15 @@ class ServiceOrchestrator(DAG):
             # Still leave to sync requests.post for StreamingResponse
             if LOGFLAG:
                 logger.info(inputs)
-            response = requests.post(
-                url=endpoint,
-                data=json.dumps(inputs),
-                headers={"Content-type": "application/json"},
-                proxies={"http": None},
-                stream=True,
-                timeout=1000,
-            )
+            with tracer.start_as_current_span(f"{cur_node}_asyn_generate"):
+                response = requests.post(
+                    url=endpoint,
+                    data=json.dumps(inputs),
+                    headers={"Content-type": "application/json"},
+                    proxies={"http": None},
+                    stream=True,
+                    timeout=1000,
+                )
             downstream = runtime_graph.downstream(cur_node)
             if downstream:
                 assert len(downstream) == 1, "Not supported multiple stream downstreams yet!"

--- a/comps/cores/telemetry/opea_telemetry.py
+++ b/comps/cores/telemetry/opea_telemetry.py
@@ -43,7 +43,6 @@ tracer = trace.get_tracer(__name__)
 
 
 def opea_telemetry(func):
-    print(f"[*** telemetry ***] {func.__name__} under telemetry.")
     if inspect.iscoroutinefunction(func):
 
         @wraps(func)

--- a/comps/cores/telemetry/opea_telemetry.py
+++ b/comps/cores/telemetry/opea_telemetry.py
@@ -6,16 +6,16 @@ import os
 from functools import wraps
 
 from opentelemetry import trace
+from opentelemetry.context.contextvars_context import ContextVarsRuntimeContext
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter as HTTPSpanExporter
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-from opentelemetry.context.contextvars_context import ContextVarsRuntimeContext
 
 def detach_ignore_err(self, token: object) -> None:
-    """Resets Context to a previous value
+    """Resets Context to a previous value.
 
     Args:
         token: A reference to a previous Context.
@@ -24,6 +24,7 @@ def detach_ignore_err(self, token: object) -> None:
         self._current_context.reset(token)  # type: ignore
     except Exception as e:
         pass
+
 
 # bypass the ValueError that ContextVar context was created in a different Context from StreamingResponse
 ContextVarsRuntimeContext.detach = detach_ignore_err

--- a/comps/cores/telemetry/opea_telemetry.py
+++ b/comps/cores/telemetry/opea_telemetry.py
@@ -12,6 +12,22 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
+from opentelemetry.context.contextvars_context import ContextVarsRuntimeContext
+
+def detach_ignore_err(self, token: object) -> None:
+    """Resets Context to a previous value
+
+    Args:
+        token: A reference to a previous Context.
+    """
+    try:
+        self._current_context.reset(token)  # type: ignore
+    except Exception as e:
+        pass
+
+# bypass the ValueError that ContextVar context was created in a different Context from StreamingResponse
+ContextVarsRuntimeContext.detach = detach_ignore_err
+
 telemetry_endpoint = os.environ.get("TELEMETRY_ENDPOINT", "http://localhost:4318/v1/traces")
 
 resource = Resource.create({SERVICE_NAME: "opea"})

--- a/comps/embeddings/src/opea_embedding_microservice.py
+++ b/comps/embeddings/src/opea_embedding_microservice.py
@@ -17,6 +17,7 @@ from comps import (
     statistics_dict,
 )
 from comps.cores.proto.api_protocol import EmbeddingRequest, EmbeddingResponse
+from comps.cores.telemetry.opea_telemetry import opea_telemetry
 
 logger = CustomLogger("opea_embedding_microservice")
 logflag = os.getenv("LOGFLAG", False)
@@ -36,6 +37,7 @@ loader = OpeaComponentLoader(
     host="0.0.0.0",
     port=6000,
 )
+@opea_telemetry
 @register_statistics(names=["opea_service@embedding"])
 async def embedding(input: EmbeddingRequest) -> EmbeddingResponse:
     start = time.time()

--- a/comps/llms/src/text-generation/opea_llm_microservice.py
+++ b/comps/llms/src/text-generation/opea_llm_microservice.py
@@ -17,6 +17,7 @@ from comps import (
     statistics_dict,
 )
 from comps.cores.proto.api_protocol import ChatCompletionRequest
+from comps.cores.telemetry.opea_telemetry import opea_telemetry
 
 logger = CustomLogger("llm")
 logflag = os.getenv("LOGFLAG", False)
@@ -42,6 +43,7 @@ loader = OpeaComponentLoader(llm_component_name, description=f"OPEA LLM Componen
     host="0.0.0.0",
     port=9000,
 )
+@opea_telemetry
 @register_statistics(names=["opea_service@llm"])
 async def llm_generate(input: Union[LLMParamsDoc, ChatCompletionRequest, SearchedDoc]):
     start = time.time()

--- a/comps/rerankings/src/opea_reranking_microservice.py
+++ b/comps/rerankings/src/opea_reranking_microservice.py
@@ -19,6 +19,7 @@ from comps import (
 )
 from comps.cores.proto.api_protocol import ChatCompletionRequest, RerankingRequest, RerankingResponse
 from comps.cores.proto.docarray import LLMParamsDoc, LVMVideoDoc, RerankedDoc, SearchedDoc, SearchedMultimodalDoc
+from comps.cores.telemetry.opea_telemetry import opea_telemetry
 
 logger = CustomLogger("opea_reranking_microservice")
 logflag = os.getenv("LOGFLAG", False)
@@ -35,6 +36,7 @@ loader = OpeaComponentLoader(rerank_component_name, description=f"OPEA RERANK Co
     host="0.0.0.0",
     port=8000,
 )
+@opea_telemetry
 @register_statistics(names=["opea_service@reranking"])
 async def reranking(
     input: Union[SearchedMultimodalDoc, SearchedDoc, RerankingRequest, ChatCompletionRequest]

--- a/comps/retrievers/src/opea_retrievers_microservice.py
+++ b/comps/retrievers/src/opea_retrievers_microservice.py
@@ -37,6 +37,7 @@ from comps.cores.proto.api_protocol import (
     RetrievalResponse,
     RetrievalResponseData,
 )
+from comps.cores.telemetry.opea_telemetry import opea_telemetry
 
 logger = CustomLogger("opea_retrievers_microservice")
 logflag = os.getenv("LOGFLAG", False)
@@ -56,6 +57,7 @@ loader = OpeaComponentLoader(
     host="0.0.0.0",
     port=7000,
 )
+@opea_telemetry
 @register_statistics(names=["opea_service@retrievers"])
 async def ingest_files(
     input: Union[EmbedDoc, EmbedMultimodalDoc, RetrievalRequest, ChatCompletionRequest]


### PR DESCRIPTION
## Description

Added open telemetry tracing into OPEA DAG execute path and also couple microservices related to ChatQnA
The purpose is to show tracing timeline for each single request.
![image](https://github.com/user-attachments/assets/ec3f5346-275c-4129-840e-e4f263af1c7d)

depend on https://github.com/opea-project/GenAIExamples/pull/1316

## Issues

 `n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

NA

## Tests

manually testing
