### PR TITLE
Add missing sentencepiece package for text2image microservice running sd3 model

### DIFF
--- a/comps/text2image/src/requirements.txt
+++ b/comps/text2image/src/requirements.txt
@@ -9,6 +9,7 @@ opentelemetry-sdk
 prometheus-fastapi-instrumentator
 pydantic==2.7.2
 pydub
+sentencepiece
 shortuuid
 torch
 transformers


### PR DESCRIPTION
## Description

Add missing sentencepiece package for text2image microservice running sd3 model.

When running sd3 model using text2image microservice, the below error was raised:

Traceback (most recent call last):

  File "/home/user/comps/text2image/src/opea_text2image_microservice.py", line 59, in <module>

    loader = OpeaComponentLoader(

  File "/home/user/comps/cores/common/component.py", line 152, in __init__

    self.component = component_class(**kwargs)

  File "/home/user/comps/text2image/src/integrations/native.py", line 51, in __init__

    self.pipe = GaudiStableDiffusion3Pipeline.from_pretrained(

  File "/home/user/.local/lib/python3.10/site-packages/optimum/habana/diffusers/pipelines/pipeline_utils.py", line 397, in from_pretrained

    model = super().from_pretrained(

  File "/home/user/.local/lib/python3.10/site-packages/huggingface_hub/utils/_validators.py", line 114, in _inner_fn

    return fn(*args, **kwargs)

  File "/home/user/.local/lib/python3.10/site-packages/diffusers/pipelines/pipeline_utils.py", line 896, in from_pretrained

    loaded_sub_model = load_sub_model(

  File "/home/user/.local/lib/python3.10/site-packages/diffusers/pipelines/pipeline_loading_utils.py", line 704, in load_sub_model

    loaded_sub_model = load_method(os.path.join(cached_folder, name), **loading_kwargs)

  File "/home/user/.local/lib/python3.10/site-packages/transformers/tokenization_utils_base.py", line 2052, in from_pretrained

    return cls._from_pretrained(

  File "/home/user/.local/lib/python3.10/site-packages/transformers/tokenization_utils_base.py", line 2292, in _from_pretrained

    tokenizer = cls(*init_inputs, **init_kwargs)

  File "/home/user/.local/lib/python3.10/site-packages/transformers/models/t5/tokenization_t5_fast.py", line 119, in __init__

    super().__init__(

  File "/home/user/.local/lib/python3.10/site-packages/transformers/tokenization_utils_fast.py", line 108, in __init__

    raise ValueError(

ValueError: Cannot instantiate this tokenizer from a slow version. If it's based on sentencepiece, make sure you have sentencepiece installed.

## Issues

`n/a`

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

None

## Tests

Local test and CI test.
