### PR TITLE
Fix vllm Openvino Dockerfile.intel_gpu build issue

### DIFF
--- a/comps/llms/text-generation/vllm/langchain/dependency/Dockerfile.intel_gpu
+++ b/comps/llms/text-generation/vllm/langchain/dependency/Dockerfile.intel_gpu
@@ -24,7 +24,7 @@ RUN wget -qO - https://repositories.intel.com/gpu/intel-graphics.key | gpg --yes
 
 WORKDIR /workspace
 
-RUN git clone -b v0.6.3.post1 https://github.com/vllm-project/vllm.git
+RUN git clone -b v0.6.6.post1 https://github.com/vllm-project/vllm.git
 
 #ARG GIT_REPO_CHECK=0
 #RUN --mount=type=bind,source=.git,target=.git \


### PR DESCRIPTION
## Description

Fix vllm openvino Dockerfile.intel_gpu build issue

Build Dockerfile.intel_gpu will fail because there are dependency conflict when vllm==v0.6.3.post1. Upgrading vllm to v0.6.6.post1 could solve the issue

Fixes [#1141](https://github.com/opea-project/GenAIComps/pull/1141)

## Issues

https://github.com/opea-project/GenAIComps/pull/1141

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ √] Bug fix (non-breaking change which fixes an issue)

## Dependencies

n/a

## Tests

![image](https://github.com/user-attachments/assets/d1b84e42-8710-4ad7-8572-8967e9b2bf6a)
