### PR TITLE
Megaservice / orchestrator metric testing + fixes

### DIFF
--- a/comps/cores/mega/orchestrator.py
+++ b/comps/cores/mega/orchestrator.py
@@ -302,10 +302,11 @@ class ServiceOrchestrator(DAG):
                                         res_txt, token_start, is_first=is_first, is_last=is_last
                                     )
                                     token_start = time.time()
+                                    is_first = False
                             else:
                                 token_start = self.metrics.token_update(token_start, is_first)
+                                is_first = False
                                 yield chunk
-                            is_first = False
 
                     self.metrics.request_update(req_start)
                     self.metrics.pending_update(False)
@@ -380,5 +381,6 @@ class ServiceOrchestrator(DAG):
         for token in tokens:
             token_start = self.metrics.token_update(token_start, is_first)
             yield prefix + repr(token.replace("\\n", "\n").encode("utf-8")) + suffix
+            is_first = False
         if is_last:
             yield "data: [DONE]\n\n"

--- a/tests/cores/mega/test_service_orchestrator_streaming.py
+++ b/tests/cores/mega/test_service_orchestrator_streaming.py
@@ -6,9 +6,13 @@ import multiprocessing
 import time
 import unittest
 
+import requests
 from fastapi.responses import StreamingResponse
+from prometheus_client import start_http_server
 
 from comps import ServiceOrchestrator, ServiceType, TextDoc, opea_microservices, register_microservice
+
+_METRIC_PORT = 8000
 
 
 @register_microservice(name="s1", host="0.0.0.0", port=8083, endpoint="/v1/add")
@@ -46,8 +50,11 @@ class TestServiceOrchestratorStreaming(unittest.IsolatedAsyncioTestCase):
 
         cls.service_builder = ServiceOrchestrator()
 
-        cls.service_builder.add(opea_microservices["s0"]).add(opea_microservices["s1"])
+        cls.service_builder.add(cls.s0).add(cls.s1)
         cls.service_builder.flow_to(cls.s0, cls.s1)
+
+        # requires prometheus_client >= 0.20.0 (earlier versions return None)
+        cls.server, cls.thread = start_http_server(_METRIC_PORT)
 
     @classmethod
     def tearDownClass(cls):
@@ -55,6 +62,9 @@ class TestServiceOrchestratorStreaming(unittest.IsolatedAsyncioTestCase):
         cls.s1.stop()
         cls.process1.terminate()
         cls.process2.terminate()
+
+        cls.server.shutdown()
+        cls.thread.join()
 
     async def test_schedule(self):
         result_dict, _ = await self.service_builder.schedule(initial_inputs={"text": "hello, "})
@@ -66,6 +76,35 @@ class TestServiceOrchestratorStreaming(unittest.IsolatedAsyncioTestCase):
             idx += 1
         token_count = len(res_expected)
         self.assertEqual(idx, token_count)
+
+        r = requests.get(f"http://localhost:{_METRIC_PORT}/metrics", timeout=5)
+        self.assertEqual(r.status_code, 200)
+        lines = r.text.splitlines()
+
+        metrics = {}
+        for line in lines:
+            if line.startswith("mega") and "_count" in line:
+                items = line.split()
+                self.assertTrue(len(items), 2)
+                name, value = items
+
+                self.assertTrue(name.startswith("megaservice_"))
+                self.assertTrue(name.endswith("_count"))
+                metrics[name] = int(float(value))
+        print(metrics)
+
+        # After request is processed:
+        # - first tokens count should be equal to request count
+        # - inter tokens count should not include first token
+        # However, above schedule() call does not appear to work properly
+        correct = {
+            "megaservice_request_latency_count": 1,
+            "megaservice_first_token_latency_count": 0,
+            "megaservice_inter_token_latency_count": token_count,  # -1
+        }
+        for name, value in correct.items():
+            self.assertTrue(name in metrics)
+            self.assertEqual(metrics[name], value)
 
     def test_extract_chunk_str(self):
         res = self.service_builder.extract_chunk_str("data: [DONE]\n\n")

--- a/tests/cores/mega/test_service_orchestrator_streaming.py
+++ b/tests/cores/mega/test_service_orchestrator_streaming.py
@@ -64,6 +64,8 @@ class TestServiceOrchestratorStreaming(unittest.IsolatedAsyncioTestCase):
         async for k in response.__reduce__()[2]["body_iterator"]:
             self.assertEqual(self.service_builder.extract_chunk_str(k).strip(), res_expected[idx])
             idx += 1
+        token_count = len(res_expected)
+        self.assertEqual(idx, token_count)
 
     def test_extract_chunk_str(self):
         res = self.service_builder.extract_chunk_str("data: [DONE]\n\n")

--- a/tests/cores/mega/test_service_orchestrator_streaming.py
+++ b/tests/cores/mega/test_service_orchestrator_streaming.py
@@ -96,11 +96,10 @@ class TestServiceOrchestratorStreaming(unittest.IsolatedAsyncioTestCase):
         # After request is processed:
         # - first tokens count should be equal to request count
         # - inter tokens count should not include first token
-        # However, above schedule() call does not appear to work properly
         correct = {
             "megaservice_request_latency_count": 1,
-            "megaservice_first_token_latency_count": 0,
-            "megaservice_inter_token_latency_count": token_count,  # -1
+            "megaservice_first_token_latency_count": 1,
+            "megaservice_inter_token_latency_count": token_count - 1,
         }
         for name, value in correct.items():
             self.assertTrue(name in metrics)


### PR DESCRIPTION
## Description

Adds test code for `orchestrator.py` metrics, and fixes for bugs revealed by the test code.

## Issues fixed

* CI does not verify that orchestrator actually produces any streamed tokens (only that what it produces, is correct)
* First token count was wrong in some situations
* CI was missing tests for orchestrator metrics

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Others (added test code)

## Dependencies

`n/a`

## Tests

* Manual testing with ChatQnA
* New CI test