### PR TITLE
Freeze the triton version in vllm-gaudi image to 3.1.0

### DIFF
--- a/.github/workflows/_comps-workflow.yml
+++ b/.github/workflows/_comps-workflow.yml
@@ -70,8 +70,8 @@ jobs:
               cd ./vllm-openvino && git checkout v0.6.1 && git rev-parse HEAD && cd ../
           fi
           if [[ $(grep -c "vllm-gaudi:" ${docker_compose_yml}) != 0 ]]; then
-               git clone https://github.com/HabanaAI/vllm-fork.git vllm-fork
-               cd vllm-fork && git checkout v0.6.4.post2+Gaudi-1.19.0 && cd ../
+              git clone --depth 1 --branch v0.6.4.post2+Gaudi-1.19.0 https://github.com/HabanaAI/vllm-fork.git
+              sed -i 's/triton/triton==3.1.0/g' vllm-fork/requirements-hpu.txt
           fi
       - name: Get build list
         id: get-build-list

--- a/.github/workflows/push-image-build.yml
+++ b/.github/workflows/push-image-build.yml
@@ -87,8 +87,8 @@ jobs:
               cd ./vllm-openvino && git checkout v0.6.1 && git rev-parse HEAD && cd ../
           fi
           if [[ $(grep -c "vllm-gaudi:" ${docker_compose_path}) != 0 ]]; then
-               git clone https://github.com/HabanaAI/vllm-fork.git vllm-fork
-               cd vllm-fork && git checkout v0.6.4.post2+Gaudi-1.19.0 && cd ../
+              git clone --depth 1 --branch v0.6.4.post2+Gaudi-1.19.0 https://github.com/HabanaAI/vllm-fork.git
+              sed -i 's/triton/triton==3.1.0/g' vllm-fork/requirements-hpu.txt
           fi
 
       - name: Build Image

--- a/.github/workflows/scripts/get_test_matrix.sh
+++ b/.github/workflows/scripts/get_test_matrix.sh
@@ -102,7 +102,7 @@ function find_test_2() {
     test_files=$(printf '%s\n' "${changed_files[@]}" | grep -E "\.sh") || true
     for test_file in ${test_files}; do
         if [ -f $test_file ]; then
-            _service=$(echo $test_file | cut -d'/' -f3 | cut -d'.' -f1 | cut -c6-)
+            _service=$(echo $test_file | cut -d'/' -f3 | grep -E "\.sh" | cut -d'.' -f1 | cut -c6-)
             _fill_in_matrix $_service
         fi
     done

--- a/comps/third_parties/vllm/src/build_docker_vllm.sh
+++ b/comps/third_parties/vllm/src/build_docker_vllm.sh
@@ -38,6 +38,7 @@ if [ "$hw_mode" = "hpu" ]; then
     git clone https://github.com/HabanaAI/vllm-fork.git
     cd ./vllm-fork/
     git checkout v0.6.4.post2+Gaudi-1.19.0
+    sed -i 's/triton/triton==3.1.0/g' requirements-hpu.txt
     docker build -f Dockerfile.hpu -t opea/vllm-gaudi:latest --shm-size=128g . --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy
     cd ..
     rm -rf vllm-fork

--- a/tests/agent/test_agent_langchain_on_intel_hpu.sh
+++ b/tests/agent/test_agent_langchain_on_intel_hpu.sh
@@ -57,6 +57,7 @@ function build_vllm_docker_images() {
     fi
     cd ./vllm-fork
     git checkout v0.6.4.post2+Gaudi-1.19.0
+    sed -i 's/triton/triton==3.1.0/g' requirements-hpu.txt
     docker build --no-cache -f Dockerfile.hpu -t opea/vllm-gaudi:comps --shm-size=128g . --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy
     if [ $? -ne 0 ]; then
         echo "opea/vllm-gaudi:comps failed"

--- a/tests/llms/test_llms_doc-summarization_vllm_on_intel_hpu.sh
+++ b/tests/llms/test_llms_doc-summarization_vllm_on_intel_hpu.sh
@@ -20,6 +20,7 @@ function build_docker_images() {
     git clone https://github.com/HabanaAI/vllm-fork.git
     cd vllm-fork/
     git checkout v0.6.4.post2+Gaudi-1.19.0
+    sed -i 's/triton/triton==3.1.0/g' requirements-hpu.txt
     docker build --no-cache -f Dockerfile.hpu -t ${REGISTRY:-opea}/vllm-gaudi:${TAG:-latest} --shm-size=128g .
     if [ $? -ne 0 ]; then
         echo "opea/vllm-gaudi built fail"

--- a/tests/llms/test_llms_faq-generation_vllm_on_intel_hpu.sh
+++ b/tests/llms/test_llms_faq-generation_vllm_on_intel_hpu.sh
@@ -20,6 +20,7 @@ function build_docker_images() {
     git clone https://github.com/HabanaAI/vllm-fork.git
     cd vllm-fork/
     git checkout v0.6.4.post2+Gaudi-1.19.0
+    sed -i 's/triton/triton==3.1.0/g' requirements-hpu.txt
     docker build --no-cache -f Dockerfile.hpu -t ${REGISTRY:-opea}/vllm-gaudi:${TAG:-latest} --shm-size=128g .
     if [ $? -ne 0 ]; then
         echo "opea/vllm-gaudi built fail"

--- a/tests/llms/test_llms_text-generation_service_vllm_on_intel_hpu.sh
+++ b/tests/llms/test_llms_text-generation_service_vllm_on_intel_hpu.sh
@@ -20,6 +20,7 @@ function build_docker_images() {
     git clone https://github.com/HabanaAI/vllm-fork.git
     cd vllm-fork/
     git checkout v0.6.4.post2+Gaudi-1.19.0
+    sed -i 's/triton/triton==3.1.0/g' requirements-hpu.txt
     docker build --no-cache -f Dockerfile.hpu -t ${REGISTRY:-opea}/vllm-gaudi:${TAG:-latest} --shm-size=128g .
     if [ $? -ne 0 ]; then
         echo "opea/vllm-gaudi built fail"


### PR DESCRIPTION
## Description

The new triton version 3.2.0 can't work with vllm-gaudi. Freeze the triton version in vllm-gaudi image to 3.1.0.

## Issues

Issue create for vllm-fork: https://github.com/HabanaAI/vllm-fork/issues/732

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
