### PR TITLE
Bug Fix neo4j dataprep ingest error handling and skip_ingestion argument passing

### DIFF
--- a/comps/dataprep/deployment/docker_compose/compose.yaml
+++ b/comps/dataprep/deployment/docker_compose/compose.yaml
@@ -86,6 +86,7 @@ services:
       LLM_MODEL_ID: ${LLM_MODEL_ID}
       LOGFLAG: ${LOGFLAG}
       HUGGINGFACEHUB_API_TOKEN: ${HF_TOKEN}
+      HF_TOKEN: ${HF_TOKEN}
     restart: unless-stopped
 
   dataprep-opensearch:

--- a/comps/dataprep/deployment/docker_compose/compose.yaml
+++ b/comps/dataprep/deployment/docker_compose/compose.yaml
@@ -87,6 +87,7 @@ services:
       LOGFLAG: ${LOGFLAG}
       HUGGINGFACEHUB_API_TOKEN: ${HF_TOKEN}
       HF_TOKEN: ${HF_TOKEN}
+      MAX_INPUT_TOKENS: ${MAX_INPUT_TOKENS:-4096}
     restart: unless-stopped
 
   dataprep-opensearch:

--- a/comps/dataprep/src/integrations/elasticsearch.py
+++ b/comps/dataprep/src/integrations/elasticsearch.py
@@ -244,6 +244,7 @@ class OpeaElasticSearchDataprep(OpeaComponent):
         chunk_overlap: int = Form(100),
         process_table: bool = Form(False),
         table_strategy: str = Form("fast"),
+        ingest_from_graphDB: bool = Form(False),
     ):
         """Ingest files/links content into ElasticSearch database.
 

--- a/comps/dataprep/src/integrations/neo4j_llamaindex.py
+++ b/comps/dataprep/src/integrations/neo4j_llamaindex.py
@@ -74,7 +74,7 @@ OPENAI_EMBEDDING_MODEL = os.getenv("OPENAI_EMBEDDING_MODEL", "text-embedding-3-s
 OPENAI_LLM_MODEL = os.getenv("OPENAI_LLM_MODEL", "gpt-4o")
 
 LLM_MODEL_ID = os.getenv("LLM_MODEL_ID", "meta-llama/Meta-Llama-3.1-70B-Instruct")
-MAX_INPUT_LEN = os.getenv("MAX_INPUT_LEN", "8192")
+MAX_INPUT_TOKENS = os.getenv("MAX_INPUT_TOKENS", "8192")
 MAX_OUTPUT_TOKENS = os.getenv("MAX_OUTPUT_TOKENS", "1024")
 
 
@@ -92,7 +92,7 @@ class GraphRAGStore(Neo4jPropertyGraphStore):
     async def generate_community_summary(self, text):
         """Generate summary for a given text using an LLM."""
         model_name = LLM_MODEL_ID
-        max_input_length = int(MAX_INPUT_LEN)
+        max_input_length = int(MAX_INPUT_TOKENS)
         if not model_name or not max_input_length:
             raise ValueError(f"Could not retrieve model information from TGI endpoint: {TGI_LLM_ENDPOINT}")
 

--- a/comps/dataprep/src/integrations/opensearch.py
+++ b/comps/dataprep/src/integrations/opensearch.py
@@ -327,6 +327,7 @@ class OpeaOpenSearchDataprep(OpeaComponent):
         chunk_overlap: int = Form(100),
         process_table: bool = Form(False),
         table_strategy: str = Form("fast"),
+        ingest_from_graphDB: bool = Form(False),
     ):
         """Ingest files/links content into opensearch database.
 

--- a/comps/dataprep/src/integrations/pgvect.py
+++ b/comps/dataprep/src/integrations/pgvect.py
@@ -250,6 +250,7 @@ class OpeaPgvectorDataprep(OpeaComponent):
         chunk_overlap: int = Form(100),
         process_table: bool = Form(False),
         table_strategy: str = Form("fast"),
+        ingest_from_graphDB: bool = Form(False),
     ):
         """Ingest files/links content into pgvector database.
 

--- a/comps/dataprep/src/integrations/pipecone.py
+++ b/comps/dataprep/src/integrations/pipecone.py
@@ -236,6 +236,7 @@ class OpeaPineConeDataprep(OpeaComponent):
         chunk_overlap: int = Form(100),
         process_table: bool = Form(False),
         table_strategy: str = Form("fast"),
+        ingest_from_graphDB: bool = Form(False),
     ):
         """Ingest files/links content into pipecone database.
 

--- a/comps/dataprep/src/integrations/qdrant.py
+++ b/comps/dataprep/src/integrations/qdrant.py
@@ -158,6 +158,7 @@ class OpeaQdrantDataprep(OpeaComponent):
         chunk_overlap: int = Form(100),
         process_table: bool = Form(False),
         table_strategy: str = Form("fast"),
+        ingest_from_graphDB: bool = Form(False),
     ):
         """Ingest files/links content into qdrant database.
 

--- a/comps/dataprep/src/integrations/redis.py
+++ b/comps/dataprep/src/integrations/redis.py
@@ -348,6 +348,7 @@ class OpeaRedisDataprep(OpeaComponent):
         chunk_overlap: int = Form(100),
         process_table: bool = Form(False),
         table_strategy: str = Form("fast"),
+        ingest_from_graphDB: bool = Form(False),
     ):
         """Ingest files/links content into redis database.
 

--- a/comps/dataprep/src/integrations/vdms.py
+++ b/comps/dataprep/src/integrations/vdms.py
@@ -151,6 +151,7 @@ class OpeaVdmsDataprep(OpeaComponent):
         chunk_overlap: int = Form(100),
         process_table: bool = Form(False),
         table_strategy: str = Form("fast"),
+        ingest_from_graphDB: bool = Form(False),
     ):
         """Ingest files/links content into VDMS database.
 

--- a/comps/dataprep/src/opea_dataprep_microservice.py
+++ b/comps/dataprep/src/opea_dataprep_microservice.py
@@ -65,7 +65,9 @@ async def ingest_files(
 
     try:
         # Use the loader to invoke the component
-        response = await loader.ingest_files(files, link_list, chunk_size, chunk_overlap, process_table, table_strategy, ingest_from_graphDB)
+        response = await loader.ingest_files(
+            files, link_list, chunk_size, chunk_overlap, process_table, table_strategy, ingest_from_graphDB
+        )
         # Log the result if logging is enabled
         if logflag:
             logger.info(f"[ ingest ] Output generated: {response}")

--- a/comps/dataprep/src/opea_dataprep_microservice.py
+++ b/comps/dataprep/src/opea_dataprep_microservice.py
@@ -55,6 +55,7 @@ async def ingest_files(
     chunk_overlap: int = Form(100),
     process_table: bool = Form(False),
     table_strategy: str = Form("fast"),
+    ingest_from_graphDB: bool = Form(False),
 ):
     start = time.time()
 
@@ -64,7 +65,7 @@ async def ingest_files(
 
     try:
         # Use the loader to invoke the component
-        response = await loader.ingest_files(files, link_list, chunk_size, chunk_overlap, process_table, table_strategy)
+        response = await loader.ingest_files(files, link_list, chunk_size, chunk_overlap, process_table, table_strategy, ingest_from_graphDB)
         # Log the result if logging is enabled
         if logflag:
             logger.info(f"[ ingest ] Output generated: {response}")

--- a/tests/dataprep/test_dataprep_neo4j_on_intel_hpu.sh
+++ b/tests/dataprep/test_dataprep_neo4j_on_intel_hpu.sh
@@ -42,6 +42,8 @@ function start_service() {
     export TEI_EMBEDDING_ENDPOINT="http://${ip_address}:${TEI_EMBEDDER_PORT}"
     export LLM_ENDPOINT_PORT=10510
     export TGI_LLM_ENDPOINT="http://${ip_address}:${LLM_ENDPOINT_PORT}"
+    export MAX_INPUT_TOKENS=4096
+    export MAX_TOTAL_TOKENS=8192
 
     cd $WORKPATH/comps/dataprep/deployment/docker_compose/
     docker compose up ${service_name} -d


### PR DESCRIPTION

-Fix error handling bug in dataprep/ingest which was returning 200 despite error 
-Renamed "skip_ingestion" argument to "ingest_from_graphDB" for clarity
-Fix parameter handling from opea_dataprep_microservice to neo4j integration. skip_ingestion was undefined causing it to execute the if skip_ingestion condition 
-Ingest_from_graphDB is a feature that skips the file ingestion and creation of graph and jumps directly to clustering and summarization which is part of dataprep (Neo4j dataprep follows Microsoft GraphRAG data preparation steps). Graph extraction is a computationally expensive step users may want to skip after the fist time through. 

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)


