### PR TITLE
Fix GenAIExamples #1607 by adding timeout to the wav2lip request

### DIFF
--- a/comps/animation/src/integrations/wav2lip.py
+++ b/comps/animation/src/integrations/wav2lip.py
@@ -31,7 +31,8 @@ class OpeaAnimation(OpeaComponent):
         """
         inputs = {"audio": input}
 
-        async with aiohttp.ClientSession() as session:
+        timeout = aiohttp.ClientTimeout(total=600)  # Set timeout to 600 seconds
+        async with aiohttp.ClientSession(timeout=timeout) as session:
             response = await session.post(url=f"{self.base_url}/v1/wav2lip", data=json.dumps(inputs), proxy=None)
             json_data = await response.json()
             outfile = json_data["wav2lip_result"]


### PR DESCRIPTION
## Description

Fix #1607 

## Issues

[List the issue or RFC link this PR is working on. If there is no such link, please mark it as `n/a`.](https://github.com/opea-project/GenAIExamples/issues/1607)

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Tests

`GenAIExamples/AvatarChatbot/tests/test_compose_on_gaudi.sh`  
`GenAIExamples/AvatarChatbot/tests/test_compose_on_xeon.sh`
