### PR TITLE
Fix port in the data prep redis README file

### DIFF
--- a/comps/dataprep/src/README_redis.md
+++ b/comps/dataprep/src/README_redis.md
@@ -112,7 +112,7 @@ docker build -t opea/dataprep:latest --build-arg https_proxy=$https_proxy --buil
 ### 2.4 Run Docker with CLI (Option A)
 
 ```bash
-docker run -d --name="dataprep-redis-server" -p 6007:6007 --runtime=runc --ipc=host -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e REDIS_URL=$REDIS_URL -e INDEX_NAME=$INDEX_NAME -e TEI_ENDPOINT=$TEI_ENDPOINT -e HUGGINGFACEHUB_API_TOKEN=$HUGGINGFACEHUB_API_TOKEN opea/dataprep:latest
+docker run -d --name="dataprep-redis-server" -p 6007:5000 --runtime=runc --ipc=host -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e REDIS_URL=$REDIS_URL -e INDEX_NAME=$INDEX_NAME -e TEI_ENDPOINT=$TEI_ENDPOINT -e HUGGINGFACEHUB_API_TOKEN=$HUGGINGFACEHUB_API_TOKEN opea/dataprep:latest
 ```
 
 ### 2.5 Run with Docker Compose (Option B - deprecated, will move to genAIExample in future)


### PR DESCRIPTION
## Description

This PR fixes an issue with the port forwarding parameter in the data prep redis README file. 

## Issues

The microservice logs show that it's internally running on port 5000:
```
INFO:     Application startup complete.
INFO:     Uvicorn running on http://0.0.0.0:5000 (Press CTRL+C to quit)
```
But the `docker run` command was using `-p 6007:6007`, which wasn't working when I was following the instructions in the README. I changed this to `-p 6007:5000` and restarted the data prep container, and that fixed the issue.

The docker compose file already has the correct `5000` port [here](https://github.com/opea-project/GenAIComps/blob/main/comps/dataprep/deployment/docker_compose/compose.yaml#L177).

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

N/A

## Tests

N/A
