### PR TITLE
Fix LLM StreamOptions Issue

### DIFF
--- a/comps/cores/proto/api_protocol.py
+++ b/comps/cores/proto/api_protocol.py
@@ -292,7 +292,7 @@ class ChatCompletionRequest(BaseModel):
     service_tier: Optional[str] = None
     stop: Union[str, List[str], None] = Field(default_factory=list)
     stream: Optional[bool] = False
-    stream_options: Optional[StreamOptions] = Field(default_factory=StreamOptions)
+    stream_options: Optional[StreamOptions] = Field(default=None)
     temperature: Optional[float] = 0.01  # vllm default 0.7
     top_p: Optional[float] = None  # openai default 1.0, but tgi needs `top_p` must be > 0.0 and < 1.0, set None
     tools: Optional[List[ChatCompletionToolsParam]] = None


### PR DESCRIPTION
## Description

Fix llm inference issue of not passing `stream_options` parameter.
Pydantic will automatically fill a wrong default value for this paremeter, then cause the error:

```bash
openai.UnprocessableEntityError: Failed to deserialize the JSON body into the target type: stream_options: missing field include_usage at line 1 column 273
```

[This PR](https://github.com/opea-project/GenAIComps/pull/1582) partially fixed this issue, but the default value of stream_options should be `Optional[StreamOptions] = Field(default=None)`.

## Issues

Fixes https://github.com/opea-project/GenAIInfra/issues/1026

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

None

## Tests

Local tested
