### PR TITLE
Align OpenAI API for FaqGen, DocSum, TextGen-native

### DIFF
--- a/comps/__init__.py
+++ b/comps/__init__.py
@@ -38,7 +38,6 @@ from comps.cores.proto.docarray import (
     PIIResponseDoc,
     Audio2text,
     DocSumDoc,
-    DocSumLLMParams,
 )
 
 # Constants

--- a/comps/cores/proto/api_protocol.py
+++ b/comps/cores/proto/api_protocol.py
@@ -269,13 +269,11 @@ class ChatCompletionRequest(BaseModel):
     request_type: Literal["chat"] = "chat"
 
 
-class DocSumChatCompletionRequest(BaseModel):
-    llm_params: Optional[ChatCompletionRequest] = None
-    text: Optional[str] = None
-    audio: Optional[str] = None
-    video: Optional[str] = None
+class DocSumChatCompletionRequest(ChatCompletionRequest):
+    summary_type: str = "auto"  # can be "auto", "stuff", "truncate", "map_reduce", "refine"
+    chunk_size: int = -1
+    chunk_overlap: int = -1
     type: Optional[str] = None
-
 
 class AudioChatCompletionRequest(BaseModel):
     audio: str

--- a/comps/cores/proto/api_protocol.py
+++ b/comps/cores/proto/api_protocol.py
@@ -275,6 +275,7 @@ class DocSumChatCompletionRequest(ChatCompletionRequest):
     chunk_overlap: int = -1
     type: Optional[str] = None
 
+
 class AudioChatCompletionRequest(BaseModel):
     audio: str
     voice: str = "default"

--- a/comps/cores/proto/docarray.py
+++ b/comps/cores/proto/docarray.py
@@ -212,12 +212,6 @@ class LLMParamsDoc(BaseDoc):
         return v
 
 
-class DocSumLLMParams(LLMParamsDoc):
-    summary_type: str = "auto"  # can be "auto", "stuff", "truncate", "map_reduce", "refine"
-    chunk_size: int = -1
-    chunk_overlap: int = -1
-
-
 class LLMParams(BaseDoc):
     model: Optional[str] = None
     max_tokens: int = 1024

--- a/comps/llms/src/doc-summarization/README.md
+++ b/comps/llms/src/doc-summarization/README.md
@@ -115,19 +115,19 @@ If you want to deal with long context, can select suitable summary type, details
 # Enable stream to receive a stream response. By default, this is set to True.
 curl http://${your_ip}:9000/v1/docsum \
   -X POST \
-  -d '{"query":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en"}' \
+  -d '{"messages":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en"}' \
   -H 'Content-Type: application/json'
 
 # Disable stream to receive a non-stream response.
 curl http://${your_ip}:9000/v1/docsum \
   -X POST \
-  -d '{"query":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "stream":false}' \
+  -d '{"messages":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "stream":false}' \
   -H 'Content-Type: application/json'
 
 # Use Chinese mode
 curl http://${your_ip}:9000/v1/docsum \
   -X POST \
-  -d '{"query":"2024年9月26日，北京——今日，英特尔正式发布英特尔® 至强® 6性能核处理器（代号Granite Rapids），为AI、数据分析、科学计算等计算密集型业务提供卓越性能。", "max_tokens":32, "language":"zh", "stream":false}' \
+  -d '{"messages":"2024年9月26日，北京——今日，英特尔正式发布英特尔® 至强® 6性能核处理器（代号Granite Rapids），为AI、数据分析、科学计算等计算密集型业务提供卓越性能。", "max_tokens":32, "language":"zh", "stream":false}' \
   -H 'Content-Type: application/json'
 ```
 
@@ -148,7 +148,7 @@ Truncate mode will truncate the input text and keep only the first chunk, whose 
 ```bash
 curl http://${your_ip}:9000/v1/docsum \
   -X POST \
-  -d '{"query":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "summary_type": "truncate", "chunk_size": 2000}' \
+  -d '{"messages":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "summary_type": "truncate", "chunk_size": 2000}' \
   -H 'Content-Type: application/json'
 ```
 
@@ -161,7 +161,7 @@ In this mode, default `chunk_size` is set to be `min(MAX_TOTAL_TOKENS - input.ma
 ```bash
 curl http://${your_ip}:9000/v1/docsum \
   -X POST \
-  -d '{"query":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "summary_type": "map_reduce", "chunk_size": 2000, "stream":false}' \
+  -d '{"messages":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "summary_type": "map_reduce", "chunk_size": 2000, "stream":false}' \
   -H 'Content-Type: application/json'
 ```
 
@@ -174,6 +174,6 @@ In this mode, default `chunk_size` is set to be `min(MAX_TOTAL_TOKENS - 2 * inpu
 ```bash
 curl http://${your_ip}:9000/v1/docsum \
   -X POST \
-  -d '{"query":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "summary_type": "refine", "chunk_size": 2000}' \
+  -d '{"messages":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "summary_type": "refine", "chunk_size": 2000}' \
   -H 'Content-Type: application/json'
 ```

--- a/comps/llms/src/doc-summarization/integrations/tgi.py
+++ b/comps/llms/src/doc-summarization/integrations/tgi.py
@@ -6,7 +6,8 @@ import os
 import requests
 from langchain_community.llms import HuggingFaceEndpoint
 
-from comps import CustomLogger, DocSumLLMParams, GeneratedDoc, OpeaComponent, OpeaComponentRegistry, ServiceType
+from comps import CustomLogger, GeneratedDoc, OpeaComponent, OpeaComponentRegistry, ServiceType
+from comps.cores.proto.api_protocol import DocSumChatCompletionRequest
 
 from .common import *
 
@@ -47,11 +48,11 @@ class OpeaDocSumTgi(OpeaDocSum):
             logger.error("Health check failed")
             return False
 
-    async def invoke(self, input: DocSumLLMParams):
+    async def invoke(self, input: DocSumChatCompletionRequest):
         """Invokes the TGI LLM service to generate summarization output for the provided input.
 
         Args:
-            input (DocSumLLMParams): The input text(s).
+            input (DocSumChatCompletionRequest): The input text(s).
         """
         server_kwargs = {}
         if self.access_token:
@@ -62,12 +63,12 @@ class OpeaDocSumTgi(OpeaDocSum):
             input.stream = False
         self.client = HuggingFaceEndpoint(
             endpoint_url=self.llm_endpoint,
-            max_new_tokens=input.max_tokens,
-            top_k=input.top_k,
-            top_p=input.top_p,
-            typical_p=input.typical_p,
-            temperature=input.temperature,
-            repetition_penalty=input.repetition_penalty,
+            max_new_tokens=input.max_tokens if input.max_tokens else 1024,
+            top_k=input.top_k if input.top_k else 10,
+            top_p=input.top_p if input.top_p else 0.95,
+            typical_p=input.typical_p if input.typical_p else 0.95,
+            temperature=input.temperature if input.temperature else 0.01,
+            repetition_penalty=input.repetition_penalty if input.repetition_penalty else 1.03,
             streaming=input.stream,
             server_kwargs=server_kwargs,
         )

--- a/comps/llms/src/doc-summarization/integrations/vllm.py
+++ b/comps/llms/src/doc-summarization/integrations/vllm.py
@@ -6,7 +6,8 @@ import os
 import requests
 from langchain_community.llms import VLLMOpenAI
 
-from comps import CustomLogger, DocSumLLMParams, GeneratedDoc, OpeaComponent, OpeaComponentRegistry, ServiceType
+from comps import CustomLogger, GeneratedDoc, OpeaComponent, OpeaComponentRegistry, ServiceType
+from comps.cores.proto.api_protocol import DocSumChatCompletionRequest
 
 from .common import *
 
@@ -40,11 +41,11 @@ class OpeaDocSumvLLM(OpeaDocSum):
             logger.error("Health check failed")
             return False
 
-    async def invoke(self, input: DocSumLLMParams):
+    async def invoke(self, input: DocSumChatCompletionRequest):
         """Invokes the vLLM LLM service to generate summarization output for the provided input.
 
         Args:
-            input (DocSumLLMParams): The input text(s).
+            input (DocSumChatCompletionRequest): The input text(s).
         """
         headers = {}
         if self.access_token:
@@ -58,11 +59,10 @@ class OpeaDocSumvLLM(OpeaDocSum):
             openai_api_base=self.llm_endpoint + "/v1",
             model_name=MODEL_NAME,
             default_headers=headers,
-            max_tokens=input.max_tokens,
-            top_p=input.top_p,
+            max_tokens=input.max_tokens if input.max_tokens else 1024,
+            top_p=input.top_p if input.top_p else 0.95,
             streaming=input.stream,
-            temperature=input.temperature,
-            presence_penalty=input.repetition_penalty,
+            temperature=input.temperature if input.temperature else 0.01,
         )
         result = await self.generate(input, self.client)
 

--- a/comps/llms/src/doc-summarization/opea_docsum_microservice.py
+++ b/comps/llms/src/doc-summarization/opea_docsum_microservice.py
@@ -9,7 +9,6 @@ from integrations.vllm import OpeaDocSumvLLM
 
 from comps import (
     CustomLogger,
-    DocSumLLMParams,
     OpeaComponentLoader,
     ServiceType,
     opea_microservices,
@@ -17,6 +16,7 @@ from comps import (
     register_statistics,
     statistics_dict,
 )
+from comps.cores.proto.api_protocol import DocSumChatCompletionRequest
 
 logger = CustomLogger("llm_docsum")
 logflag = os.getenv("LOGFLAG", False)
@@ -34,7 +34,7 @@ loader = OpeaComponentLoader(llm_component_name, description=f"OPEA LLM DocSum C
     port=9000,
 )
 @register_statistics(names=["opea_service@llm_docsum"])
-async def llm_generate(input: DocSumLLMParams):
+async def llm_generate(input: DocSumChatCompletionRequest):
     start = time.time()
 
     # Log the input if logging is enabled

--- a/comps/llms/src/faq-generation/README.md
+++ b/comps/llms/src/faq-generation/README.md
@@ -98,13 +98,13 @@ curl http://${host_ip}:${FAQ_PORT}/v1/health_check\
 # Set stream to True. Default will be True.
 curl http://${host_ip}:${FAQ_PORT}/v1/faqgen \
   -X POST \
-  -d '{"query":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.","max_tokens": 128}' \
+  -d '{"messages":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.","max_tokens": 128}' \
   -H 'Content-Type: application/json'
 
 # Non-Streaming Response
 # Set stream to False.
 curl http://${host_ip}:${FAQ_PORT}/v1/faqgen \
   -X POST \
-  -d '{"query":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.","max_tokens": 128, "stream":false}' \
+  -d '{"messages":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.","max_tokens": 128, "stream":false}' \
   -H 'Content-Type: application/json'
 ```

--- a/comps/llms/src/faq-generation/integrations/tgi.py
+++ b/comps/llms/src/faq-generation/integrations/tgi.py
@@ -6,7 +6,8 @@ import os
 import requests
 from langchain_community.llms import HuggingFaceEndpoint
 
-from comps import CustomLogger, GeneratedDoc, LLMParamsDoc, OpeaComponent, OpeaComponentRegistry, ServiceType
+from comps import CustomLogger, GeneratedDoc, OpeaComponent, OpeaComponentRegistry, ServiceType
+from comps.cores.proto.api_protocol import ChatCompletionRequest
 
 from .common import *
 
@@ -47,11 +48,11 @@ class OpeaFaqGenTgi(OpeaFaqGen):
             logger.error("Health check failed")
             return False
 
-    async def invoke(self, input: LLMParamsDoc):
+    async def invoke(self, input: ChatCompletionRequest):
         """Invokes the TGI LLM service to generate FAQ output for the provided input.
 
         Args:
-            input (LLMParamsDoc): The input text(s).
+            input (ChatCompletionRequest): The input text(s).
         """
         server_kwargs = {}
         if self.access_token:
@@ -59,12 +60,12 @@ class OpeaFaqGenTgi(OpeaFaqGen):
 
         self.client = HuggingFaceEndpoint(
             endpoint_url=self.llm_endpoint,
-            max_new_tokens=input.max_tokens,
-            top_k=input.top_k,
-            top_p=input.top_p,
-            typical_p=input.typical_p,
-            temperature=input.temperature,
-            repetition_penalty=input.repetition_penalty,
+            max_new_tokens=input.max_tokens if input.max_tokens else 1024,
+            top_k=input.top_k if input.top_k else 10,
+            top_p=input.top_p if input.top_p else 0.95,
+            typical_p=input.typical_p if input.typical_p else 0.95,
+            temperature=input.temperature if input.temperature else 0.01,
+            repetition_penalty=input.repetition_penalty if input.repetition_penalty else 1.03,
             streaming=input.stream,
             server_kwargs=server_kwargs,
         )

--- a/comps/llms/src/faq-generation/integrations/vllm.py
+++ b/comps/llms/src/faq-generation/integrations/vllm.py
@@ -6,7 +6,8 @@ import os
 import requests
 from langchain_community.llms import VLLMOpenAI
 
-from comps import CustomLogger, GeneratedDoc, LLMParamsDoc, OpeaComponent, OpeaComponentRegistry, ServiceType
+from comps import CustomLogger, GeneratedDoc, OpeaComponent, OpeaComponentRegistry, ServiceType
+from comps.cores.proto.api_protocol import ChatCompletionRequest
 
 from .common import *
 
@@ -40,11 +41,11 @@ class OpeaFaqGenvLLM(OpeaFaqGen):
             logger.error("Health check failed")
             return False
 
-    async def invoke(self, input: LLMParamsDoc):
+    async def invoke(self, input: ChatCompletionRequest):
         """Invokes the vLLM LLM service to generate FAQ output for the provided input.
 
         Args:
-            input (LLMParamsDoc): The input text(s).
+            input (ChatCompletionRequest): The input text(s).
         """
         headers = {}
         if self.access_token:
@@ -55,10 +56,10 @@ class OpeaFaqGenvLLM(OpeaFaqGen):
             openai_api_base=self.llm_endpoint + "/v1",
             model_name=MODEL_NAME,
             default_headers=headers,
-            max_tokens=input.max_tokens,
-            top_p=input.top_p,
+            max_tokens=input.max_tokens if input.max_tokens else 1024,
+            top_p=input.top_p if input.top_p else 0.95,
             streaming=input.stream,
-            temperature=input.temperature,
+            temperature=input.temperature if input.temperature else 0.01,
         )
         result = await self.generate(input, self.client)
 

--- a/comps/llms/src/faq-generation/opea_faqgen_microservice.py
+++ b/comps/llms/src/faq-generation/opea_faqgen_microservice.py
@@ -9,7 +9,6 @@ from integrations.vllm import OpeaFaqGenvLLM
 
 from comps import (
     CustomLogger,
-    LLMParamsDoc,
     OpeaComponentLoader,
     ServiceType,
     opea_microservices,
@@ -17,6 +16,7 @@ from comps import (
     register_statistics,
     statistics_dict,
 )
+from comps.cores.proto.api_protocol import ChatCompletionRequest
 
 logger = CustomLogger("llm_faqgen")
 logflag = os.getenv("LOGFLAG", False)
@@ -34,7 +34,7 @@ loader = OpeaComponentLoader(llm_component_name, description=f"OPEA LLM FAQGen C
     port=9000,
 )
 @register_statistics(names=["opea_service@llm_faqgen"])
-async def llm_generate(input: LLMParamsDoc):
+async def llm_generate(input: ChatCompletionRequest):
     start = time.time()
 
     # Log the input if logging is enabled

--- a/comps/llms/src/text-generation/README_native.md
+++ b/comps/llms/src/text-generation/README_native.md
@@ -58,6 +58,6 @@ curl http://${your_ip}:9000/v1/health_check\
 ```bash
 curl http://${your_ip}:9000/v1/chat/completions\
   -X POST \
-  -d '{"query":"What is Deep Learning?"}' \
+  -d '{"messages":"What is Deep Learning?"}' \
   -H 'Content-Type: application/json'
 ```

--- a/tests/llms/test_llms_doc-summarization_tgi.sh
+++ b/tests/llms/test_llms_doc-summarization_tgi.sh
@@ -87,7 +87,7 @@ function validate_microservices() {
         'text' \
         "llm_summarization" \
         "llm-docsum-server" \
-        '{"query": "Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en"}'
+        '{"messages": "Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en"}'
 
     echo "Validate stream=False..."
     validate_services \
@@ -95,7 +95,7 @@ function validate_microservices() {
         'text' \
         "llm_summarization" \
         "llm-docsum-server" \
-        '{"query":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "stream":false}'
+        '{"messages":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "stream":false}'
 
     echo "Validate Chinese mode..."
     validate_services \
@@ -103,7 +103,7 @@ function validate_microservices() {
         'text' \
         "llm_summarization" \
         "llm-docsum-server" \
-        '{"query":"2024年9月26日，北京——今日，英特尔正式发布英特尔® 至强® 6性能核处理器（代号Granite Rapids），为AI、数据分析、科学计算等计算密集型业务提供卓越性能。", "max_tokens":32, "language":"zh", "stream":false}'
+        '{"messages":"2024年9月26日，北京——今日，英特尔正式发布英特尔® 至强® 6性能核处理器（代号Granite Rapids），为AI、数据分析、科学计算等计算密集型业务提供卓越性能。", "max_tokens":32, "language":"zh", "stream":false}'
 
     echo "Validate truncate mode..."
     validate_services \
@@ -111,7 +111,7 @@ function validate_microservices() {
         'text' \
         "llm_summarization" \
         "llm-docsum-server" \
-        '{"query":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "summary_type": "truncate", "chunk_size": 2000}'
+        '{"messages":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "summary_type": "truncate", "chunk_size": 2000}'
 
     echo "Validate map_reduce mode..."
     validate_services \
@@ -119,7 +119,7 @@ function validate_microservices() {
         'text' \
         "llm_summarization" \
         "llm-docsum-server" \
-        '{"query":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "summary_type": "map_reduce", "chunk_size": 2000, "stream":false}'
+        '{"messages":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "summary_type": "map_reduce", "chunk_size": 2000, "stream":false}'
 
     echo "Validate refine mode..."
     validate_services \
@@ -127,7 +127,7 @@ function validate_microservices() {
         'text' \
         "llm_summarization" \
         "llm-docsum-server" \
-        '{"query":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "summary_type": "refine", "chunk_size": 2000}'
+        '{"messages":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "summary_type": "refine", "chunk_size": 2000}'
 }
 
 function stop_docker() {

--- a/tests/llms/test_llms_doc-summarization_tgi_on_intel_hpu.sh
+++ b/tests/llms/test_llms_doc-summarization_tgi_on_intel_hpu.sh
@@ -87,7 +87,7 @@ function validate_microservices() {
         'text' \
         "llm_summarization" \
         "llm-docsum-server" \
-        '{"query": "Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en"}'
+        '{"messages": "Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en"}'
 
     echo "Validate stream=False..."
     validate_services \
@@ -95,7 +95,7 @@ function validate_microservices() {
         'text' \
         "llm_summarization" \
         "llm-docsum-server" \
-        '{"query":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "stream":false}'
+        '{"messages":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "stream":false}'
 
     echo "Validate Chinese mode..."
     validate_services \
@@ -103,7 +103,7 @@ function validate_microservices() {
         'text' \
         "llm_summarization" \
         "llm-docsum-server" \
-        '{"query":"2024年9月26日，北京——今日，英特尔正式发布英特尔® 至强® 6性能核处理器（代号Granite Rapids），为AI、数据分析、科学计算等计算密集型业务提供卓越性能。", "max_tokens":32, "language":"zh", "stream":false}'
+        '{"messages":"2024年9月26日，北京——今日，英特尔正式发布英特尔® 至强® 6性能核处理器（代号Granite Rapids），为AI、数据分析、科学计算等计算密集型业务提供卓越性能。", "max_tokens":32, "language":"zh", "stream":false}'
 
     echo "Validate truncate mode..."
     validate_services \
@@ -111,7 +111,7 @@ function validate_microservices() {
         'text' \
         "llm_summarization" \
         "llm-docsum-server" \
-        '{"query":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "summary_type": "truncate", "chunk_size": 2000}'
+        '{"messages":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "summary_type": "truncate", "chunk_size": 2000}'
 
     echo "Validate map_reduce mode..."
     validate_services \
@@ -119,7 +119,7 @@ function validate_microservices() {
         'text' \
         "llm_summarization" \
         "llm-docsum-server" \
-        '{"query":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "summary_type": "map_reduce", "chunk_size": 2000, "stream":false}'
+        '{"messages":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "summary_type": "map_reduce", "chunk_size": 2000, "stream":false}'
 
     echo "Validate refine mode..."
     validate_services \
@@ -127,7 +127,7 @@ function validate_microservices() {
         'text' \
         "llm_summarization" \
         "llm-docsum-server" \
-        '{"query":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "summary_type": "refine", "chunk_size": 2000}'
+        '{"messages":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "summary_type": "refine", "chunk_size": 2000}'
 }
 
 function stop_docker() {

--- a/tests/llms/test_llms_doc-summarization_vllm_on_intel_hpu.sh
+++ b/tests/llms/test_llms_doc-summarization_vllm_on_intel_hpu.sh
@@ -100,7 +100,7 @@ function validate_microservices() {
         'text' \
         "llm_summarization" \
         "llm-docsum-server" \
-        '{"query": "Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en"}'
+        '{"messages": "Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en"}'
 
     echo "Validate stream=False..."
     validate_services \
@@ -108,7 +108,7 @@ function validate_microservices() {
         'text' \
         "llm_summarization" \
         "llm-docsum-server" \
-        '{"query":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "stream":false}'
+        '{"messages":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "stream":false}'
 
     echo "Validate Chinese mode..."
     validate_services \
@@ -116,7 +116,7 @@ function validate_microservices() {
         'text' \
         "llm_summarization" \
         "llm-docsum-server" \
-        '{"query":"2024年9月26日，北京——今日，英特尔正式发布英特尔® 至强® 6性能核处理器（代号Granite Rapids），为AI、数据分析、科学计算等计算密集型业务提供卓越性能。", "max_tokens":32, "language":"zh", "stream":false}'
+        '{"messages":"2024年9月26日，北京——今日，英特尔正式发布英特尔® 至强® 6性能核处理器（代号Granite Rapids），为AI、数据分析、科学计算等计算密集型业务提供卓越性能。", "max_tokens":32, "language":"zh", "stream":false}'
 
     echo "Validate truncate mode..."
     validate_services \
@@ -124,7 +124,7 @@ function validate_microservices() {
         'text' \
         "llm_summarization" \
         "llm-docsum-server" \
-        '{"query":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "summary_type": "truncate", "chunk_size": 2000}'
+        '{"messages":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "summary_type": "truncate", "chunk_size": 2000}'
 
     echo "Validate map_reduce mode..."
     validate_services \
@@ -132,7 +132,7 @@ function validate_microservices() {
         'text' \
         "llm_summarization" \
         "llm-docsum-server" \
-        '{"query":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "summary_type": "map_reduce", "chunk_size": 2000, "stream":false}'
+        '{"messages":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "summary_type": "map_reduce", "chunk_size": 2000, "stream":false}'
 
     echo "Validate refine mode..."
     validate_services \
@@ -140,7 +140,7 @@ function validate_microservices() {
         'text' \
         "llm_summarization" \
         "llm-docsum-server" \
-        '{"query":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "summary_type": "refine", "chunk_size": 2000}'
+        '{"messages":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.", "max_tokens":32, "language":"en", "summary_type": "refine", "chunk_size": 2000}'
 }
 
 function stop_docker() {

--- a/tests/llms/test_llms_faq-generation_tgi.sh
+++ b/tests/llms/test_llms_faq-generation_tgi.sh
@@ -81,7 +81,7 @@ function validate_backend_microservices() {
         "text" \
         "llm - faqgen" \
         "llm-faqgen-server" \
-        '{"query":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.","max_tokens": 32}'
+        '{"messages":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.","max_tokens": 32}'
 
     # faq, non-stream
     validate_services \
@@ -89,7 +89,7 @@ function validate_backend_microservices() {
         "text" \
         "FAQGen" \
         "llm-faqgen-server" \
-        '{"query":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.","max_tokens": 32, "stream":false}'
+        '{"messages":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.","max_tokens": 32, "stream":false}'
 }
 
 function stop_docker() {

--- a/tests/llms/test_llms_faq-generation_tgi_on_intel_hpu.sh
+++ b/tests/llms/test_llms_faq-generation_tgi_on_intel_hpu.sh
@@ -81,7 +81,7 @@ function validate_backend_microservices() {
         "text" \
         "llm - faqgen" \
         "llm-faqgen-server" \
-        '{"query":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.","max_tokens": 32}'
+        '{"messages":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.","max_tokens": 32}'
 
     # faq, non-stream
     validate_services \
@@ -89,7 +89,7 @@ function validate_backend_microservices() {
         "text" \
         "FAQGen" \
         "llm-faqgen-server" \
-        '{"query":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.","max_tokens": 32, "stream":false}'
+        '{"messages":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.","max_tokens": 32, "stream":false}'
 }
 
 function stop_docker() {

--- a/tests/llms/test_llms_faq-generation_vllm_on_intel_hpu.sh
+++ b/tests/llms/test_llms_faq-generation_vllm_on_intel_hpu.sh
@@ -95,7 +95,7 @@ function validate_backend_microservices() {
         "text" \
         "llm - faqgen" \
         "llm-faqgen-server" \
-        '{"query":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.","max_tokens": 32}'
+        '{"messages":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.","max_tokens": 32}'
 
     # faq, non-stream
     validate_services \
@@ -103,7 +103,7 @@ function validate_backend_microservices() {
         "text" \
         "FAQGen" \
         "llm-faqgen-server" \
-        '{"query":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.","max_tokens": 32, "stream":false}'
+        '{"messages":"Text Embeddings Inference (TEI) is a toolkit for deploying and serving open source text embeddings and sequence classification models. TEI enables high-performance extraction for the most popular models, including FlagEmbedding, Ember, GTE and E5.","max_tokens": 32, "stream":false}'
 }
 
 function stop_docker() {

--- a/tests/llms/test_llms_text-generation_native_on_intel_hpu.sh
+++ b/tests/llms/test_llms_text-generation_native_on_intel_hpu.sh
@@ -49,7 +49,7 @@ function start_service() {
 function validate_microservice() {
     llm_native_service_port=5070
     URL="http://${ip_address}:${llm_native_service_port}/v1/chat/completions"
-    INPUT_DATA='{"query":"What is Deep Learning?"}'
+    INPUT_DATA='{"messages":"What is Deep Learning?"}'
     HTTP_RESPONSE=$(curl --silent --write-out "HTTPSTATUS:%{http_code}" -X POST -d "$INPUT_DATA" -H 'Content-Type: application/json' "$URL")
     HTTP_STATUS=$(echo $HTTP_RESPONSE | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
     RESPONSE_BODY=$(echo $HTTP_RESPONSE | sed -e 's/HTTPSTATUS\:.*//g')


### PR DESCRIPTION
## Description

Algin all the inputs to OpenAI API format for FaqGen, DocSum, TextGen-native, now all the services in llm comps should be OpenAI API compatiable

## Issues

https://github.com/opea-project/GenAIComps/issues/998

## Type of change

List the type of change like below. Please delete options that are not relevant.
- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

no

## Tests

tests/llm/*.sh
