### PR TITLE
Refine Dataprep Redis with Async Issue

### DIFF
--- a/comps/dataprep/src/integrations/redis.py
+++ b/comps/dataprep/src/integrations/redis.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from typing import List, Optional, Union
 
 import redis
+import asyncio
+from redis import asyncio as aioredis
 from fastapi import Body, File, Form, HTTPException, UploadFile
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_community.embeddings import HuggingFaceBgeEmbeddings, HuggingFaceInferenceAPIEmbeddings
@@ -100,11 +102,11 @@ REDIS_URL = format_redis_conn_from_env()
 redis_pool = redis.ConnectionPool.from_url(REDIS_URL)
 
 
-def check_index_existance(client):
+async def check_index_existance(client):
     if logflag:
         logger.info(f"[ check index existence ] checking {client}")
     try:
-        results = client.search("*")
+        results = await client.search("*")
         if logflag:
             logger.info(f"[ check index existence ] index of client exists: {client}")
         return results
@@ -114,12 +116,12 @@ def check_index_existance(client):
         return None
 
 
-def create_index(client, index_name: str = KEY_INDEX_NAME):
+async def create_index(client, index_name: str = KEY_INDEX_NAME):
     if logflag:
         logger.info(f"[ create index ] creating index {index_name}")
     try:
         definition = IndexDefinition(index_type=IndexType.HASH, prefix=["file:"])
-        client.create_index((TextField("file_name"), TextField("key_ids")), definition=definition)
+        await client.create_index((TextField("file_name"), TextField("key_ids")), definition=definition)
         if logflag:
             logger.info(f"[ create index ] index {index_name} successfully created")
     except Exception as e:
@@ -129,11 +131,11 @@ def create_index(client, index_name: str = KEY_INDEX_NAME):
     return True
 
 
-def store_by_id(client, key, value):
+async def store_by_id(client, key, value):
     if logflag:
         logger.info(f"[ store by id ] storing ids of {key}")
     try:
-        client.add_document(doc_id="file:" + key, file_name=key, key_ids=value)
+        await client.add_document(doc_id="file:" + key, file_name=key, key_ids=value)
         if logflag:
             logger.info(f"[ store by id ] store document success. id: file:{key}")
     except Exception as e:
@@ -183,31 +185,9 @@ def delete_by_id(client, id):
     return True
 
 
-def ingest_chunks_to_redis(file_name: str, chunks: List):
+async def ingest_chunks_to_redis(file_name: str, chunks: List, embedder):
     if logflag:
         logger.info(f"[ redis ingest chunks ] file name: {file_name}")
-    # Create vectorstore
-    if TEI_EMBEDDING_ENDPOINT:
-        if not HUGGINGFACEHUB_API_TOKEN:
-            raise HTTPException(
-                status_code=400,
-                detail="You MUST offer the `HUGGINGFACEHUB_API_TOKEN` when using `TEI_EMBEDDING_ENDPOINT`.",
-            )
-        import requests
-
-        response = requests.get(TEI_EMBEDDING_ENDPOINT + "/info")
-        if response.status_code != 200:
-            raise HTTPException(
-                status_code=400, detail=f"TEI embedding endpoint {TEI_EMBEDDING_ENDPOINT} is not available."
-            )
-        model_id = response.json()["model_id"]
-        # create embeddings using TEI endpoint service
-        embedder = HuggingFaceInferenceAPIEmbeddings(
-            api_key=HUGGINGFACEHUB_API_TOKEN, model_name=model_id, api_url=TEI_EMBEDDING_ENDPOINT
-        )
-    else:
-        # create embeddings using local embedding model
-        embedder = HuggingFaceBgeEmbeddings(model_name=EMBED_MODEL)
 
     # Batch size
     batch_size = 32
@@ -220,7 +200,8 @@ def ingest_chunks_to_redis(file_name: str, chunks: List):
         batch_chunks = chunks[i : i + batch_size]
         batch_texts = batch_chunks
 
-        _, keys = Redis.from_texts_return_keys(
+        _, keys = await asyncio.to_thread(
+            Redis.from_texts_return_keys,
             texts=batch_texts,
             embedding=embedder,
             index_name=INDEX_NAME,
@@ -233,13 +214,13 @@ def ingest_chunks_to_redis(file_name: str, chunks: List):
             logger.info(f"[ redis ingest chunks ] Processed batch {i//batch_size + 1}/{(num_chunks-1)//batch_size + 1}")
 
     # store file_ids into index file-keys
-    r = redis.Redis(connection_pool=redis_pool)
+    r = await aioredis.from_url(REDIS_URL)
     client = r.ft(KEY_INDEX_NAME)
-    if not check_index_existance(client):
-        assert create_index(client)
+    if not await check_index_existance(client):
+        await create_index(client)
 
     try:
-        assert store_by_id(client, key=file_name, value="#".join(file_ids))
+        await store_by_id(client, key=file_name, value="#".join(file_ids))
     except Exception as e:
         if logflag:
             logger.info(f"[ redis ingest chunks ] {e}. Fail to store chunks of file {file_name}.")
@@ -247,7 +228,7 @@ def ingest_chunks_to_redis(file_name: str, chunks: List):
     return True
 
 
-async def ingest_data_to_redis(doc_path: DocPath):
+async def ingest_data_to_redis(doc_path: DocPath, embedder):
     """Ingest document to Redis."""
     path = doc_path.path
     if logflag:
@@ -278,7 +259,7 @@ async def ingest_data_to_redis(doc_path: DocPath):
     if ext in structured_types:
         chunks = content
     else:
-        chunks = text_splitter.split_text(content)
+        chunks = await asyncio.to_thread(text_splitter.split_text, content)
 
     ### Specially processing for the table content in PDFs
     if doc_path.process_table and path.endswith(".pdf"):
@@ -288,7 +269,7 @@ async def ingest_data_to_redis(doc_path: DocPath):
         logger.info(f"[ redis ingest data ] Done preprocessing. Created {len(chunks)} chunks of the given file.")
 
     file_name = doc_path.path.split("/")[-1]
-    return ingest_chunks_to_redis(file_name, chunks)
+    return await ingest_chunks_to_redis(file_name, chunks, embedder)
 
 
 @OpeaComponentRegistry.register("OPEA_DATAPREP_REDIS")
@@ -301,26 +282,53 @@ class OpeaRedisDataprep(OpeaComponent):
 
     def __init__(self, name: str, description: str, config: dict = None):
         super().__init__(name, ServiceType.DATAPREP.name.lower(), description, config)
-        self.client = self._initialize_client()
-        self.data_index_client = self.client.ft(INDEX_NAME)
-        self.key_index_client = self.client.ft(KEY_INDEX_NAME)
+        self.client = redis.Redis(connection_pool=redis_pool)
+        self.data_index_client, self.key_index_client = asyncio.run(self._initialize_client())
+        self.embedder = asyncio.run(self._initialize_embedder())
         health_status = self.check_health()
         if not health_status:
             logger.error("OpeaRedisDataprep health check failed.")
 
-    def _initialize_client(self) -> redis.Redis:
+    async def _initialize_client(self) -> redis.Redis:
         if logflag:
             logger.info("[ initialize client ] initializing redis client...")
 
         """Initializes the redis client."""
         try:
-            client = redis.Redis(connection_pool=redis_pool)
-            return client
+            client = await aioredis.from_url(REDIS_URL)
+            data_index_client = client.ft(INDEX_NAME)
+            key_index_client = client.ft(KEY_INDEX_NAME)
+            return data_index_client, key_index_client
         except Exception as e:
             logger.error(f"fail to initialize redis client: {e}")
             return None
 
-    def check_health(self) -> bool:
+    async def _initialize_embedder(self):
+        if TEI_EMBEDDING_ENDPOINT:
+            if not HUGGINGFACEHUB_API_TOKEN:
+                raise HTTPException(
+                    status_code=400,
+                    detail="You MUST offer the `HUGGINGFACEHUB_API_TOKEN` when using `TEI_EMBEDDING_ENDPOINT`.",
+                )
+
+            import httpx
+            async with httpx.AsyncClient() as client:
+                response = await client.get(TEI_EMBEDDING_ENDPOINT + "/info")
+                if response.status_code != 200:
+                    raise HTTPException(
+                        status_code=400, detail=f"TEI embedding endpoint {TEI_EMBEDDING_ENDPOINT} is not available."
+                    )
+                model_id = response.json()["model_id"]
+            # create embeddings using TEI endpoint service
+            embedder = HuggingFaceInferenceAPIEmbeddings(
+                api_key=HUGGINGFACEHUB_API_TOKEN, model_name=model_id, api_url=TEI_EMBEDDING_ENDPOINT
+            )
+        else:
+            # create embeddings using local embedding model
+            embedder = HuggingFaceBgeEmbeddings(model_name=EMBED_MODEL)
+        return embedder
+
+    async def check_health(self) -> bool:
         """Checks the health of the dataprep service.
 
         Returns:
@@ -400,7 +408,8 @@ class OpeaRedisDataprep(OpeaComponent):
                         chunk_overlap=chunk_overlap,
                         process_table=process_table,
                         table_strategy=table_strategy,
-                    )
+                    ),
+                    self.embedder
                 )
                 uploaded_files.append(save_path)
                 if logflag:
@@ -444,7 +453,8 @@ class OpeaRedisDataprep(OpeaComponent):
                         chunk_overlap=chunk_overlap,
                         process_table=process_table,
                         table_strategy=table_strategy,
-                    )
+                    ),
+                    self.embedder
                 )
             if logflag:
                 logger.info(f"[ redis ingest] Successfully saved link list {link_list}")
@@ -468,7 +478,7 @@ class OpeaRedisDataprep(OpeaComponent):
         file_list = []
 
         # check index existence
-        res = check_index_existance(self.key_index_client)
+        res = await check_index_existance(self.key_index_client)
         if not res:
             if logflag:
                 logger.info(f"[ redis get ] index {KEY_INDEX_NAME} does not exist")
@@ -506,7 +516,7 @@ class OpeaRedisDataprep(OpeaComponent):
                 logger.info("[ redis delete ] delete all files")
 
             # drop index KEY_INDEX_NAME
-            if check_index_existance(self.key_index_client):
+            if await check_index_existance(self.key_index_client):
                 try:
                     assert drop_index(index_name=KEY_INDEX_NAME)
                 except Exception as e:
@@ -517,7 +527,7 @@ class OpeaRedisDataprep(OpeaComponent):
                 logger.info(f"[ redis delete ] Index {KEY_INDEX_NAME} does not exits.")
 
             # drop index INDEX_NAME
-            if check_index_existance(self.data_index_client):
+            if await check_index_existance(self.data_index_client):
                 try:
                     assert drop_index(index_name=INDEX_NAME)
                 except Exception as e:

--- a/comps/dataprep/src/integrations/redis.py
+++ b/comps/dataprep/src/integrations/redis.py
@@ -3,19 +3,19 @@
 # for test
 
 
+import asyncio
 import json
 import os
 from pathlib import Path
 from typing import List, Optional, Union
 
 import redis
-import asyncio
-from redis import asyncio as aioredis
 from fastapi import Body, File, Form, HTTPException, UploadFile
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_community.embeddings import HuggingFaceBgeEmbeddings, HuggingFaceInferenceAPIEmbeddings
 from langchain_community.vectorstores import Redis
 from langchain_text_splitters import HTMLHeaderTextSplitter
+from redis import asyncio as aioredis
 from redis.commands.search.field import TextField
 from redis.commands.search.indexDefinition import IndexDefinition, IndexType
 
@@ -312,6 +312,7 @@ class OpeaRedisDataprep(OpeaComponent):
                 )
 
             import httpx
+
             async with httpx.AsyncClient() as client:
                 response = await client.get(TEI_EMBEDDING_ENDPOINT + "/info")
                 if response.status_code != 200:
@@ -409,7 +410,7 @@ class OpeaRedisDataprep(OpeaComponent):
                         process_table=process_table,
                         table_strategy=table_strategy,
                     ),
-                    self.embedder
+                    self.embedder,
                 )
                 uploaded_files.append(save_path)
                 if logflag:
@@ -454,7 +455,7 @@ class OpeaRedisDataprep(OpeaComponent):
                         process_table=process_table,
                         table_strategy=table_strategy,
                     ),
-                    self.embedder
+                    self.embedder,
                 )
             if logflag:
                 logger.info(f"[ redis ingest] Successfully saved link list {link_list}")

--- a/comps/dataprep/src/utils.py
+++ b/comps/dataprep/src/utils.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import base64
 import errno
 import functools
@@ -13,8 +14,6 @@ import signal
 import subprocess
 import tempfile
 import timeit
-import aiofiles
-import asyncio
 import unicodedata
 import urllib.parse
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -22,6 +21,7 @@ from pathlib import Path
 from typing import Dict, List, Union
 from urllib.parse import urlparse, urlunparse
 
+import aiofiles
 import aiohttp
 import cairosvg
 import cv2

--- a/comps/dataprep/src/utils.py
+++ b/comps/dataprep/src/utils.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-import asyncio
 import base64
 import errno
 import functools
@@ -14,6 +13,8 @@ import signal
 import subprocess
 import tempfile
 import timeit
+import aiofiles
+import asyncio
 import unicodedata
 import urllib.parse
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -21,7 +22,6 @@ from pathlib import Path
 from typing import Dict, List, Union
 from urllib.parse import urlparse, urlunparse
 
-import aiofiles
 import aiohttp
 import cairosvg
 import cv2
@@ -163,11 +163,13 @@ def load_html(html_path):
     return content
 
 
-def load_txt(txt_path):
-    """Load txt file."""
-    with open(txt_path, "r") as file:
-        text = file.read()
-    return text
+async def load_txt(txt_path):
+    """Asynchronously stream a large text file in chunks."""
+    text = []
+    async with aiofiles.open(txt_path, "r", encoding="utf-8") as file:
+        async for line in file:
+            text.append(line)
+    return "".join(text)
 
 
 async def load_doc(doc_path):
@@ -195,7 +197,7 @@ async def load_doc(doc_path):
 
 async def load_docx(docx_path):
     """Load docx file."""
-    doc = docx.Document(docx_path)
+    doc = await asyncio.to_thread(docx.Document, docx_path)
     text = ""
     # Save all 'rId:filenames' relationships in an dictionary and save the images if any.
     rid2img = {}
@@ -204,19 +206,27 @@ async def load_docx(docx_path):
             rid2img[r.rId] = os.path.basename(r._target.partname)
     if rid2img:
         save_path = tempfile.mkdtemp()
-        docx2txt.process(docx_path, save_path)
+        await asyncio.to_thread(docx2txt.process, docx_path, save_path)
+    
+    text_chunks = []
+    image_tasks = []
     for paragraph in doc.paragraphs:
         if hasattr(paragraph, "text"):
-            text += paragraph.text + "\n"
+            text_chunks.append(paragraph.text + "\n")
         if "graphicData" in paragraph._p.xml:
             for rid in rid2img:
                 if rid in paragraph._p.xml:
                     img_path = os.path.join(save_path, rid2img[rid])
-                    img_text = await load_image(img_path)
-                    if img_text:
-                        text += img_text + "\n"
+                    image_tasks.append(load_image(img_path))
+    image_texts = await asyncio.gather(*image_tasks)
+
+    for img_text in image_texts:
+        if img_text:
+            text_chunks.append(img_text + "\n")
+    text = "".join(text_chunks)
+    
     if rid2img:
-        shutil.rmtree(save_path)
+        await asyncio.to_thread(shutil.rmtree, save_path)
     return text
 
 
@@ -272,77 +282,91 @@ async def load_pptx(pptx_path):
     return text
 
 
-def load_md(md_path):
-    """Load md file."""
-    loader = UnstructuredMarkdownLoader(md_path)
-    text = loader.load()[0].page_content
-    return text
+async def load_md(md_path):
+    """Asynchronously load and process Markdown file."""
+    def process_md():
+        loader = UnstructuredMarkdownLoader(md_path)
+        return loader.load()[0].page_content
+
+    return await asyncio.to_thread(process_md)
 
 
-def load_xml(xml_path):
-    """Load xml file."""
-    loader = UnstructuredXMLLoader(xml_path)
-    text = loader.load()[0].page_content
-    return text
+async def load_xml(xml_path):
+    """Asynchronously load and process XML file."""
+    def process_xml():
+        loader = UnstructuredXMLLoader(xml_path)
+        return loader.load()[0].page_content
+
+    return await asyncio.to_thread(process_xml)
 
 
-def load_json(json_path):
-    """Load and process json file."""
-    with open(json_path, "r") as file:
-        data = json.load(file)
-    content_list = [json.dumps(item) for item in data]
-    return content_list
+async def load_json(json_path):
+    """Asynchronously load and process JSON file."""
+    async with aiofiles.open(json_path, "r", encoding="utf-8") as file:
+        content = await file.read()
+    data = json.loads(content)
+    return [json.dumps(item) for item in data]
 
 
-def load_jsonl(jsonl_path):
-    """Load and process jsonl file."""
+async def load_jsonl(jsonl_path):
+    """Asynchronously load and process JSONL file line by line."""
     content_list = []
-    with open(jsonl_path, "r") as file:
-        for line in file:
+    async with aiofiles.open(jsonl_path, "r", encoding="utf-8") as file:
+        async for line in file:
             json_obj = json.loads(line)
             content_list.append(json_obj)
     return content_list
 
 
-def load_yaml(yaml_path):
-    """Load and process yaml file."""
-    with open(yaml_path, "r") as file:
-        data = yaml.safe_load(file)
+async def load_yaml(yaml_path):
+    """Asynchronously load and process YAML file."""
+    async with aiofiles.open(yaml_path, "r", encoding="utf-8") as file:
+        content = await file.read()
+    data = yaml.safe_load(content)
     return yaml.dump(data)
 
 
-def load_xlsx(input_path):
-    """Load and process xlsx file."""
-    df = pd.read_excel(input_path)
-    content_list = df.apply(lambda row: ", ".join(row.astype(str)), axis=1).tolist()
-    return content_list
+async def load_xlsx(input_path):
+    """Asynchronously load and process an xlsx file."""
+    def process_xlsx():
+        df = pd.read_excel(input_path)
+        return df.apply(lambda row: ", ".join(row.astype(str)), axis=1).tolist()
+
+    return await asyncio.to_thread(process_xlsx)
 
 
-def load_csv(input_path):
-    """Load the csv file."""
-    df = pd.read_csv(input_path)
-    content_list = df.apply(lambda row: ", ".join(row.astype(str)), axis=1).tolist()
-    return content_list
+async def load_csv(input_path):
+    """Asynchronously load and process CSV file."""
+    def process_csv():
+        df = pd.read_csv(input_path)
+        return df.apply(lambda row: ", ".join(row.astype(str)), axis=1).tolist()
+
+    return await asyncio.to_thread(process_csv)
 
 
 async def load_image(image_path):
     """Load the image file."""
+    async def read_image_async(image_path):
+        return await asyncio.to_thread(lambda: open(image_path, "rb").read())
+    
     if os.getenv("SUMMARIZE_IMAGE_VIA_LVM", None) == "1":
         query = "Please summarize this image."
-        image_b64_str = base64.b64encode(open(image_path, "rb").read()).decode()
+        image_b64_str = base64.b64encode(await read_image_async(image_path)).decode()
         async with aiohttp.ClientSession() as session:
-            response = await session.post(
+            async with session.post(
                 url="http://localhost:9399/v1/lvm",
-                data=json.dumps({"image": image_b64_str, "prompt": query}),
+                json={"image": image_b64_str, "prompt": query},
                 headers={"Content-Type": "application/json"},
-                proxy=None,
-            )
-
-            json_data = await response.json()
+            ) as response:
+                json_data = await response.json()
         return json_data["text"].strip()
-    loader = UnstructuredImageLoader(image_path)
-    text = loader.load()[0].page_content
-    return text.strip()
+    
+    def load_text_from_image():
+        loader = UnstructuredImageLoader(image_path)
+        return loader.load()[0].page_content.strip()
+    
+    text = await asyncio.to_thread(load_text_from_image)
+    return text
 
 
 async def load_svg(svg_path):
@@ -360,7 +384,7 @@ async def document_loader(doc_path):
     elif doc_path.endswith(".html"):
         return load_html(doc_path)
     elif doc_path.endswith(".txt"):
-        return load_txt(doc_path)
+        return await load_txt(doc_path)
     elif doc_path.endswith(".doc"):
         return await load_doc(doc_path)
     elif doc_path.endswith(".docx"):
@@ -370,19 +394,19 @@ async def document_loader(doc_path):
     elif doc_path.endswith(".pptx"):
         return await load_pptx(doc_path)
     elif doc_path.endswith(".md"):
-        return load_md(doc_path)
+        return await load_md(doc_path)
     elif doc_path.endswith(".xml"):
-        return load_xml(doc_path)
+        return await load_xml(doc_path)
     elif doc_path.endswith(".json"):
-        return load_json(doc_path)
+        return await load_json(doc_path)
     elif doc_path.endswith(".jsonl"):
-        return load_jsonl(doc_path)
+        return await load_jsonl(doc_path)
     elif doc_path.endswith(".yaml"):
-        return load_yaml(doc_path)
+        return await load_yaml(doc_path)
     elif doc_path.endswith(".xlsx") or doc_path.endswith(".xls"):
-        return load_xlsx(doc_path)
+        return await load_xlsx(doc_path)
     elif doc_path.endswith(".csv"):
-        return load_csv(doc_path)
+        return await load_csv(doc_path)
     elif (
         doc_path.endswith(".tiff")
         or doc_path.endswith(".jpg")


### PR DESCRIPTION

## Description

Refine dataprep `redis.py` functions from sync to async to avoid blocking of async health check process.
Initialize embedder once when initializing Dataprep instance, instead of create embeder whenever ingesting data.
Refine utils of `load_pdf` and `save_content_to_local_disk` from sync to async.

## Issues

https://github.com/opea-project/GenAIComps/issues/1385

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

None

## Tests

Local tested
