### PR TITLE
dataprep: return same type of data in get_tables_result

### DIFF
--- a/comps/dataprep/src/utils.py
+++ b/comps/dataprep/src/utils.py
@@ -736,13 +736,13 @@ def parse_html_new(input, chunk_size, chunk_overlap):
 
 def get_tables_result(pdf_path, table_strategy):
     """Extract tables information from pdf file."""
+    tables_result = []
     if table_strategy == "fast":
-        return None
+        return tables_result
 
     from unstructured.documents.elements import FigureCaption
     from unstructured.partition.pdf import partition_pdf
 
-    tables_result = []
     raw_pdf_elements = partition_pdf(
         filename=pdf_path,
         infer_table_structure=True,


### PR DESCRIPTION
## Description

Return the same type of data in get_tables_result() to fix issue #1695

## Issues

Fixes #1695.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
