### PR TITLE
Remove template_llava.jinja in command

### DIFF
--- a/comps/lvms/deployment/docker_compose/compose.yaml
+++ b/comps/lvms/deployment/docker_compose/compose.yaml
@@ -28,7 +28,7 @@ services:
       interval: 10s
       timeout: 10s
       retries: 100
-    command: --model $LLM_MODEL_ID --host 0.0.0.0 --port 80 --chat-template examples/template_llava.jinja  # https://docs.vllm.ai/en/v0.5.0/models/vlm.html
+    command: --model $LLM_MODEL_ID --host 0.0.0.0 --port 80 # --chat-template examples/template_llava.jinja  # https://docs.vllm.ai/en/v0.5.0/models/vlm.html
   vllm-gaudi-service:
     image: ${REGISTRY:-opea}/vllm-gaudi:${TAG:-latest}
     container_name: vllm-gaudi-service


### PR DESCRIPTION
## Description

Remove template_llava.jinja in command since its no longer included in default vllm image, and pipeline works fine without it.

## Issues

`n/a`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

no.

## Tests

UT.
