### PR TITLE
Architecture specific args for a few containers

### DIFF
--- a/comps/lvms/src/Dockerfile
+++ b/comps/lvms/src/Dockerfile
@@ -3,6 +3,9 @@
 
 FROM python:3.11-slim
 
+# Set this to "cpu" or "gpu" or etc
+ARG ARCH="cpu"
+
 RUN useradd -m -s /bin/bash user && \
     mkdir -p /home/user && \
     chown -R user /home/user/
@@ -12,7 +15,11 @@ ENV LANG=C.UTF-8
 COPY comps /home/user/comps
 
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
-    pip install --no-cache-dir -r /home/user/comps/lvms/src/requirements.txt && \
+    if [ ${ARCH} = "cpu" ]; then \
+      pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r /home/user/comps/lvms/src/requirements.txt; \
+    else \
+      pip install --no-cache-dir -r /home/user/comps/lvms/src/requirements.txt; \
+    fi && \
     pip install --no-cache-dir --upgrade transformers
 
 ENV PYTHONPATH=$PYTHONPATH:/home/user

--- a/comps/third_parties/llava/src/Dockerfile
+++ b/comps/third_parties/llava/src/Dockerfile
@@ -2,6 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 FROM python:3.11-slim
+
+# Set this to "cpu" or "gpu" or etc
+ARG ARCH="cpu"
+
 RUN useradd -m -s /bin/bash user && \
     mkdir -p /home/user && \
     chown -R user /home/user/
@@ -16,7 +20,11 @@ ENV PYTHONPATH=/home/user:/usr/lib/habanalabs/:/optimum-habana
 COPY comps /home/user/comps
 
 RUN pip install --no-cache-dir --upgrade pip setuptools && \
-    pip install --no-cache-dir -r /home/user/comps/third_parties/llava/src/requirements.txt
+    if [ ${ARCH} = "cpu" ]; then \
+      pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r /home/user/comps/third_parties/llava/src/requirements.txt; \
+    else \
+      pip install --no-cache-dir -r /home/user/comps/third_parties/llava/src/requirements.txt; \
+    fi
 
 ENV PYTHONPATH=$PYTHONPATH:/home/user
 


### PR DESCRIPTION
## Description

This PR adds optional `build-arg`'s for the following Dockerfiles:
```
- comps/lvms/src/Dockerfile
- comps/third_parties/llava/src/Dockerfile
```

## Issues

Current Dockerfiles always defaults to `gpu` Torch installation while `CPU` users might not necessarily need extra packages. This had the advantage of building smaller containers for CPU users and faster builds.

For users interested to do `gpu` builds, all they need to do is build this image this way for example:
```
docker build --build-arg ARCH='gpu' -f comps/lvms/src/Dockerfile -t opea/lvm:latest .
```

## Type of change

List the type of change like below. Please delete options that are not relevant.

- extra `build-arg` option `ARCH` to build a few of our containers for either CPU or GPU where applicable.

## Dependencies

None
