### PR TITLE
Fix failing data prep milvus multimodal tests that use the LVM

### DIFF
--- a/tests/dataprep/test_dataprep_milvus_multimodal.sh
+++ b/tests/dataprep/test_dataprep_milvus_multimodal.sh
@@ -60,7 +60,7 @@ function start_lvm_service() {
     unset http_proxy
     docker run -d --name="test-comps-lvm-llava" -e http_proxy=$http_proxy -e https_proxy=$https_proxy -p 5029:8399 --ipc=host opea/lvm-llava:comps
     sleep 4m
-    docker run -d --name="test-comps-lvm-llava-svc" -e LVM_ENDPOINT=http://$ip_address:5029 -e http_proxy=$http_proxy -e https_proxy=$https_proxy -p ${LVM_PORT}:9399 --ipc=host opea/lvm:comps
+    docker run -d --name="test-comps-lvm-llava-svc" -e LVM_COMPONENT_NAME=OPEA_LLAVA_LVM -e LVM_ENDPOINT=http://$ip_address:5029 -e http_proxy=$http_proxy -e https_proxy=$https_proxy -p ${LVM_PORT}:9399 --ipc=host opea/lvm:comps
     sleep 1m
 }
 


### PR DESCRIPTION
## Description

The same issue that I fixed in the redis multimodal tests in PR #1440 is also happening in the Milvus multimodal test. 

Background: [PR 1362](https://github.com/opea-project/GenAIComps/pull/1362/files#diff-d0e095d7e805e3984c37992788f9b50ff95363841be369f8637212a7e3719970R33) changes the default LVM component from `OPEA_LLAVA_LVM` to `OPEA_VLLM_LVM`. Since the start up of the LVM microservice in the data prep Milvus multimodal tests were not specifying a `LVM_COMPONENT_NAME`, it's defaulting to vLLM and calls to the LVM endpoint are not working.

## Issues

An example of the test failing can be seen [here](https://github.com/opea-project/GenAIComps/actions/runs/13995319401/job/39188942297?pr=1433).

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

None

## Tests

This is a test fix.
