### PR TITLE
fix vllm-openvino-arc openvino version issue

### DIFF
--- a/comps/third_parties/vllm/deployment/docker_compose/compose.yaml
+++ b/comps/third_parties/vllm/deployment/docker_compose/compose.yaml
@@ -94,7 +94,7 @@ services:
       LLM_MODEL_ID: ${LLM_MODEL_ID}
       LLM_ENDPOINT_PORT: ${LLM_ENDPOINT_PORT}
       host_ip: ${host_ip}
-    entrypoint: /bin/bash -c " export VLLM_OPENVINO_DEVICE=GPU &&  export VLLM_OPENVINO_ENABLE_QUANTIZED_WEIGHTS=ON &&  python3 -m vllm.entrypoints.openai.api_server    --model ${LLM_MODEL_ID}    --host 0.0.0.0    --port ${LLM_ENDPOINT_PORT}    --max_model_len 8192"
+    entrypoint: /bin/bash -c " export VLLM_OPENVINO_DEVICE=GPU &&  export VLLM_OPENVINO_ENABLE_QUANTIZED_WEIGHTS=ON &&  python3 -m vllm.entrypoints.openai.api_server    --model ${LLM_MODEL_ID}    --host 0.0.0.0    --port ${LLM_ENDPOINT_PORT}    --max_model_len 4096"
     ipc: host
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://${host_ip}:${LLM_ENDPOINT_PORT}/health || exit 1"]

--- a/comps/third_parties/vllm/src/Dockerfile.intel_gpu
+++ b/comps/third_parties/vllm/src/Dockerfile.intel_gpu
@@ -55,6 +55,8 @@ RUN python3 -m pip install -U pip
 RUN PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu" python3 -m pip install --no-cache-dir -r /workspace/vllm/requirements-build.txt
 # build vLLM with OpenVINO backend
 RUN PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/cpu" VLLM_TARGET_DEVICE="openvino" python3 -m pip install --no-cache-dir /workspace/vllm/
+# fix OpenVINO version to 25.0.0
+RUN python3 -m pip install openvino==2025.0.0
 
 #COPY examples/ /workspace/vllm/examples
 #COPY benchmarks/ /workspace/vllm/benchmarks


### PR DESCRIPTION
## Description

latest openvino is not supported by vllm 
how to fix:
1. set openvino version to 25.0.0 in comps_vllm_openvino_arc dockerfile to resolve bug
2. decrease 'max_model_len' in docker compose file, 8192 is too large

## Issues

https://github.com/opea-project/GenAIComps/issues/1590

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ √] Bug fix (non-breaking change which fixes an issue)

## Dependencies

n/a

## Tests

![image](https://github.com/user-attachments/assets/ac54dc2d-a760-4133-b9c2-1746282f7e22)
