### PR TITLE
fix the redis version due to conflic with langchain-redis

### DIFF
--- a/comps/dataprep/src/requirements.txt
+++ b/comps/dataprep/src/requirements.txt
@@ -61,7 +61,7 @@ python-bidi
 python-docx
 python-pptx
 qdrant-client
-redis
+redis==5.2.1
 scipy
 sentence_transformers
 shortuuid


### PR DESCRIPTION
## Description

fix the redis version due to conflic with langchain-redis

## Issues
[1765](https://github.com/opea-project/GenAIComps/issues/1765)

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests
GenAIComps_msc/tests/dataprep
