### PR TITLE
[Telemetry] use existed env variable instead of introducing new one

### DIFF
--- a/comps/cores/mega/orchestrator.py
+++ b/comps/cores/mega/orchestrator.py
@@ -25,7 +25,7 @@ from .logger import CustomLogger
 
 logger = CustomLogger("comps-core-orchestrator")
 LOGFLAG = os.getenv("LOGFLAG", False)
-ENABLE_OPEA_TELEMETRY = os.getenv("ENABLE_OPEA_TELEMETRY", "false").lower() == "true"
+ENABLE_OPEA_TELEMETRY = bool(os.environ.get("TELEMETRY_ENDPOINT"))
 
 
 class OrchestratorMetrics:

--- a/comps/cores/telemetry/opea_telemetry.py
+++ b/comps/cores/telemetry/opea_telemetry.py
@@ -14,7 +14,9 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-ENABLE_OPEA_TELEMETRY = os.getenv("ENABLE_OPEA_TELEMETRY", "false").lower() == "true"
+from ..mega.logger import CustomLogger
+
+logger = CustomLogger("OpeaComponent")
 
 
 def detach_ignore_err(self, token: object) -> None:
@@ -32,12 +34,17 @@ def detach_ignore_err(self, token: object) -> None:
 # bypass the ValueError that ContextVar context was created in a different Context from StreamingResponse
 ContextVarsRuntimeContext.detach = detach_ignore_err
 
-telemetry_endpoint = os.environ.get("TELEMETRY_ENDPOINT", "http://localhost:4318/v1/traces")
-
 resource = Resource.create({SERVICE_NAME: "opea"})
 traceProvider = TracerProvider(resource=resource)
 
-traceProvider.add_span_processor(BatchSpanProcessor(HTTPSpanExporter(endpoint=telemetry_endpoint)))
+ENABLE_OPEA_TELEMETRY = False
+telemetry_endpoint = os.environ.get("TELEMETRY_ENDPOINT")
+if telemetry_endpoint is not None:
+
+    ENABLE_OPEA_TELEMETRY = True
+    logger.info(f" Has Telemetry Endpoint :  {telemetry_endpoint}")
+    traceProvider.add_span_processor(BatchSpanProcessor(HTTPSpanExporter(endpoint=telemetry_endpoint)))
+
 in_memory_exporter = InMemorySpanExporter()
 traceProvider.add_span_processor(BatchSpanProcessor(in_memory_exporter))
 trace.set_tracer_provider(traceProvider)

--- a/tests/cores/telemetry/test_telemetry.py
+++ b/tests/cores/telemetry/test_telemetry.py
@@ -6,7 +6,7 @@ import os
 import time
 import unittest
 
-os.environ["ENABLE_OPEA_TELEMETRY"] = "True"
+os.environ["TELEMETRY_ENDPOINT"] = "http://jaeger:4318/v1/traces"
 from comps.cores.telemetry.opea_telemetry import in_memory_exporter, opea_telemetry
 
 
@@ -35,7 +35,7 @@ async def dummy_async_func():
 class TestTelemetry(unittest.TestCase):
 
     def tearDown(self):
-        os.environ["ENABLE_OPEA_TELEMETRY"] = "False"
+        os.environ["TELEMETRY_ENDPOINT"] = ""
 
     def test_time_tracing(self):
         dummy_func()


### PR DESCRIPTION
## Description
Remove new environment variable and use existed one to disable/enable telemetry feature 
[PR#1168](https://github.com/opea-project/GenAIComps/pull/1168)

might need to pay attention to no proxy setting to make connection to jaeger successful
export no_proxy=chatqna-xeon-ui-server,chatqna-xeon-backend-server,dataprep-redis-service,tei-embedding-service,retriever,tei-reranking-service,tgi-service,vllm-service,jaeger,172.25.116.82,0.0.0.0,localhost

## Issues

NA

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

no

## Tests

manually testing
