### PR TITLE
Fix failing multimodal redis retriever tests due to TEI_EMBEDDING_ENDPOINT

### DIFF
--- a/tests/retrievers/test_retrievers_redis.sh
+++ b/tests/retrievers/test_retrievers_redis.sh
@@ -55,6 +55,7 @@ function start_multimodal_service() {
     export LOGFLAG=True
     export BRIDGE_TOWER_EMBEDDING=true
     export RETRIEVER_TYPE="redis"
+    unset TEI_EMBEDDING_ENDPOINT
 
     cd $WORKPATH/comps/retrievers/deployment/docker_compose
     docker compose -f compose.yaml up ${service_name_mm} -d > ${LOG_PATH}/start_services_with_compose_multimodal.log


### PR DESCRIPTION
## Description

This PR fixes a test failure that is seen when running the multimodal redis retriever tests. It's using the BridgeTower embedding backend, and not TEI. We need to unset the TEI env var that previous gets set when the redis retriever tests are run.

Without this fix, bringing up the multimodal redis retriever is failing with the following error in the logs:
```
Traceback (most recent call last):
  File "/home/user/comps/retrievers/src/opea_retrievers_microservice.py", line 47, in <module>
    loader = OpeaComponentLoader(
             ^^^^^^^^^^^^^^^^^^^^
  File "/home/user/comps/cores/common/component.py", line 152, in __init__
    self.component = component_class(**kwargs)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/comps/retrievers/src/integrations/redis.py", line 56, in __init__
    self.embeddings = asyncio.run(self._initialize_embedder())
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/nest_asyncio.py", line 30, in run
    return loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/nest_asyncio.py", line 98, in run_until_complete
    return f.result()
           ^^^^^^^^^^
  File "/usr/local/lib/python3.11/asyncio/futures.py", line 203, in result
    raise self._exception.with_traceback(self._exception_tb)
  File "/usr/local/lib/python3.11/asyncio/tasks.py", line 277, in __step
    result = coro.send(None)
             ^^^^^^^^^^^^^^^
  File "/home/user/comps/retrievers/src/integrations/redis.py", line 74, in _initialize_embedder
    response = await client.get(TEI_EMBEDDING_ENDPOINT + "/info")
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/httpx/_client.py", line 1768, in get
    return await self.request(
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/httpx/_client.py", line 1540, in request
    return await self.send(request, auth=auth, follow_redirects=follow_redirects)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/httpx/_client.py", line 1629, in send
    response = await self._send_handling_auth(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/httpx/_client.py", line 1657, in _send_handling_auth
    response = await self._send_handling_redirects(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/httpx/_client.py", line 1694, in _send_handling_redirects
    response = await self._send_single_request(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/httpx/_client.py", line 1730, in _send_single_request
    response = await transport.handle_async_request(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/httpx/_transports/default.py", line 393, in handle_async_request
    with map_httpcore_exceptions():
  File "/usr/local/lib/python3.11/contextlib.py", line 158, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/usr/local/lib/python3.11/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
    raise mapped_exc(message) from exc
httpx.ConnectError: All connection attempts failed
```
Specifically, in the stack trace, we can see here that it's the `response = await client.get(TEI_EMBEDDING_ENDPOINT + "/info")` in the call stack that is trying to call the TEI embedding endpoint, but the TEI microservice is not running.

This issue was caused by a combination of these two PRs, which it looks like happened to merge on the same day:
* [Fix Retriever Async Issue](https://github.com/opea-project/GenAIComps/pull/1457) - this adds the `await client.get(TEI_EMBEDDING_ENDPOINT + "/info")` call
* [Fix issue with orphaned containers in the Github runtime program for running tests](https://github.com/opea-project/GenAIComps/pull/1454) - before this PR, the TEI service would be left running from the redis tests, which made the multimodal retriever service come up successfully. After this PR, the TEI service is stopped before multimodal tests are run.

## Issues

https://github.com/opea-project/GenAIComps/issues/1497

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

N/A

## Tests

Ran the retriever tests locally on Xeon.
