### PR TITLE
Fix Deprecation warnings in logs service logs

### DIFF
--- a/comps/dataprep/src/integrations/elasticsearch.py
+++ b/comps/dataprep/src/integrations/elasticsearch.py
@@ -10,6 +10,7 @@ from elasticsearch import Elasticsearch
 from fastapi import Body, File, Form, HTTPException, UploadFile
 from langchain.text_splitter import HTMLHeaderTextSplitter, RecursiveCharacterTextSplitter
 from langchain_community.embeddings import HuggingFaceBgeEmbeddings, HuggingFaceInferenceAPIEmbeddings
+from langchain_huggingface import HuggingFaceEmbeddings
 from langchain_core.documents import Document
 from langchain_elasticsearch import ElasticsearchStore
 
@@ -78,7 +79,7 @@ class OpeaElasticSearchDataprep(OpeaComponent):
         if not self.es_client.indices.exists(index=INDEX_NAME):
             self.es_client.indices.create(index=INDEX_NAME)
 
-    def get_embedder(self) -> Union[HuggingFaceInferenceAPIEmbeddings, HuggingFaceBgeEmbeddings]:
+    def get_embedder(self) -> Union[HuggingFaceInferenceAPIEmbeddings, HuggingFaceEmbeddings]:
         """Obtain required Embedder."""
         if TEI_EMBEDDING_ENDPOINT:
             if not HUGGINGFACEHUB_API_TOKEN:
@@ -99,10 +100,10 @@ class OpeaElasticSearchDataprep(OpeaComponent):
             )
             return embedder
         else:
-            return HuggingFaceBgeEmbeddings(model_name=EMBED_MODEL)
+            return HuggingFaceEmbeddings(model_name=EMBED_MODEL)
 
     def get_elastic_store(
-        self, embedder: Union[HuggingFaceInferenceAPIEmbeddings, HuggingFaceBgeEmbeddings]
+        self, embedder: Union[HuggingFaceInferenceAPIEmbeddings, HuggingFaceEmbeddings]
     ) -> ElasticsearchStore:
         """Get Elasticsearch vector store."""
         return ElasticsearchStore(index_name=INDEX_NAME, embedding=embedder, es_connection=self.es_client)

--- a/comps/dataprep/src/integrations/milvus.py
+++ b/comps/dataprep/src/integrations/milvus.py
@@ -12,6 +12,7 @@ from fastapi import Body, File, Form, HTTPException, UploadFile
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_community.embeddings import HuggingFaceBgeEmbeddings, HuggingFaceInferenceAPIEmbeddings, OpenAIEmbeddings
 from langchain_core.documents import Document
+from langchain_huggingface import HuggingFaceEmbeddings
 from langchain_milvus.vectorstores import Milvus
 from langchain_text_splitters import HTMLHeaderTextSplitter
 
@@ -213,7 +214,7 @@ class OpeaMilvusDataprep(OpeaComponent):
             # create embeddings using local embedding model
             if logflag:
                 logger.info(f"[ milvus embedding ] LOCAL_EMBEDDING_MODEL:{LOCAL_EMBEDDING_MODEL}")
-            embeddings = HuggingFaceBgeEmbeddings(model_name=LOCAL_EMBEDDING_MODEL)
+            embeddings = HuggingFaceEmbeddings(model_name=LOCAL_EMBEDDING_MODEL)
         return embeddings
 
     def check_health(self) -> bool:

--- a/comps/dataprep/src/integrations/opensearch.py
+++ b/comps/dataprep/src/integrations/opensearch.py
@@ -9,6 +9,7 @@ from fastapi import Body, File, Form, HTTPException, UploadFile
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_community.embeddings import HuggingFaceBgeEmbeddings, HuggingFaceInferenceAPIEmbeddings
 from langchain_community.vectorstores import OpenSearchVectorSearch
+from langchain_huggingface import HuggingFaceEmbeddings
 from langchain_text_splitters import HTMLHeaderTextSplitter
 from opensearchpy import OpenSearch
 
@@ -99,7 +100,7 @@ class OpeaOpenSearchDataprep(OpeaComponent):
                 api_key=HUGGINGFACEHUB_API_TOKEN, model_name=model_id, api_url=TEI_EMBEDDING_ENDPOINT
             )
         else:
-            self.embeddings = HuggingFaceBgeEmbeddings(model_name=Config.EMBED_MODEL)
+            self.embeddings = HuggingFaceEmbeddings(model_name=Config.EMBED_MODEL)
 
         # OpenSearch client setup
         self.auth = ("admin", Config.OPENSEARCH_INITIAL_ADMIN_PASSWORD)

--- a/comps/dataprep/src/integrations/pgvect.py
+++ b/comps/dataprep/src/integrations/pgvect.py
@@ -12,6 +12,7 @@ from fastapi import Body, File, Form, HTTPException, UploadFile
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_community.embeddings import HuggingFaceBgeEmbeddings, HuggingFaceInferenceAPIEmbeddings
 from langchain_community.vectorstores import PGVector
+from langchain_huggingface import HuggingFaceEmbeddings
 
 from comps import CustomLogger, DocPath, OpeaComponent, OpeaComponentRegistry, ServiceType
 from comps.dataprep.src.utils import (
@@ -73,7 +74,7 @@ class OpeaPgvectorDataprep(OpeaComponent):
             )
         else:
             # create embeddings using local embedding model
-            self.embedder = HuggingFaceBgeEmbeddings(model_name=EMBED_MODEL)
+            self.embedder = HuggingFaceEmbeddings(model_name=EMBED_MODEL)
 
         # Perform health check
         health_status = self.check_health()

--- a/comps/dataprep/src/integrations/pipecone.py
+++ b/comps/dataprep/src/integrations/pipecone.py
@@ -10,6 +10,7 @@ from fastapi import Body, File, Form, HTTPException, UploadFile
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_community.embeddings import HuggingFaceBgeEmbeddings, HuggingFaceInferenceAPIEmbeddings
 from langchain_pinecone import PineconeVectorStore
+from langchain_huggingface import HuggingFaceEmbeddings
 from langchain_text_splitters import HTMLHeaderTextSplitter
 from pinecone import Pinecone, ServerlessSpec
 
@@ -72,7 +73,7 @@ class OpeaPineConeDataprep(OpeaComponent):
             )
         else:
             # create embeddings using local embedding model
-            self.embedder = HuggingFaceBgeEmbeddings(model_name=EMBED_MODEL)
+            self.embedder = HuggingFaceEmbeddings(model_name=EMBED_MODEL)
         self.pc = Pinecone(api_key=PINECONE_API_KEY)
 
         # Perform health check

--- a/comps/dataprep/src/integrations/qdrant.py
+++ b/comps/dataprep/src/integrations/qdrant.py
@@ -9,6 +9,7 @@ from fastapi import Body, File, Form, HTTPException, UploadFile
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_community.embeddings import HuggingFaceBgeEmbeddings, HuggingFaceInferenceAPIEmbeddings
 from langchain_community.vectorstores import Qdrant
+from langchain_huggingface import HuggingFaceEmbeddings
 from langchain_text_splitters import HTMLHeaderTextSplitter
 from qdrant_client import QdrantClient
 
@@ -70,7 +71,7 @@ class OpeaQdrantDataprep(OpeaComponent):
             )
         else:
             # create embeddings using local embedding model
-            self.embedder = HuggingFaceBgeEmbeddings(model_name=EMBED_MODEL)
+            self.embedder = HuggingFaceEmbeddings(model_name=EMBED_MODEL)
 
         # Perform health check
         health_status = self.check_health()

--- a/comps/dataprep/src/integrations/redis.py
+++ b/comps/dataprep/src/integrations/redis.py
@@ -13,6 +13,7 @@ import redis
 from fastapi import Body, File, Form, HTTPException, UploadFile
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_community.embeddings import HuggingFaceBgeEmbeddings, HuggingFaceInferenceAPIEmbeddings
+from langchain_huggingface import HuggingFaceEmbeddings
 from langchain_community.vectorstores import Redis
 from langchain_text_splitters import HTMLHeaderTextSplitter
 from redis import asyncio as aioredis
@@ -326,7 +327,7 @@ class OpeaRedisDataprep(OpeaComponent):
             )
         else:
             # create embeddings using local embedding model
-            embedder = HuggingFaceBgeEmbeddings(model_name=EMBED_MODEL)
+            embedder = HuggingFaceEmbeddings(model_name=EMBED_MODEL)
         return embedder
 
     async def check_health(self) -> bool:

--- a/comps/dataprep/src/integrations/redis.py
+++ b/comps/dataprep/src/integrations/redis.py
@@ -13,8 +13,8 @@ import redis
 from fastapi import Body, File, Form, HTTPException, UploadFile
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_community.embeddings import HuggingFaceBgeEmbeddings, HuggingFaceInferenceAPIEmbeddings
-from langchain_huggingface import HuggingFaceEmbeddings
 from langchain_community.vectorstores import Redis
+from langchain_huggingface import HuggingFaceEmbeddings
 from langchain_text_splitters import HTMLHeaderTextSplitter
 from redis import asyncio as aioredis
 from redis.commands.search.field import TextField

--- a/comps/dataprep/src/integrations/utils/redis_finance_utils.py
+++ b/comps/dataprep/src/integrations/utils/redis_finance_utils.py
@@ -9,6 +9,7 @@ from docling.document_converter import DocumentConverter
 from fastapi import HTTPException
 from langchain_community.embeddings import HuggingFaceBgeEmbeddings
 from langchain_core.documents import Document
+from langchain_huggingface import HuggingFaceEmbeddings
 from langchain_huggingface import HuggingFaceEndpointEmbeddings
 from langchain_redis import RedisConfig, RedisVectorStore
 from openai import OpenAI
@@ -47,7 +48,7 @@ def get_embedder():
         embedder = HuggingFaceEndpointEmbeddings(model=TEI_EMBEDDING_ENDPOINT)
     else:
         # create embeddings using local embedding model
-        embedder = HuggingFaceBgeEmbeddings(model_name=EMBED_MODEL)
+        embedder = HuggingFaceEmbeddings(model_name=EMBED_MODEL)
     return embedder
 
 

--- a/comps/dataprep/src/integrations/vdms.py
+++ b/comps/dataprep/src/integrations/vdms.py
@@ -8,6 +8,7 @@ from typing import List, Optional, Union
 from fastapi import Body, File, Form, HTTPException, UploadFile
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_community.embeddings import HuggingFaceBgeEmbeddings, HuggingFaceInferenceAPIEmbeddings
+from langchain_huggingface import HuggingFaceEmbeddings
 from langchain_community.vectorstores.vdms import VDMS, VDMS_Client
 from langchain_text_splitters import HTMLHeaderTextSplitter
 
@@ -83,7 +84,7 @@ class OpeaVdmsDataprep(OpeaComponent):
             )
         else:
             # create embeddings using local embedding model
-            self.embedder = HuggingFaceBgeEmbeddings(model_name=EMBED_MODEL)
+            self.embedder = HuggingFaceEmbeddings(model_name=EMBED_MODEL)
 
         # Perform health check
         health_status = self.check_health()

--- a/comps/retrievers/src/integrations/elasticsearch.py
+++ b/comps/retrievers/src/integrations/elasticsearch.py
@@ -8,6 +8,7 @@ from elasticsearch import Elasticsearch
 from fastapi import HTTPException
 from langchain_community.embeddings import HuggingFaceBgeEmbeddings, HuggingFaceInferenceAPIEmbeddings
 from langchain_elasticsearch import ElasticsearchStore
+from langchain_huggingface import HuggingFaceEmbeddings
 
 from comps import CustomLogger, EmbedDoc, OpeaComponent, OpeaComponentRegistry, ServiceType
 
@@ -61,7 +62,7 @@ class OpeaElasticsearchRetriever(OpeaComponent):
             # create embeddings using local embedding model
             if logflag:
                 logger.info(f"[ init embedder ] LOCAL_EMBEDDING_MODEL:{EMBED_MODEL}")
-            embeddings = HuggingFaceBgeEmbeddings(model_name=EMBED_MODEL)
+            embeddings = HuggingFaceEmbeddings(model_name=EMBED_MODEL)
         return embeddings
 
     def _initialize_client(self) -> Elasticsearch:

--- a/comps/retrievers/src/integrations/milvus.py
+++ b/comps/retrievers/src/integrations/milvus.py
@@ -7,6 +7,7 @@ import os
 from fastapi import HTTPException
 from langchain_community.embeddings import HuggingFaceBgeEmbeddings, HuggingFaceInferenceAPIEmbeddings
 from langchain_milvus.vectorstores import Milvus
+from langchain_huggingface import HuggingFaceEmbeddings
 
 from comps import CustomLogger, EmbedDoc, OpeaComponent, OpeaComponentRegistry, ServiceType
 
@@ -64,7 +65,7 @@ class OpeaMilvusRetriever(OpeaComponent):
             # create embeddings using local embedding model
             if logflag:
                 logger.info(f"[ init embedder ] LOCAL_EMBEDDING_MODEL:{LOCAL_EMBEDDING_MODEL}")
-            embeddings = HuggingFaceBgeEmbeddings(model_name=LOCAL_EMBEDDING_MODEL)
+            embeddings = HuggingFaceEmbeddings(model_name=LOCAL_EMBEDDING_MODEL)
         return embeddings
 
     def _initialize_client(self) -> Milvus:

--- a/comps/retrievers/src/integrations/opensearch.py
+++ b/comps/retrievers/src/integrations/opensearch.py
@@ -9,6 +9,7 @@ import numpy as np
 from fastapi import HTTPException
 from langchain_community.embeddings import HuggingFaceBgeEmbeddings, HuggingFaceInferenceAPIEmbeddings
 from langchain_community.vectorstores import OpenSearchVectorSearch
+from langchain_huggingface import HuggingFaceEmbeddings
 from pydantic import conlist
 
 from comps import CustomLogger, EmbedDoc, OpeaComponent, OpeaComponentRegistry, ServiceType
@@ -71,7 +72,7 @@ class OpeaOpensearchRetriever(OpeaComponent):
             # create embeddings using local embedding model
             if logflag:
                 logger.info(f"[ init embedder ] LOCAL_EMBEDDING_MODEL:{EMBED_MODEL}")
-            embeddings = HuggingFaceBgeEmbeddings(model_name=EMBED_MODEL)
+            embeddings = HuggingFaceEmbeddings(model_name=EMBED_MODEL)
         return embeddings
 
     def _initialize_client(self):

--- a/comps/retrievers/src/integrations/pgvector.py
+++ b/comps/retrievers/src/integrations/pgvector.py
@@ -7,6 +7,7 @@ import os
 from fastapi import HTTPException
 from langchain_community.embeddings import HuggingFaceBgeEmbeddings, HuggingFaceInferenceAPIEmbeddings
 from langchain_community.vectorstores import PGVector
+from langchain_huggingface import HuggingFaceEmbeddings
 
 from comps import CustomLogger, EmbedDoc, OpeaComponent, OpeaComponentRegistry, ServiceType
 
@@ -60,7 +61,7 @@ class OpeaPGVectorRetriever(OpeaComponent):
             # create embeddings using local embedding model
             if logflag:
                 logger.info(f"[ init embedder ] LOCAL_EMBEDDING_MODEL:{EMBED_MODEL}")
-            embeddings = HuggingFaceBgeEmbeddings(model_name=EMBED_MODEL)
+            embeddings = HuggingFaceEmbeddings(model_name=EMBED_MODEL)
         return embeddings
 
     def _initialize_client(self) -> PGVector:

--- a/comps/retrievers/src/integrations/pinecone.py
+++ b/comps/retrievers/src/integrations/pinecone.py
@@ -8,6 +8,7 @@ import time
 from fastapi import HTTPException
 from langchain_community.embeddings import HuggingFaceBgeEmbeddings, HuggingFaceInferenceAPIEmbeddings
 from langchain_pinecone import PineconeVectorStore
+from langchain_huggingface import HuggingFaceEmbeddings
 from pinecone import Pinecone, ServerlessSpec
 
 from comps import CustomLogger, EmbedDoc, OpeaComponent, OpeaComponentRegistry, ServiceType
@@ -62,7 +63,7 @@ class OpeaPineconeRetriever(OpeaComponent):
             # create embeddings using local embedding model
             if logflag:
                 logger.info(f"[ init embedder ] LOCAL_EMBEDDING_MODEL:{EMBED_MODEL}")
-            embeddings = HuggingFaceBgeEmbeddings(model_name=EMBED_MODEL)
+            embeddings = HuggingFaceEmbeddings(model_name=EMBED_MODEL)
         return embeddings
 
     def _initialize_client(self) -> Pinecone:

--- a/comps/retrievers/src/integrations/redis.py
+++ b/comps/retrievers/src/integrations/redis.py
@@ -48,9 +48,9 @@ class OpeaRedisRetriever(OpeaComponent):
             self.embeddings = BridgeTowerEmbedding()
         else:
             # create embeddings using local embedding model
-            from langchain_community.embeddings import HuggingFaceBgeEmbeddings
+            from langchain_community.embeddings import HuggingFaceEmbeddings
 
-            self.embeddings = HuggingFaceBgeEmbeddings(model_name=EMBED_MODEL)
+            self.embeddings = HuggingFaceEmbeddings(model_name=EMBED_MODEL)
         self.client = self._initialize_client()
         health_status = self.check_health()
         if not health_status:

--- a/comps/retrievers/src/integrations/vdms.py
+++ b/comps/retrievers/src/integrations/vdms.py
@@ -7,6 +7,7 @@ import os
 from fastapi import HTTPException
 from langchain_community.embeddings import HuggingFaceBgeEmbeddings, HuggingFaceInferenceAPIEmbeddings
 from langchain_community.vectorstores.vdms import VDMS, VDMS_Client
+from langchain_huggingface import HuggingFaceEmbeddings
 
 from comps import CustomLogger, EmbedDoc, OpeaComponent, OpeaComponentRegistry, ServiceType
 
@@ -73,7 +74,7 @@ class OpeaVDMsRetriever(OpeaComponent):
             # create embeddings using local embedding model
             if logflag:
                 logger.info(f"[ init embedder ] LOCAL_EMBEDDING_MODEL:{EMBED_MODEL}")
-            embeddings = HuggingFaceBgeEmbeddings(model_name=EMBED_MODEL)
+            embeddings = HuggingFaceEmbeddings(model_name=EMBED_MODEL)
         return embeddings
 
     def _initialize_vector_db(self) -> VDMS:

--- a/comps/third_parties/pathway/src/requirements.txt
+++ b/comps/third_parties/pathway/src/requirements.txt
@@ -1,5 +1,6 @@
 langchain
 langchain-community
+langchain-huggingface
 openai
 pathway[xpack-llm]
 sentence-transformers

--- a/comps/third_parties/pathway/src/vectorstore_pathway.py
+++ b/comps/third_parties/pathway/src/vectorstore_pathway.py
@@ -9,6 +9,7 @@ import pathway as pw
 from langchain import text_splitter
 from langchain_community.embeddings import HuggingFaceBgeEmbeddings, HuggingFaceInferenceAPIEmbeddings
 from pathway.xpacks.llm.parsers import ParseUnstructured
+from langchain_huggingface import HuggingFaceEmbeddings
 from pathway.xpacks.llm.vector_store import VectorStoreServer
 
 logging.basicConfig(
@@ -52,7 +53,7 @@ if __name__ == "__main__":
         )
     else:
         # create embeddings using local embedding model
-        embeddings = HuggingFaceBgeEmbeddings(model_name=EMBED_MODEL)
+        embeddings = HuggingFaceEmbeddings(model_name=EMBED_MODEL)
 
     server = VectorStoreServer.from_langchain_components(
         *data_sources,

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ httpx
 kubernetes
 langchain
 langchain-community
+langchain-huggingface
 opentelemetry-api
 opentelemetry-exporter-otlp
 opentelemetry-sdk


### PR DESCRIPTION
## Description

Fix Deprecation warnings in logs service logs

The `HuggingFaceBgeEmbeddings` class deprecated in langchain and there's warning like below:
```bash
/home/user/comps/dataprep/src/integrations/redis.py:210: LangChainDeprecationWarning: The class `HuggingFaceBgeEmbeddings` was deprecated in LangChain 0.2.2 and will be removed in 1.0. 
An updated version of the class exists in the :class:`~langchain-huggingface package and should be used instead. 
To use it run `pip install -U :class:`~langchain-huggingface` and import as `from :class:`~langchain_huggingface import HuggingFaceEmbeddings``.
```
This PR will update all of the `HuggingFaceBgeEmbeddings` class into `HuggingFaceEmbeddings`.

## Issues

https://github.com/opea-project/GenAIComps/issues/1434

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
