### PR TITLE
Disable telemetry by default

### DIFF
--- a/comps/__init__.py
+++ b/comps/__init__.py
@@ -51,7 +51,7 @@ from comps.cores.mega.orchestrator_with_yaml import ServiceOrchestratorWithYaml
 from comps.cores.mega.micro_service import MicroService, register_microservice, opea_microservices
 
 # Telemetry
-if os.getenv('ENABLE_OPEA_TELEMETRY', 'false').lower() == 'true':
+if os.getenv("ENABLE_OPEA_TELEMETRY", "false").lower() == "true":
     from comps.cores.telemetry.opea_telemetry import opea_telemetry
 
 # Common

--- a/comps/__init__.py
+++ b/comps/__init__.py
@@ -3,6 +3,8 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+import os
+
 # Document
 from comps.cores.proto.docarray import (
     Audio2TextDoc,
@@ -49,7 +51,8 @@ from comps.cores.mega.orchestrator_with_yaml import ServiceOrchestratorWithYaml
 from comps.cores.mega.micro_service import MicroService, register_microservice, opea_microservices
 
 # Telemetry
-from comps.cores.telemetry.opea_telemetry import opea_telemetry
+if os.getenv('ENABLE_OPEA_TELEMETRY', 'false').lower() == 'true':
+    from comps.cores.telemetry.opea_telemetry import opea_telemetry
 
 # Common
 from comps.cores.common.component import OpeaComponent, OpeaComponentRegistry, OpeaComponentLoader


### PR DESCRIPTION
## Description

Disable telemetry by default, if users want to enable telemetry, please pass the env 'ENABLE_OPEA_TELEMETRY' with true.

Many our opea services(e.g. opea/llm-textgen, opea/embedding, opea/reranking, opea/retriever, etc) by default requires a OpenTelemetry trace collector to be in the system. Otherwise, the service will report the [following error](https://gist.github.com/lianhao/6c5e895f3f34fa1ba6b29f3e99432304) every time it process a user request.

## Issues

`n/a`

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

None

## Tests

Local test and CI test.
