### PR TITLE
Dataprep Multimodal Redis README fixes

### DIFF
--- a/comps/dataprep/src/README_multimodal.md
+++ b/comps/dataprep/src/README_multimodal.md
@@ -88,7 +88,7 @@ export HUGGINGFACEHUB_API_TOKEN=${your_hf_api_token}
 
 ```bash
 cd ../../../../
-docker build -t opea/dataprep-multimodal-redis:latest --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy -f comps/dataprep/src/Dockerfile .
+docker build -t opea/dataprep:latest --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy -f comps/dataprep/src/Dockerfile .
 ```
 
 ### 2.5 Run Docker with CLI (Option A)
@@ -116,7 +116,7 @@ Once this dataprep microservice is started, user can use the below commands to i
 
 This microservice provides 3 different ways for users to ingest files into Redis vector store corresponding to the 3 use cases.
 
-### 4.1 Consume _ingest_with_text_ API
+### 4.1 Consume _ingest_ API
 
 **Use case:** This API is used for videos accompanied by transcript files (`.vtt` format), images accompanied by text caption files (`.txt` format), and PDF files containing a mix of text and images.
 


### PR DESCRIPTION
## Description

This updates the data prep README to fix a couple of issues:
* Fix the name of the docker image name in the build command to match what is used after the [data prep refactor](https://github.com/opea-project/GenAIExamples/pull/1408/files#diff-1d1cfced259dada6f277c25da44cbaea85aa3629b3ce3fb54780c4525a9a3896R147).
* Also in the [data prep refactor](https://github.com/opea-project/GenAIComps/pull/1153/files#diff-d4c7a3a55e0854cbe262901ca8bc6519a662ee5138cea3cf8d5d9f1d27cad870L136-R136), the endpoint was changed from `ingest_with_text` to `data_prep/ingest`, but the heading in was not updated.

## Issues

N/A

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

None

## Tests

None
