### PR TITLE
improve the performance by replace the keys by dbsize

### DIFF
--- a/comps/retrievers/src/integrations/redis.py
+++ b/comps/retrievers/src/integrations/redis.py
@@ -148,7 +148,7 @@ class OpeaRedisRetriever(OpeaComponent):
 
         except Exception as e:
             logger.error(f"Redis key check failed: {e}")
-            keys_exist = []
+            keys_exist = False
 
         if not keys_exist:
             if logflag:

--- a/comps/retrievers/src/integrations/redis.py
+++ b/comps/retrievers/src/integrations/redis.py
@@ -144,7 +144,7 @@ class OpeaRedisRetriever(OpeaComponent):
 
         # check if the Redis index has data
         try:
-            keys_exist = client.client.keys()
+            keys_exist = client.client.dbsize() > 0
 
         except Exception as e:
             logger.error(f"Redis key check failed: {e}")


### PR DESCRIPTION
## Description

To get perf improvement by replace the keys by dbsize when ingesting large dataset(pubmed_1files.txt,pubmed_10files.txt,pubmed_100files.txt)

## Issues

List the issue or RFC link this PR is working on. If there is no such link, please mark it as `n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
Below we could see the throughput got 10.9x speedup, TTFT got 11.4x, with pubmed_100files.txt
<img width="655" alt="image" src="https://github.com/user-attachments/assets/22fdb671-d225-4487-91c9-de3a28664cb4" />


Here is a flamegraph shows that the function keys() consumes almost 50% cpu time.
<img width="469" alt="image" src="https://github.com/user-attachments/assets/7bba5ef8-1700-417b-aeaa-87d264845f34" />

