### PR TITLE
Add in entrypoint new download links for wav2lip and wav2lip_gan mode…

### DIFF
--- a/comps/third_parties/wav2lip/src/entrypoint.sh
+++ b/comps/third_parties/wav2lip/src/entrypoint.sh
@@ -13,8 +13,8 @@ fi
 # Download model weights
 wget --no-verbose https://www.adrianbulat.com/downloads/python-fan/s3fd-619a316812.pth -O Wav2Lip/face_detection/detection/sfd/s3fd.pth
 mkdir -p Wav2Lip/checkpoints
-wget --no-verbose "https://iiitaphyd-my.sharepoint.com/:f:/g/personal/radrabha_m_research_iiit_ac_in/Eb3LEzbfuKlJiR600lQWRxgBIY27JZg80f7V9jtMfbNDaQ?download=1" -O Wav2Lip/checkpoints/wav2lip.pth
-wget --no-verbose "https://iiitaphyd-my.sharepoint.com/:f:/g/personal/radrabha_m_research_iiit_ac_in/EdjI7bZlgApMqsVoEUUXpLsBxqXbn5z8VTmoxp55YNDcIA?download=1" -O Wav2Lip/checkpoints/wav2lip_gan.pth
+wget --no-verbose https://huggingface.co/camenduru/Wav2Lip/resolve/main/checkpoints/wav2lip.pth -O Wav2Lip/checkpoints/wav2lip.pth
+wget --no-verbose https://huggingface.co/camenduru/Wav2Lip/resolve/main/checkpoints/wav2lip_gan.pth -O Wav2Lip/checkpoints/wav2lip_gan.pth
 wget --no-verbose https://github.com/TencentARC/GFPGAN/releases/download/v1.3.0/GFPGANv1.4.pth -P gfpgan/experiments/pretrained_models
 echo "Face Detector, Wav2Lip, GFPGAN weights downloaded."
 


### PR DESCRIPTION
## Description

Add in entrypoint new download links for wav2lip and wav2lip_gan models, as old links were deprecated.

## Issues

Old links were deprecated by third-party author. Found HF substitutes.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

[camenduru/Wav2Lip](https://huggingface.co/camenduru/Wav2Lip/tree/main/checkpoints) model weights

## Tests

`GenAIExamples/AvatarChatbot/tests/test_compose_on_gaudi.sh`  
`GenAIExamples/AvatarChatbot/tests/test_compose_on_xeon.sh`
