### PR TITLE
Update Gaudi Docker to v1.19.0 and PyTorch Installer 2.5.1

### DIFF
--- a/.github/workflows/scripts/freeze_images.sh
+++ b/.github/workflows/scripts/freeze_images.sh
@@ -3,9 +3,10 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+# vault.habana.ai/gaudi-docker/1.19.0/ubuntu22.04/habanalabs/pytorch-installer-2.5.1
 declare -A dict
 dict["langchain/langchain"]="docker://docker.io/langchain/langchain"
-dict["vault.habana.ai/gaudi-docker/1.18.0/ubuntu22.04/habanalabs/pytorch-installer-2.4.0"]="docker://vault.habana.ai/gaudi-docker/1.18.0/ubuntu22.04/habanalabs/pytorch-installer-2.4.0"
+dict["vault.habana.ai/gaudi-docker/1.19.0/ubuntu22.04/habanalabs/pytorch-installer-2.5.1"]="docker://vault.habana.ai/gaudi-docker/1.19.0/ubuntu22.04/habanalabs/pytorch-installer-2.5.1"
 
 function get_latest_version() {
     repo_image=$1

--- a/comps/asr/src/integrations/dependency/whisper/Dockerfile.intel_hpu
+++ b/comps/asr/src/integrations/dependency/whisper/Dockerfile.intel_hpu
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # HABANA environment
-FROM vault.habana.ai/gaudi-docker/1.18.0/ubuntu22.04/habanalabs/pytorch-installer-2.4.0 AS hpu
+FROM vault.habana.ai/gaudi-docker/1.19.0/ubuntu22.04/habanalabs/pytorch-installer-2.5.1 AS hpu
 
 RUN useradd -m -s /bin/bash user && \
     mkdir -p /home/user && \

--- a/comps/finetuning/src/Dockerfile.intel_hpu
+++ b/comps/finetuning/src/Dockerfile.intel_hpu
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Use the same python version with ray
-FROM vault.habana.ai/gaudi-docker/1.18.0/ubuntu22.04/habanalabs/pytorch-installer-2.4.0 AS hpu
+FROM vault.habana.ai/gaudi-docker/1.19.0/ubuntu22.04/habanalabs/pytorch-installer-2.5.1 AS hpu
 
 ENV DEVICE="hpu"
 

--- a/comps/image2image/src/Dockerfile.intel_hpu
+++ b/comps/image2image/src/Dockerfile.intel_hpu
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # HABANA environment
-FROM vault.habana.ai/gaudi-docker/1.18.0/ubuntu22.04/habanalabs/pytorch-installer-2.4.0 AS hpu
+FROM vault.habana.ai/gaudi-docker/1.19.0/ubuntu22.04/habanalabs/pytorch-installer-2.5.1 AS hpu
 RUN useradd -m -s /bin/bash user && \
     mkdir -p /home/user && \
     chown -R user /home/user/

--- a/comps/image2video/src/Dockerfile.intel_hpu
+++ b/comps/image2video/src/Dockerfile.intel_hpu
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # HABANA environment
-FROM vault.habana.ai/gaudi-docker/1.18.0/ubuntu22.04/habanalabs/pytorch-installer-2.4.0 AS hpu
+FROM vault.habana.ai/gaudi-docker/1.19.0/ubuntu22.04/habanalabs/pytorch-installer-2.5.1 AS hpu
 RUN useradd -m -s /bin/bash user && \
     mkdir -p /home/user && \
     chown -R user /home/user/
@@ -15,7 +15,7 @@ RUN chown -R user /home/user/comps/image2video
 # SPDX-License-Identifier: Apache-2.0
 
 # HABANA environment
-FROM vault.habana.ai/gaudi-docker/1.18.0/ubuntu22.04/habanalabs/pytorch-installer-2.4.0 AS hpu
+FROM vault.habana.ai/gaudi-docker/1.19.0/ubuntu22.04/habanalabs/pytorch-installer-2.5.1 AS hpu
 RUN useradd -m -s /bin/bash user && \
     mkdir -p /home/user && \
     chown -R user /home/user/

--- a/comps/lvms/src/integrations/dependency/llava/Dockerfile.intel_hpu
+++ b/comps/lvms/src/integrations/dependency/llava/Dockerfile.intel_hpu
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # HABANA environment
-FROM vault.habana.ai/gaudi-docker/1.18.0/ubuntu22.04/habanalabs/pytorch-installer-2.4.0 AS hpu
+FROM vault.habana.ai/gaudi-docker/1.19.0/ubuntu22.04/habanalabs/pytorch-installer-2.5.1 AS hpu
 RUN useradd -m -s /bin/bash user && \
     mkdir -p /home/user && \
     chown -R user /home/user/

--- a/comps/text2image/src/Dockerfile.intel_hpu
+++ b/comps/text2image/src/Dockerfile.intel_hpu
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # HABANA environment
-FROM vault.habana.ai/gaudi-docker/1.18.0/ubuntu22.04/habanalabs/pytorch-installer-2.4.0 AS hpu
+FROM vault.habana.ai/gaudi-docker/1.19.0/ubuntu22.04/habanalabs/pytorch-installer-2.5.1 AS hpu
 RUN useradd -m -s /bin/bash user && \
     mkdir -p /home/user && \
     chown -R user /home/user/

--- a/comps/third_parties/bridgetower/src/Dockerfile.intel_hpu
+++ b/comps/third_parties/bridgetower/src/Dockerfile.intel_hpu
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # HABANA environment
-FROM vault.habana.ai/gaudi-docker/1.18.0/ubuntu22.04/habanalabs/pytorch-installer-2.4.0 AS hpu
+FROM vault.habana.ai/gaudi-docker/1.19.0/ubuntu22.04/habanalabs/pytorch-installer-2.5.1 AS hpu
 RUN useradd -m -s /bin/bash user && \
     mkdir -p /home/user && \
     chown -R user /home/user/

--- a/comps/third_parties/wav2lip/src/Dockerfile.intel_hpu
+++ b/comps/third_parties/wav2lip/src/Dockerfile.intel_hpu
@@ -1,6 +1,6 @@
 # Use a base image
 # FROM python:3.11-slim
-FROM vault.habana.ai/gaudi-docker/1.18.0/ubuntu22.04/habanalabs/pytorch-installer-2.4.0 AS hpu
+FROM vault.habana.ai/gaudi-docker/1.19.0/ubuntu22.04/habanalabs/pytorch-installer-2.5.1 AS hpu
 
 # Set environment variables
 ENV LANG=en_US.UTF-8

--- a/comps/tts/src/integrations/dependency/speecht5/Dockerfile.intel_hpu
+++ b/comps/tts/src/integrations/dependency/speecht5/Dockerfile.intel_hpu
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # HABANA environment
-FROM vault.habana.ai/gaudi-docker/1.18.0/ubuntu22.04/habanalabs/pytorch-installer-2.4.0 AS hpu
+FROM vault.habana.ai/gaudi-docker/1.19.0/ubuntu22.04/habanalabs/pytorch-installer-2.5.1 AS hpu
 RUN useradd -m -s /bin/bash user && \
     mkdir -p /home/user && \
     chown -R user /home/user/


### PR DESCRIPTION
## Description
With Gaudi being at 1.20.x right now, it's time to at least move up to v1.19.0 and also ensure we're using that minimum version everywhere.
This also brings PyTorch version up to v2.5.1 which is more recent one.

## Issues
N/A

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [X] Others (enhancement, documentation, validation, etc.)

## Dependencies
None

## Tests
Currently relying on CI tests to pass.
