### PR TITLE
Fix port and delete command in multimodal data prep README

### DIFF
--- a/comps/dataprep/src/README_multimodal.md
+++ b/comps/dataprep/src/README_multimodal.md
@@ -94,7 +94,7 @@ docker build -t opea/dataprep-multimodal-redis:latest --build-arg https_proxy=$h
 ### 2.5 Run Docker with CLI (Option A)
 
 ```bash
-docker run -d --name="dataprep-multimodal-redis" -p 6007:6007 --runtime=runc --ipc=host -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e REDIS_URL=$REDIS_URL -e INDEX_NAME=$INDEX_NAME -e LVM_ENDPOINT=$LVM_ENDPOINT -e HUGGINGFACEHUB_API_TOKEN=$HUGGINGFACEHUB_API_TOKEN -e MULTIMODAL_DATAPREP=true -e DATAPREP_COMPONENT_NAME="OPEA_DATAPREP_MULTIMODALREDIS" opea/dataprep-multimodal-redis:latest
+docker run -d --name="dataprep-multimodal-redis" -p 6007:5000 --runtime=runc --ipc=host -e no_proxy=$no_proxy -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e REDIS_HOST=$your_ip -e REDIS_URL=$REDIS_URL -e INDEX_NAME=$INDEX_NAME -e LVM_ENDPOINT=$LVM_ENDPOINT -e HUGGINGFACEHUB_API_TOKEN=$HUGGINGFACEHUB_API_TOKEN -e MULTIMODAL_DATAPREP=true -e DATAPREP_COMPONENT_NAME="OPEA_DATAPREP_MULTIMODALREDIS" opea/dataprep-multimodal-redis:latest
 ```
 
 ### 2.6 Run with Docker Compose (Option B - deprecated, will move to genAIExample in future)
@@ -240,5 +240,6 @@ To delete uploaded files and clear the database, use the following command.
 ```bash
 curl -X POST \
     -H "Content-Type: application/json" \
+    -d '{"file_path": "all"}' \
     http://localhost:6007/v1/dataprep/delete
 ```


### PR DESCRIPTION
## Description

This PR fixes issues in the multimodal data prep README file.

## Issues

Similar to the fix in [GenAIExamples](https://github.com/opea-project/GenAIExamples/pull/1457), the multimodal data prep microservice uses an internal port of 5000 and an external port of 6007. The `README_multimodal.md` needs to port forward the internal 5000 port to 6007 for the other commands to work. 

Also, the delete command in the README fails when a file is not specified:
```
curl -X POST \
    -H "Content-Type: application/json" \
    http://localhost:6007/v1/dataprep/delete
{"detail":[{"type":"missing","loc":["body","file_path"],"msg":"Field required","input":null}]}
```

## Type of change

List the type of change like below. Please delete options that are not relevant.
- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

None

## Tests

Manually tested commands in the README file.
