### PR TITLE
Fix opensearch container start failed issue

### DIFF
--- a/tests/dataprep/test_dataprep_opensearch.sh
+++ b/tests/dataprep/test_dataprep_opensearch.sh
@@ -33,6 +33,8 @@ function start_service() {
     service_name="opensearch-vector-db dataprep-opensearch"
     export host_ip=${ip_address}
     cd $WORKPATH/comps/dataprep/deployment/docker_compose/
+    # set vm.max_map_count to 262144 for opensearch
+    sudo sysctl -w vm.max_map_count=262144
     docker compose up ${service_name} -d
     sleep 1m
 }

--- a/tests/retrievers/test_retrievers_opensearch.sh
+++ b/tests/retrievers/test_retrievers_opensearch.sh
@@ -41,6 +41,8 @@ function start_service() {
     export INDEX_NAME="file-index"
 
     cd $WORKPATH/comps/retrievers/deployment/docker_compose
+    # set vm.max_map_count to 262144 for opensearch
+    sudo sysctl -w vm.max_map_count=262144
     docker compose -f compose.yaml up ${service_name} -d > ${LOG_PATH}/start_services_with_compose.log
 
 


### PR DESCRIPTION
## Description

Fix opensearch container start failed issue: `ERROR: [1] bootstrap checks failed [1]: max virtual memory areas vm.max_map_count [65530] is too low, increase to at least [262144]`
Set `vm.max_map_count=262144` in test scripts

## Issues

https://github.com/opea-project/GenAIComps/issues/1498

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

None

## Tests

Local tested
