### PR TITLE
unset OPENAI KEY in retriever neo4j CI test

### DIFF
--- a/tests/retrievers/test_retrievers_neo4j_on_intel_hpu.sh
+++ b/tests/retrievers/test_retrievers_neo4j_on_intel_hpu.sh
@@ -15,7 +15,7 @@ WORKPATH=$(dirname "$PWD")
 LOG_PATH="$WORKPATH/tests"
 export host_ip=$(hostname -I | awk '{print $1}')
 service_name="retriever-neo4j"
-
+unset OPENAI_API_KEY
 function build_docker_images() {
     cd $WORKPATH
     echo "current dir: $PWD"


### PR DESCRIPTION
CI environment has OPENAI_KEY so unsetting for test
