### PR TITLE
Add Dockerfile for comps-base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Base image for GenAIComps based OPEA Python applications
+# Build: docker build -t opea/comps-base -f Dockerfile .
+
+ARG IMAGE_NAME=python
+ARG IMAGE_TAG=3.11-slim
+
+FROM ${IMAGE_NAME}:${IMAGE_TAG} AS base
+
+ENV HOME=/home/user
+
+RUN useradd -m -s /bin/bash user && \
+    mkdir -p $HOME && \
+    chown -R user $HOME
+
+# get security updates
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get clean autoclean && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR $HOME
+
+COPY *.toml *.py *.txt *.md LICENSE ./
+
+RUN pip install --no-cache-dir --upgrade pip setuptools && \
+    pip install --no-cache-dir -r requirements.txt
+
+COPY comps/ comps/
+
+ENV PYTHONPATH=$PYTHONPATH:$HOME
+
+USER user
+
+ENTRYPOINT ["sh", "-c", "set && ls -la"]


### PR DESCRIPTION
## Description

Add Docker file for a base image that can be used by GenAIExamples applications.

With a shared base image, CI can do test builds much faster, they take much less space locally and in registry, and images sharing the same base download much faster.

With this, almost all of the 20 application Dockerfiles, e.g. this one:
https://github.com/opea-project/GenAIExamples/blob/main/ChatQnA/Dockerfile

Can be reduced just to:
```
# Copyright (C) 2025 Intel Corporation
# SPDX-License-Identifier: Apache-2.0

ARG BASE_TAG=latest
FROM opea/comps-base:$BASE_TAG

COPY ./chatqna.py $HOME/chatqna.py
ENTRYPOINT ["python", "chatqna.py"]
```

(For releases, `docker build` command can be given e.g. `--build-arg=BASE_TAG=1.2` option.)


## Issues

This is first part in fixing image sizes and how much time and disk space is used for them.  There are multiple tickets about the image sizes.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

`n/a`

## Tests

Tested manually that the added Dockerfile, and ChatQnA & DocSum Dockerfiles relying on it build, and that the resulting ChatQnA & DocSum applications work fine.

## Next steps

Somebody (else) needs to:
* Add checking & building of this image to CI
* Do nightly builds of it and upload them both to CI and DockerHub registries for applications
* Do similar simplification / optimization for rest of the Dockerfiles (ones in this repo, and UI ones in GenAIExamples)