### PR TITLE
Fix metric id issue when initializing multiple Orchestrator instances

### DIFF
--- a/comps/cores/mega/orchestrator.py
+++ b/comps/cores/mega/orchestrator.py
@@ -28,15 +28,13 @@ LOGFLAG = os.getenv("LOGFLAG", False)
 
 
 class OrchestratorMetrics:
-    # Need an instance ID for metric prefix because:
-    # - Orchestror instances are not named
-    # - CI creates several orchestrator instances
+    # Need an static class-level ID for metric prefix because:
     # - Prometheus requires metrics (their names) to be unique
     _instance_id = 0
 
     def __init__(self) -> None:
-        self._instance_id += 1
-        if self._instance_id > 1:
+        OrchestratorMetrics._instance_id += 1
+        if OrchestratorMetrics._instance_id > 1:
             self._prefix = f"megaservice{self._instance_id}"
         else:
             self._prefix = "megaservice"


### PR DESCRIPTION

## Description

- Fix the wrong _instance_id handling in https://github.com/opea-project/GenAIComps/pull/1092
- essential for https://github.com/opea-project/GenAIExamples/pull/1528 UT pass

## Issues

as above
## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

na
## Tests

ut