### PR TITLE
nginx: Adapt to API changes in dataprep

### DIFF
--- a/comps/third_parties/nginx/src/nginx.conf.template
+++ b/comps/third_parties/nginx/src/nginx.conf.template
@@ -37,7 +37,7 @@ server {
         gzip off;
     }
 
-    location /v1/dataprep {
+    location /v1/dataprep/ingest {
         proxy_pass http://${DATAPREP_SERVICE_IP}:${DATAPREP_SERVICE_PORT};
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -49,7 +49,7 @@ server {
         send_timeout 6000;
     }
 
-    location /v1/dataprep/get_file {
+    location /v1/dataprep/get {
         proxy_pass http://${DATAPREP_SERVICE_IP}:${DATAPREP_SERVICE_PORT};
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -57,7 +57,7 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
-    location /v1/dataprep/delete_file {
+    location /v1/dataprep/delete {
         proxy_pass http://${DATAPREP_SERVICE_IP}:${DATAPREP_SERVICE_PORT};
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;


### PR DESCRIPTION
## Description

Following the dataprep PR #1153, Change according to the following API changes in dataprep:

- change "/v1/dataprep/" to "/v1/dataprep/ingest"
- change "/v1/dataprep/get_file" to "/v1/dataprep/get"
- change "/v1/dataprep/delete_file" to "/v1/dataprep/delete"

## Issues

List the issue or RFC link this PR is working on. If there is no such link, please mark it as `n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
