### PR TITLE
Bug Fix (WIP) - MultimodalQnA for PDF ingestion fails if PDF has only text and don't have any images

### DIFF
--- a/comps/dataprep/src/integrations/redis_multimodal.py
+++ b/comps/dataprep/src/integrations/redis_multimodal.py
@@ -418,7 +418,9 @@ class OpeaMultimodalRedisDataprep(OpeaComponent):
         for item in annotation:
             page_index = item["frame_no"]
             image_index = item.get("sub_video_id", None)
-            path_to_image = os.path.join(path_to_files, f"page{page_index}_image{image_index}.png") if image_index else None
+            path_to_image = (
+                os.path.join(path_to_files, f"page{page_index}_image{image_index}.png") if image_index else None
+            )
             caption_for_ingesting = item["caption"]
             caption_for_inference = item["caption"]
 
@@ -738,7 +740,9 @@ class OpeaMultimodalRedisDataprep(OpeaComponent):
                                 annotations.append(
                                     {
                                         "video_id": file_id,
-                                        "video_name": os.path.basename(os.path.join(self.upload_folder, media_file_name)),
+                                        "video_name": os.path.basename(
+                                            os.path.join(self.upload_folder, media_file_name)
+                                        ),
                                         "b64_img_str": decoded_string,
                                         "caption": text,
                                         "time": 0.0,
@@ -748,14 +752,14 @@ class OpeaMultimodalRedisDataprep(OpeaComponent):
                                 )
                         else:
                             annotations.append(
-                                 {
-                                     "video_id": file_id,
-                                     "video_name": os.path.basename(os.path.join(self.upload_folder, media_file_name)),
-                                     "caption": text,
-                                     "time": 0.0,
-                                     "frame_no": page_idx,
-                                 }
-                             )
+                                {
+                                    "video_id": file_id,
+                                    "video_name": os.path.basename(os.path.join(self.upload_folder, media_file_name)),
+                                    "caption": text,
+                                    "time": 0.0,
+                                    "frame_no": page_idx,
+                                }
+                            )
 
                     with open(os.path.join(output_dir, "annotations.json"), "w") as f:
                         json.dump(annotations, f)


### PR DESCRIPTION
## Description

This was a bug found when experimenting MultimodalQnA UI for uploading PDFs from the UI. It worked for PDFs that have at least one image per page, which is detected by `pymupdf` in the `get_images()` method but failed for PDFs that don't have any images. This PR fixes that issue.

## Issues

`n/a`

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

`n/a`

## Tests

Manually tested for PDFs that have images and don't have images and it worked in both cases.
