### PR TITLE
Architecture specific args for a few containers

### DIFF
--- a/comps/animation/src/Dockerfile
+++ b/comps/animation/src/Dockerfile
@@ -14,7 +14,11 @@ ARG ARCH=cpu
 COPY comps /home/user/comps
 
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
-    pip install --no-cache-dir -r /home/user/comps/animation/src/requirements.txt ;
+    if [ ${ARCH} = "cpu" ]; then \
+      pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r /home/user/comps/animation/src/requirements.txt; \
+    else \
+      pip install --no-cache-dir -r /home/user/comps/animation/src/requirements.txt; \
+    fi
 
 ENV PYTHONPATH=$PYTHONPATH:/home/user
 USER user

--- a/comps/llms/src/faq-generation/Dockerfile
+++ b/comps/llms/src/faq-generation/Dockerfile
@@ -1,7 +1,11 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+# Use a base image
 FROM python:3.11-slim
+
+# Set this to "cpu" or "gpu" or etc
+ARG ARCH="cpu"
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends --fix-missing \
     libgl1-mesa-glx \
@@ -14,7 +18,11 @@ RUN useradd -m -s /bin/bash user && \
 COPY comps /home/user/comps
 
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
-    pip install --no-cache-dir -r /home/user/comps/llms/src/faq-generation/requirements.txt
+    if [ ${ARCH} = "cpu" ]; then \
+      pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r /home/user/comps/llms/src/faq-generation/requirements.txt; \
+    else \
+      pip install --no-cache-dir -r /home/user/comps/llms/src/faq-generation/requirements.txt; \
+    fi
 
 ENV PYTHONPATH=$PYTHONPATH:/home/user
 

--- a/comps/third_parties/bridgetower/src/Dockerfile
+++ b/comps/third_parties/bridgetower/src/Dockerfile
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 FROM python:3.10-slim
+
+# Set this to "cpu" or "gpu" or etc
+ARG ARCH="cpu"
+
 RUN useradd -m -s /bin/bash user && \
     mkdir -p /home/user && \
     chown -R user /home/user/
@@ -15,7 +19,11 @@ ENV PYTHONPATH=/home/user:/usr/lib/habanalabs/:/optimum-habana
 COPY --chown=user comps /home/user/comps
 
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
-    pip install --no-cache-dir -r /home/user/comps/third_parties/bridgetower/src/requirements.txt
+    if [ ${ARCH} = "cpu" ]; then \
+      pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r /home/user/comps/third_parties/bridgetower/src/requirements.txt; \
+    else \
+      pip install --no-cache-dir -r /home/user/comps/third_parties/bridgetower/src/requirements.txt; \
+    fi
     
 
 ENV PYTHONPATH=$PYTHONPATH:/home/user

--- a/comps/third_parties/gpt-sovits/src/Dockerfile
+++ b/comps/third_parties/gpt-sovits/src/Dockerfile
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 FROM python:3.10-slim
+
+# Set this to "cpu" or "gpu" or etc
+ARG ARCH="cpu"
+
 RUN useradd -m -s /bin/bash user && \
     mkdir -p /home/user
 
@@ -15,8 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends --fix-missing \
     google-perftools \
     libomp-dev \
     numactl \
-    wget && \
-    pip install --upgrade pip
+    wget
 
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libiomp5.so:/usr/lib/x86_64-linux-gnu/libtcmalloc.so.4
 ENV MALLOC_CONF="oversize_threshold:1,background_thread:true,metadata_thp:auto,dirty_decay_ms:9000000000,muzzy_decay_ms:9000000000"
@@ -25,12 +28,16 @@ ENV LANG=C.UTF-8
 # Clone source repo
 RUN git clone --depth=1 --branch openai_compat --single-branch https://github.com/Spycsh/GPT-SoVITS.git
 
-RUN pip install --no-cache-dir -r GPT-SoVITS/requirements.txt && \
-    pip install --no-cache-dir --upgrade setuptools && \
-    python -m nltk.downloader averaged_perceptron_tagger_eng cmudict && \
+RUN pip install --no-cache-dir --upgrade pip setuptools && \
+    if [ ${ARCH} = "cpu" ]; then \
+      pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r GPT-SoVITS/requirements.txt; \
+    else \
+      pip install --no-cache-dir -r GPT-SoVITS/requirements.txt; \
+    fi
+
+RUN python -m nltk.downloader averaged_perceptron_tagger_eng cmudict && \
     mv /root/nltk_data /home/user/ && \
     mv GPT-SoVITS /home/user/
-
 
 COPY --chown=user:user comps/third_parties/gpt-sovits/src/start.sh /home/user/GPT-SoVITS
 


### PR DESCRIPTION
## Description

This PR adds optional `build-arg`'s for the following Dockerfiles:
```
- comps/animation/src/Dockerfile
- comps/llms/src/faq-generation/Dockerfile
- comps/third_parties/bridgetower/src/Dockerfile
- comps/third_parties/gpt-sovits/src/Dockerfile
```

## Issues

Current Dockerfiles always defaults to `gpu` Torch installation while `CPU` users might not necessarily need extra packages. This had the advantage of building smaller containers for CPU users and faster builds.

For users interested to do `gpu` builds, all they need to do is build this image this way for example:
```
docker build --build-arg ARCH='gpu' -f comps/animation/src/Dockerfile. -t opea/faq-generation:latest
```

## Type of change

List the type of change like below. Please delete options that are not relevant.

- extra `build-arg` option `ARCH` to build a few of our containers for either CPU or GPU where applicable.

## Dependencies

None
