### PR TITLE
MMQnA - Adds option to delete selected files from vector store rather than all at once

### DIFF
--- a/comps/dataprep/src/integrations/redis_multimodal.py
+++ b/comps/dataprep/src/integrations/redis_multimodal.py
@@ -870,11 +870,11 @@ class OpeaMultimodalRedisDataprep(OpeaComponent):
         if file_path == 'all':
             clear_upload_folder(self.upload_folder)
         else:
-            file_path = list(file_path) if isinstance(file_path, str) else file_path
+            file_path = [file_path] if isinstance(file_path, str) else file_path
             for f in file_path:
                 x = os.path.join(self.upload_folder, f)
-                print(f'file exists: {os.path.exists(x)}')
-                os.remove(x)
+                if os.path.exists(x):
+                    os.remove(x)
         logger.info("Successfully deleted all uploaded files.")
         return {"status": True}
 

--- a/comps/dataprep/src/opea_dataprep_multimodal_microservice.py
+++ b/comps/dataprep/src/opea_dataprep_multimodal_microservice.py
@@ -239,7 +239,7 @@ async def get_videos():
     port=5000,
 )
 @register_statistics(names=["opea_service@dataprep_multimodal"])
-async def delete_files(file_path: str = Body(..., embed=True)):
+async def delete_files(file_path: Union[str, List[str]] = Body(..., embed=True)):
     start = time.time()
 
     if logflag:


### PR DESCRIPTION
## Description

The current behavior of the `DATAPREP_DELETE_FILE_ENDPOINT` deletes all files at once. This PR enhances that functionality to delete selected files from the vector store by giving the ingested file names as list of strings in the `filepath` key.

**Example:**
Delete all files at once -
```
curl ${DATAPREP_DELETE_FILE_ENDPOINT} \
  -X POST \
  -H "Content-Type: application/json" \
  -d '{"file_path": "all"}'
```
Delete a single file -
```
curl ${DATAPREP_DELETE_FILE_ENDPOINT} \
  -X POST \
  -H "Content-Type: application/json" \
  -d '{"file_path": "image_871bdd55-9653-4413-aa25-55dfa60c4845.png"}'
```
Delete multiple files -
```
curl ${DATAPREP_DELETE_FILE_ENDPOINT} \
  -X POST \
  -H "Content-Type: application/json" \
  -d '{"file_path": ["image_871bdd55-9653-4413-aa25-55dfa60c4845.png", "test_3fa3d668-f629-4b08-80ee-cef0c294ba2c.pdf]}'
```

## Issues

`n/a`

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

No new dependencies.

## Tests

Manually ran and tested the above mentioned commands.
