### PR TITLE
Fix dependency issue in Retriever

### DIFF
--- a/comps/retrievers/src/requirements.txt
+++ b/comps/retrievers/src/requirements.txt
@@ -1,3 +1,4 @@
+aiofiles
 bs4
 cairosvg
 docarray[full]


### PR DESCRIPTION
## Description

Add `aiofiles` in requirements.txt of retriever, which is caused by cross-component function call of retriever neo4j.

## Issues

Fixes #1392

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

Add `aiofiles`

## Tests

Describe the tests that you ran to verify your changes.
