### PR TITLE
Bug fix: set openai version to 1.81.0

### DIFF
--- a/comps/dataprep/src/requirements.txt
+++ b/comps/dataprep/src/requirements.txt
@@ -39,7 +39,7 @@ markdown
 moviepy
 neo4j
 numpy
-openai
+openai==1.81.0
 openai-whisper
 opencv-python
 opensearch-py


### PR DESCRIPTION
## Description


Set openai version to 1.81.0 to avoid the datapep service failure. 

## Issues

#1749

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies
N/A

## Tests
GenAIComps_msc/tests/dataprep/