### PR TITLE
Update nofile's hard limit to 262144 for opensearch

### DIFF
--- a/comps/third_parties/opensearch/deployment/docker_compose/compose.yaml
+++ b/comps/third_parties/opensearch/deployment/docker_compose/compose.yaml
@@ -23,7 +23,7 @@ services:
         hard: -1
       nofile:
         soft: 65536  # maximum number of open files for the OpenSearch user, set to at least 65536 on modern systems
-        hard: 65536
+        hard: 262144
     ports:
       - "${OPENSEARCH_PORT1:-9200}:9200"
       - "${OPENSEARCH_PORT2:-9600}:9600"


### PR DESCRIPTION
## Description

This PR sets the hard limit for opensearch container as suggested here:
https://opensearch.org/docs/latest/install-and-configure/install-opensearch/index/

## Issues

List the issue or RFC link this PR is working on. If there is no such link, please mark it as `n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [Y] Bug fix (non-breaking change which fixes an issue)
- [N] New feature (non-breaking change which adds new functionality)
- [N] Breaking change (fix or feature that would break existing design and interface)
- [N] Others (enhancement, documentation, validation, etc.)

## Dependencies

N/A

## Tests
There's a CI test for this.
