### PR TITLE
Resolve Hardcoded LVM Endpoint in Dataprep

### DIFF
--- a/comps/dataprep/src/utils.py
+++ b/comps/dataprep/src/utils.py
@@ -366,9 +366,10 @@ async def load_image(image_path):
     if os.getenv("SUMMARIZE_IMAGE_VIA_LVM", None) == "1":
         query = "Please summarize this image."
         image_b64_str = base64.b64encode(await read_image_async(image_path)).decode()
+        lvm_endpoint = os.getenv("LVM_ENDPOINT", "http://localhost:9399/v1/lvm")
         async with aiohttp.ClientSession() as session:
             async with session.post(
-                url="http://localhost:9399/v1/lvm",
+                url=lvm_endpoint,
                 json={"image": image_b64_str, "prompt": query},
                 headers={"Content-Type": "application/json"},
             ) as response:


### PR DESCRIPTION
## Description

Resolve Hardcoded LVM Endpoint in Dataprep
Get LVM endpoint from environment variables with default value `http://localhost:9399/v1/lvm` 

## Issues

Fixes https://github.com/opea-project/GenAIComps/issues/1698

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

None

## Tests

CI test
