### PR TITLE
Update docs to clone latest release v1.3 everywhere

### DIFF
--- a/tests/dataprep/test_dataprep_redis_multimodal.sh
+++ b/tests/dataprep/test_dataprep_redis_multimodal.sh
@@ -139,7 +139,7 @@ tire.""" > ${transcript_fn}
     wget https://github.com/docarray/docarray/blob/main/tests/toydata/image-data/apple.png?raw=true -O ${image_fn}
 
     echo "Downloading Image (jpg)"
-    wget https://raw.githubusercontent.com/opea-project/GenAIComps/refs/tags/v1.2/comps/animation/src/assets/img/avatar1.jpg -O ${jpg_image_fn}
+    wget https://raw.githubusercontent.com/opea-project/GenAIComps/refs/tags/v1.3/comps/animation/src/assets/img/avatar1.jpg -O ${jpg_image_fn}
 
     echo "Downloading Video"
     wget http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/WeAreGoingOnBullrun.mp4 -O ${video_fn}


### PR DESCRIPTION
## Description
Since v1.3 is out, we want to encourage users to use the latest version but making references to that version whenever there's a `git clone` for example.
Otherwise if they copy and paste commands then, they may not nessasirity using the latest version.

## Issues
N/A

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [X] Others (enhancement, documentation, validation, etc.)

## Dependencies
N/A

## Tests
Most likely just docs build is what's needed for this one before merge.