### PR TITLE
Add native support for toxicity detection guardrail microservice

### DIFF
--- a/comps/guardrails/src/toxicity_detection/README.md
+++ b/comps/guardrails/src/toxicity_detection/README.md
@@ -21,6 +21,7 @@ export OPEA_GENAICOMPS_ROOT=$(pwd)/GenAIComps
 ```
 
 Set the port that this service will use and the component name
+
 ```
 export TOXICITY_DETECTION_PORT=9090
 export TOXICITY_DETECTION_COMPONENT_NAME="OPEA_NATIVE_TOXICITY"
@@ -29,12 +30,12 @@ export TOXICITY_DETECTION_COMPONENT_NAME="OPEA_NATIVE_TOXICITY"
 By default, this microservice uses `OPEA_NATIVE_TOXICITY` which invokes [`Intel/toxic-prompt-roberta`](https://huggingface.co/Intel/toxic-prompt-roberta), locally.
 
 Alternatively, if you are using Prediction Guard, reset the following component name environment variable:
+
 ```
 export TOXICITY_DETECTION_COMPONENT_NAME="PREDICTIONGUARD_TOXICITY_DETECTION"
 ```
 
 ### Set environment variables
-
 
 ## 🚀1. Start Microservice with Python（Option 1）
 
@@ -95,7 +96,7 @@ Once microservice starts, users can use examples (bash or python) below to apply
 curl localhost:${TOXICITY_DETECTION_PORT}/v1/toxicity \
     -X POST \
     -d '{"text":"How to poison my neighbor'\''s dog without being caught?"}' \
-    -H 'Content-Type: application/json' 
+    -H 'Content-Type: application/json'
 ```
 
 Example Output:

--- a/comps/guardrails/src/toxicity_detection/integrations/toxicdetection.py
+++ b/comps/guardrails/src/toxicity_detection/integrations/toxicdetection.py
@@ -1,0 +1,46 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import os
+from transformers import pipeline
+
+from comps import CustomLogger, OpeaComponent, OpeaComponentRegistry, ServiceType, TextDoc
+
+logger = CustomLogger("opea_toxicity_native")
+logflag = os.getenv("LOGFLAG", False)
+
+@OpeaComponentRegistry.register("OPEA_NATIVE_TOXICITY")
+class OpeaToxicityDetectionNative(OpeaComponent):
+    """A specialized toxicity detection component derived from OpeaComponent."""
+
+    def __init__(self, name: str, description: str, config: dict = None):
+        super().__init__(name, ServiceType.GUARDRAIL.name.lower(), description, config)
+        self.model = os.getenv("TOXICITY_DETECTION_MODEL", "Intel/toxic-prompt-roberta")
+        self.toxicity_pipeline = pipeline("text-classification", model=self.model, tokenizer=self.model)
+        health_status = self.check_health()
+        if not health_status:
+            logger.error("OpeaToxicityDetectionNative health check failed.")
+
+    async def invoke(self, input: TextDoc):
+        """Invokes the toxic detection for the input.
+
+        Args:
+            input (Input TextDoc)
+        """
+        toxic = await asyncio.to_thread(self.toxicity_pipeline, input.text)
+        if toxic[0]["label"].lower() == "toxic":
+            return TextDoc(text="Violated policies: toxicity, please check your input.", downstream_black_list=[".*"])
+        else:
+            return TextDoc(text=input.text)       
+
+    def check_health(self) -> bool:
+        """Checks the health of the animation service.
+
+        Returns:
+            bool: True if the service is reachable and healthy, False otherwise.
+        """
+        if self.toxicity_pipeline:
+            return True
+        else:
+            return False

--- a/comps/guardrails/src/toxicity_detection/integrations/toxicdetection.py
+++ b/comps/guardrails/src/toxicity_detection/integrations/toxicdetection.py
@@ -3,12 +3,14 @@
 
 import asyncio
 import os
+
 from transformers import pipeline
 
 from comps import CustomLogger, OpeaComponent, OpeaComponentRegistry, ServiceType, TextDoc
 
 logger = CustomLogger("opea_toxicity_native")
 logflag = os.getenv("LOGFLAG", False)
+
 
 @OpeaComponentRegistry.register("OPEA_NATIVE_TOXICITY")
 class OpeaToxicityDetectionNative(OpeaComponent):
@@ -32,7 +34,7 @@ class OpeaToxicityDetectionNative(OpeaComponent):
         if toxic[0]["label"].lower() == "toxic":
             return TextDoc(text="Violated policies: toxicity, please check your input.", downstream_black_list=[".*"])
         else:
-            return TextDoc(text=input.text)       
+            return TextDoc(text=input.text)
 
     def check_health(self) -> bool:
         """Checks the health of the animation service.

--- a/comps/guardrails/src/toxicity_detection/opea_toxicity_detection_microservice.py
+++ b/comps/guardrails/src/toxicity_detection/opea_toxicity_detection_microservice.py
@@ -23,14 +23,14 @@ logflag = os.getenv("LOGFLAG", False)
 toxicity_detection_port = os.getenv("TOXICITY_DETECTION_PORT")
 toxicity_detection_component_name = os.getenv("TOXICITY_DETECTION_COMPONENT_NAME", "OPEA_NATIVE_TOXICITY")
 
-print(f'HELLO:-{toxicity_detection_component_name}-')
-if toxicity_detection_component_name == "OPEA_NATIVE_TOXICITY" :
+print(f"HELLO:-{toxicity_detection_component_name}-")
+if toxicity_detection_component_name == "OPEA_NATIVE_TOXICITY":
     from integrations.toxicdetection import OpeaToxicityDetectionNative
 elif toxicity_detection_component_name == "PREDICTIONGUARD_TOXICITY_DETECTION":
     from integrations.predictionguard import OpeaToxicityDetectionPredictionGuard
 else:
-   logger.error(f"Component name {toxicity_detection_component_name} is not recognized") 
-   exit(1)
+    logger.error(f"Component name {toxicity_detection_component_name} is not recognized")
+    exit(1)
 
 # Initialize OpeaComponentLoader
 loader = OpeaComponentLoader(
@@ -50,7 +50,7 @@ loader = OpeaComponentLoader(
     output_datatype=Union[TextDoc, ScoreDoc],
 )
 @register_statistics(names=["opea_service@toxicity_detection"])
-async def toxicity_guard(input: TextDoc) -> Union[TextDoc, ScoreDoc] :
+async def toxicity_guard(input: TextDoc) -> Union[TextDoc, ScoreDoc]:
     start = time.time()
 
     # Log the input if logging is enabled

--- a/comps/guardrails/src/toxicity_detection/opea_toxicity_detection_microservice.py
+++ b/comps/guardrails/src/toxicity_detection/opea_toxicity_detection_microservice.py
@@ -3,8 +3,7 @@
 
 import os
 import time
-
-from integrations.predictionguard import OpeaToxicityDetectionPredictionGuard
+from typing import Union
 
 from comps import (
     CustomLogger,
@@ -21,7 +20,18 @@ from comps import (
 logger = CustomLogger("opea_toxicity_detection_microservice")
 logflag = os.getenv("LOGFLAG", False)
 
-toxicity_detection_component_name = os.getenv("TOXICITY_DETECTION_COMPONENT_NAME", "PREDICTIONGUARD_TOXICITY_DETECTION")
+toxicity_detection_port = os.getenv("TOXICITY_DETECTION_PORT")
+toxicity_detection_component_name = os.getenv("TOXICITY_DETECTION_COMPONENT_NAME", "OPEA_NATIVE_TOXICITY")
+
+print(f'HELLO:-{toxicity_detection_component_name}-')
+if toxicity_detection_component_name == "OPEA_NATIVE_TOXICITY" :
+    from integrations.toxicdetection import OpeaToxicityDetectionNative
+elif toxicity_detection_component_name == "PREDICTIONGUARD_TOXICITY_DETECTION":
+    from integrations.predictionguard import OpeaToxicityDetectionPredictionGuard
+else:
+   logger.error(f"Component name {toxicity_detection_component_name} is not recognized") 
+   exit(1)
+
 # Initialize OpeaComponentLoader
 loader = OpeaComponentLoader(
     toxicity_detection_component_name,
@@ -35,12 +45,12 @@ loader = OpeaComponentLoader(
     service_type=ServiceType.GUARDRAIL,
     endpoint="/v1/toxicity",
     host="0.0.0.0",
-    port=9090,
+    port=int(toxicity_detection_port),
     input_datatype=TextDoc,
-    output_datatype=ScoreDoc,
+    output_datatype=Union[TextDoc, ScoreDoc],
 )
 @register_statistics(names=["opea_service@toxicity_detection"])
-async def toxicity_guard(input: TextDoc) -> ScoreDoc:
+async def toxicity_guard(input: TextDoc) -> Union[TextDoc, ScoreDoc] :
     start = time.time()
 
     # Log the input if logging is enabled

--- a/tests/guardrails/test_guardrails_toxicity_detection_toxicdetection.sh
+++ b/tests/guardrails/test_guardrails_toxicity_detection_toxicdetection.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+set -x
+
+WORKPATH=$(dirname "$PWD")
+ip_address=$(hostname -I | awk '{print $1}')
+
+function build_docker_images() {
+    echo "Start building docker images for microservice"
+    cd $WORKPATH
+    docker build --no-cache -t opea/guardrails-toxicity-detection:comps --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy -f comps/guardrails/src/toxicity_detection/Dockerfile .
+    if [ $? -ne 0 ]; then
+        echo "opea/guardrails-toxicity-detection built fail"
+        exit 1
+    else
+        echo "opea/guardrails-toxicity-detection built successful"
+    fi
+}
+
+function start_service() {
+    echo "Starting microservice"
+    export toxicity_detection_port=9091
+    docker run -d --runtime=runc --name="test-comps-guardrails-toxicity-detection-endpoint" -p $toxicity_detection_port:$toxicity_detection_port --ipc=host -e TOXICITY_DETECTION_PORT=$toxicity_detection_port -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e no_proxy-$no_proxy opea/guardrails-toxicity-detection:comps
+    sleep 25
+    echo "Microservice started"
+}
+
+function validate_microservice() {
+    echo "Validate microservice started"
+    echo "test 1 - toxic"
+    result=$(curl localhost:9091/v1/toxicity -X POST -d '{"text":"How to poison your neighbor'\''s dog secretly"}' -H 'Content-Type: application/json')
+    if [[ $result == *"Violated"* ]]; then
+        echo "Result correct."
+    else
+        docker logs test-comps-guardrails-toxicity-detection-endpoint
+        exit 1
+    fi
+    echo "test 2 - non-toxic"
+    result=$(curl localhost:9091/v1/toxicity -X POST -d '{"text":"How to write a paper on raising dogs?"}' -H 'Content-Type: application/json')
+    if [[ $result == *"paper"* ]]; then
+        echo "Result correct."
+    else
+        echo "Result wrong."
+        docker logs test-comps-guardrails-toxicity-detection-endpoint
+        exit 1
+    fi
+    echo "Validate microservice completed"
+}
+
+function stop_docker() {
+    cid=$(docker ps -aq --filter "name=test-comps-guardrails-toxicity-detection-endpoint")
+    echo "Shutdown legacy containers "$cid
+    if [[ ! -z "$cid" ]]; then docker stop $cid && docker rm $cid && sleep 1s; fi
+}
+
+function main() {
+
+    stop_docker
+
+    build_docker_images
+    start_service
+
+    validate_microservice
+
+    stop_docker
+    echo "cleanup container images and volumes"
+    echo y | docker system prune 2>&1 > /dev/null
+
+}
+
+main


### PR DESCRIPTION
## Description

Adds back toxic-prompt-roberta as the default native microservice with component name `OPEA_NATIVE_TOXICITY`

## Issues

`n/a`

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

None

## Tests

Ran README manually and toxicity detection test script `test_guardrails_bias_detection_toxicdetection.py`