### PR TITLE
Fix fine-tuning Python regex syntax CI/linting error

### DIFF
--- a/comps/finetuning/src/integrations/native.py
+++ b/comps/finetuning/src/integrations/native.py
@@ -201,7 +201,7 @@ class OpeaFinetuning(OpeaComponent):
             for file in files:  # Loop over directory contents
                 file_path = os.path.join(output_dir, file)
                 if os.path.isdir(file_path) and file.startswith("checkpoint"):
-                    steps = re.findall("\d+", file)[0]
+                    steps = re.findall(r"\d+", file)[0]
                     checkpointsResponse = FineTuningJobCheckpoint(
                         id=f"ftckpt-{uuid.uuid4()}",  # Generate a unique ID
                         created_at=int(time.time()),  # Use the current timestamp


### PR DESCRIPTION
## Description

Fix fine-tuning Python regex quoting by using raw string type: https://docs.python.org/3/library/re.html#raw-string-notation

## Issues

CI Python code heck fails in PRs that are not related to fine-tuning without this one-liner fix.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

`n/a`

## Tests

CI