### PR TITLE
Fix docker compose command in the embedding BridgeTower README

### DIFF
--- a/comps/third_parties/bridgetower/src/README.md
+++ b/comps/third_parties/bridgetower/src/README.md
@@ -27,7 +27,7 @@ export EMBEDDER_PORT=8080
 cd ../../../../../../../
 docker build -t opea/embedding-multimodal-bridgetower-gaudi:latest --build-arg EMBEDDER_PORT=$EMBEDDER_PORT --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy -f comps/third_parties/bridgetower/src/Dockerfile.intel_hpu .
 cd comps/third_parties/bridgetower/deployment/docker_compose/
-docker compose -f compose_intel_hpu.yaml up -d
+docker compose -f compose.yaml up -d multimodal-bridgetower-embedding-gaudi-serving
 ```
 
 ## 🚀2. Start MMEI on Xeon CPU
@@ -41,7 +41,7 @@ export EMBEDDER_PORT=8080
 cd ../../../../../../../
 docker build -t opea/embedding-multimodal-bridgetower:latest --build-arg EMBEDDER_PORT=$EMBEDDER_PORT --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy -f comps/third_parties/bridgetower/src/Dockerfile .
 cd comps/third_parties/bridgetower/deployment/docker_compose/
-docker compose -f compose_intel_cpu.yaml up -d
+docker compose -f compose.yaml up -d multimodal-bridgetower-embedding-serving
 ```
 
 ## 🚀3. Access the service


### PR DESCRIPTION
## Description

This PR fixes a documentation bug in the `docker compose up` command in the BridgeTower embedding service README file.

## Issues

The README was incorrectly saying to use `compose_intel_hpu.yaml` and `compose_intel_cpu.yaml` files, which don't exist in the repo.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

None

## Tests

Tested the README commands for both Xeon and Gaudi.
