### PR TITLE
Architecture specific args for a few containers

### DIFF
--- a/comps/finetuning/src/Dockerfile
+++ b/comps/finetuning/src/Dockerfile
@@ -18,11 +18,11 @@ RUN chown -R user /home/user/comps/finetuning
 
 ENV PATH=$PATH:/home/user/.local/bin
 
-RUN python -m pip install --no-cache-dir --upgrade pip setuptools peft && \
+RUN python -m pip install --no-cache-dir --upgrade pip setuptools && \
     python -m pip install --no-cache-dir torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu && \
     python -m pip install --no-cache-dir intel-extension-for-pytorch && \
-    python -m pip install --no-cache-dir oneccl_bind_pt --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/cpu/cn/ && \
-    python -m pip install --no-cache-dir -r /home/user/comps/finetuning/src/requirements.txt
+    python -m pip install --no-cache-dir oneccl_bind_pt --extra-index-url https://pytorch-extension.intel.com/release-whl/stable/cpu/us/ && \
+    python -m pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r /home/user/comps/finetuning/src/requirements.txt
 
 ENV PYTHONPATH=$PYTHONPATH:/home/user
 

--- a/comps/third_parties/wav2lip/src/Dockerfile
+++ b/comps/third_parties/wav2lip/src/Dockerfile
@@ -4,6 +4,9 @@
 # Use a base image
 FROM python:3.11-slim
 
+# Set this to "cpu" or "gpu" or etc
+ARG ARCH="cpu"
+
 # Set environment variables
 ENV LANG=en_US.UTF-8
 ENV PYTHONPATH=/usr/local/lib/python3.11/site-packages:/home:/home/user
@@ -28,7 +31,7 @@ COPY comps /home/user/comps
 COPY comps/third_parties/wav2lip/src/entrypoint.sh /usr/local/bin/entrypoint.sh
 
 # Install ffmpeg with x264 software codec
-RUN git clone https://github.com/FFmpeg/FFmpeg.git /home/user/comps/animation/src/FFmpeg
+RUN git clone --depth=1 https://github.com/FFmpeg/FFmpeg.git /home/user/comps/animation/src/FFmpeg
 WORKDIR /home/user/comps/animation/src/FFmpeg
 RUN ./configure --enable-gpl --enable-libx264 --enable-cross-compile && \
     make -j$(nproc-1) && \
@@ -37,7 +40,7 @@ RUN ./configure --enable-gpl --enable-libx264 --enable-cross-compile && \
 RUN chmod +x $(which ffmpeg)
 
 # Upgrade pip
-RUN python3 -m pip install --upgrade pip
+RUN python3 -m pip install --upgrade pip setuptools
 
 # Install Wav2Lip from pip
 RUN pip install --no-cache-dir --no-deps Wav2Lipy
@@ -53,8 +56,11 @@ ENV PYTHONPATH="$PYTHONPATH:/usr/local/lib/python3.11/site-packages/gfpgan"
 WORKDIR /usr/local/lib/python3.11/site-packages
 
 # Install pip dependencies
-RUN pip install --no-cache-dir --upgrade pip setuptools && \
-    pip install --no-cache-dir -r /home/user/comps/animation/src/requirements.txt
+RUN if [ ${ARCH} = "cpu" ]; then \
+      pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -r /home/user/comps/animation/src/requirements.txt; \
+    else \
+      pip install --no-cache-dir -r /home/user/comps/animation/src/requirements.txt; \
+    fi
 
 # Custom patches
 # Modify the degradations.py file to import rgb_to_grayscale from torchvision.transforms.functional


### PR DESCRIPTION
## Description

This PR adds optional `build-arg`'s for the following Dockerfiles:
```
- comps/finetuning/src/Dockerfile
- comps/third_parties/wav2lip/src/Dockerfile
```

## Issues

Current Dockerfiles always defaults to `gpu` Torch installation while `CPU` users might not necessarily need extra packages. This had the advantage of building smaller containers for CPU users and faster builds.

For users interested to do `gpu` builds, all they need to do is build this image this way for example:
```
docker build --build-arg ARCH='gpu' -f comps/finetuning/src/Dockerfile -t opea/finetuning:latest .
```

## Type of change

List the type of change like below. Please delete options that are not relevant.

- extra `build-arg` option `ARCH` to build a few of our containers for either CPU or GPU where applicable.

## Dependencies

None
