### PR TITLE
Fix: Default value for StreamOptions

### DIFF
--- a/comps/cores/proto/api_protocol.py
+++ b/comps/cores/proto/api_protocol.py
@@ -37,7 +37,7 @@ class ResponseFormat(BaseModel):
 
 class StreamOptions(BaseModel):
     # refer https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/openai/protocol.py#L105
-    include_usage: Optional[bool]
+    include_usage: Optional[bool] = False
 
 
 class FunctionDefinition(BaseModel):
@@ -169,7 +169,7 @@ class ChatCompletionRequest(BaseModel):
     service_tier: Optional[str] = None
     stop: Union[str, List[str], None] = Field(default_factory=list)
     stream: Optional[bool] = False
-    stream_options: Optional[StreamOptions] = None
+    stream_options: Optional[StreamOptions] = Field(default_factory=StreamOptions)
     temperature: Optional[float] = 0.01  # vllm default 0.7
     top_p: Optional[float] = None  # openai default 1.0, but tgi needs `top_p` must be > 0.0 and < 1.0, set None
     tools: Optional[List[ChatCompletionToolsParam]] = None


### PR DESCRIPTION
OpenAI client requires a non null value for StreamOptions.

Before fix, when running `opea/llm-textgen` (using local TGI):

```sh
curl http://localhost:9000/v1/chat/completions \
        -X POST \
        -d '{"model": "Intel/neural-chat-7b-v3-3", "messages": [{"role": "user", "content": "What is Deep Learning?"}],  "max_tokens":20}' \
        -H 'Content-Type: application/json'
```

One would get an error:

```
openai.UnprocessableEntityError: Failed to deserialize the JSON body into the target type: stream_options: invalid type: null, expected struct StreamOptions
```

----

It is explicitly used in here:
https://github.com/opea-project/GenAIComps/blob/402430275b376e1cc4b81042e9eb28d99a96ef2b/comps/llms/src/text-generation/integrations/service.py#L214

## Description

Solved using a default factory in pydantic.

## Issues

`n/a`

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)



