### PR TITLE
Fix test_telemetry.py import error

### DIFF
--- a/tests/cores/telemetry/test_telemetry.py
+++ b/tests/cores/telemetry/test_telemetry.py
@@ -5,8 +5,7 @@ import asyncio
 import time
 import unittest
 
-from comps import opea_telemetry
-from comps.cores.telemetry.opea_telemetry import in_memory_exporter
+from comps.cores.telemetry.opea_telemetry import opea_telemetry, in_memory_exporter
 
 
 @opea_telemetry

--- a/tests/cores/telemetry/test_telemetry.py
+++ b/tests/cores/telemetry/test_telemetry.py
@@ -5,7 +5,7 @@ import asyncio
 import time
 import unittest
 
-from comps.cores.telemetry.opea_telemetry import opea_telemetry, in_memory_exporter
+from comps.cores.telemetry.opea_telemetry import in_memory_exporter, opea_telemetry
 
 
 @opea_telemetry


### PR DESCRIPTION
## Description
This PR fixes issue with importing opea_telemetry within `test_telemetry.py`

## Issues
Currently tip of main fails with this:
https://github.com/opea-project/GenAIComps/actions/runs/12836942696/job/35799616804
```
==================================== ERRORS ====================================
___________ ERROR collecting tests/cores/telemetry/test_telemetry.py ___________
ImportError while importing test module '/GenAIComps/tests/cores/telemetry/test_telemetry.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/usr/lib/python3.10/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
telemetry/test_telemetry.py:8: in <module>
    from comps import opea_telemetry
E   ImportError: cannot import name 'opea_telemetry' from 'comps' (/usr/local/lib/python3.10/dist-packages/opea_comps-1.1-py3.10.egg/comps/__init__.py)
```

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [N/A] New feature (non-breaking change which adds new functionality)
- [N/A] Breaking change (fix or feature that would break existing design and interface)
- [N/A] Others (enhancement, documentation, validation, etc.)

## Dependencies
None

## Tests
This attempts to fix a failing unit test.
