### PR TITLE
bridgetower/clip: add missing dependency for aiohttp

### DIFF
--- a/comps/third_parties/bridgetower/src/requirements.txt
+++ b/comps/third_parties/bridgetower/src/requirements.txt
@@ -1,3 +1,4 @@
+aiohttp
 docarray[full]
 fastapi
 huggingface_hub

--- a/comps/third_parties/clip/src/requirements.txt
+++ b/comps/third_parties/clip/src/requirements.txt
@@ -1,3 +1,4 @@
+aiohttp
 dateparser
 docarray[full]
 einops


### PR DESCRIPTION
## Description

bridgetower/clip: add missing dependency for aiohttp.

## Issues

Fixes #1370

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
