### PR TITLE
Revert "Fix Workflow Access to id-token for OIDC Auth (#1170)"

### DIFF
--- a/.github/workflows/pr-microservice-test.yml
+++ b/.github/workflows/pr-microservice-test.yml
@@ -18,11 +18,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-# Allow generation of id-token for OIDC auth with AWS
-permissions:
-  id-token: write
-  contents: read
-
 jobs:
   job1:
     uses: ./.github/workflows/_get-test-matrix.yml


### PR DESCRIPTION
This reverts commit b0abbde6073d5b98c6aa6b51f56ca77802bd2704.

## Description

Revert "Fix Workflow Access to id-token for OIDC Auth (#1170)"

## Issues

This PR revert the change that block the microservice CI. 

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
