### PR TITLE
fix pymilvus==2.5.6

### DIFF
--- a/comps/dataprep/src/requirements.txt
+++ b/comps/dataprep/src/requirements.txt
@@ -27,7 +27,6 @@ langchain-text-splitters
 langchain-vdms>=0.1.4
 langchain_huggingface
 langchain_milvus
-pymilvus==2.5.6
 llama-index
 llama-index-core==0.12.19
 llama-index-embeddings-text-embeddings-inference
@@ -52,6 +51,7 @@ pinecone-client
 prometheus-fastapi-instrumentator
 protobuf==4.24.2
 psycopg2
+pymilvus==2.5.6
 pymupdf
 pyspark
 pytesseract

--- a/comps/dataprep/src/requirements.txt
+++ b/comps/dataprep/src/requirements.txt
@@ -27,6 +27,7 @@ langchain-text-splitters
 langchain-vdms>=0.1.4
 langchain_huggingface
 langchain_milvus
+pymilvus==2.5.6
 llama-index
 llama-index-core==0.12.19
 llama-index-embeddings-text-embeddings-inference

--- a/comps/retrievers/src/requirements.txt
+++ b/comps/retrievers/src/requirements.txt
@@ -18,6 +18,7 @@ langchain-vdms>=0.1.4
 langchain_community
 langchain_huggingface
 langchain_milvus
+pymilvus==2.5.6
 llama-index-core==0.12.19
 llama-index-embeddings-openai
 llama-index-embeddings-text-embeddings-inference

--- a/comps/retrievers/src/requirements.txt
+++ b/comps/retrievers/src/requirements.txt
@@ -18,7 +18,6 @@ langchain-vdms>=0.1.4
 langchain_community
 langchain_huggingface
 langchain_milvus
-pymilvus==2.5.6
 llama-index-core==0.12.19
 llama-index-embeddings-openai
 llama-index-embeddings-text-embeddings-inference
@@ -38,6 +37,7 @@ prometheus-fastapi-instrumentator
 protobuf==4.24.2
 psycopg2-binary
 pydantic
+pymilvus==2.5.6
 pymupdf
 pytesseract
 python-docx


### PR DESCRIPTION
## Description

Fix pymilvus==2.5.6, we can remove this version limit after `langchain-milvus` adapt the new release. 

## Issues

https://github.com/opea-project/GenAIComps/issues/1619

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
