### PR TITLE
Add postgres health check for text2sql

### DIFF
--- a/comps/text2sql/src/README.md
+++ b/comps/text2sql/src/README.md
@@ -122,6 +122,8 @@ export LLM_MODEL_ID="mistralai/Mistral-7B-Instruct-v0.3"
 export POSTGRES_USER=postgres
 export POSTGRES_PASSWORD=testpwd
 export POSTGRES_DB=chinook
+export LLM_ENDPOINT_PORT=${TGI_PORT}
+export host_ip=${your_ip}
 ```
 
 ##### Start the services.
@@ -149,15 +151,15 @@ The Text-to-SQL microservice exposes the following API endpoints:
 - Test Database Connection
 
   ```bash
-  curl --location http://${your_ip}:9090/v1/postgres/health \
+  curl --location http://${your_ip}:8080/v1/postgres/health \
   --header 'Content-Type: application/json' \
-  --data '{"user": "'${POSTGRES_USER}'","password": "'${POSTGRES_PASSWORD}'","host": "'${your_ip}'", "port": "5442", "database": "'${POSTGRES_DB}'"}'
+  --data '{"conn_str": {"user": "'${POSTGRES_USER}'","password": "'${POSTGRES_PASSWORD}'","host": "'${your_ip}'", "port": "5442", "database": "'${POSTGRES_DB}'"}}'
   ```
 
 - Execute SQL Query from input text
 
   ```bash
-  curl http://${your_ip}:9090/v1/text2sql\
+  curl http://${your_ip}:8080/v1/text2sql\
           -X POST \
           -d '{"input_text": "Find the total number of Albums.","conn_str": {"user": "'${POSTGRES_USER}'","password": "'${POSTGRES_PASSWORD}'","host": "'${your_ip}'", "port": "5442", "database": "'${POSTGRES_DB}'"}}' \
           -H 'Content-Type: application/json'

--- a/comps/text2sql/src/integrations/opea.py
+++ b/comps/text2sql/src/integrations/opea.py
@@ -69,6 +69,10 @@ class Input(BaseModel):
     conn_str: Optional[PostgresConnection] = None
 
 
+class DBConnectionInput(BaseModel):
+    conn_str: PostgresConnection
+
+
 @OpeaComponentRegistry.register("OPEA_TEXT2SQL")
 class OpeaText2SQL(OpeaComponent):
     """A specialized text to sql component derived from OpeaComponent for interacting with TGI services and Database.

--- a/comps/text2sql/src/opea_text2sql_microservice.py
+++ b/comps/text2sql/src/opea_text2sql_microservice.py
@@ -5,11 +5,11 @@ import os
 import pathlib
 import sys
 
-from fastapi.exceptions import HTTPException
 from fastapi import status
+from fastapi.exceptions import HTTPException
 
 from comps import CustomLogger, OpeaComponentLoader, opea_microservices, register_microservice
-from comps.text2sql.src.integrations.opea import Input, DBConnectionInput, OpeaText2SQL
+from comps.text2sql.src.integrations.opea import DBConnectionInput, Input, OpeaText2SQL
 
 cur_path = pathlib.Path(__file__).parent.resolve()
 comps_path = os.path.join(cur_path, "../../../")


### PR DESCRIPTION
## Description

API "/v1/postgres/health" is missing in text2sql microservice, which is required by UI in GenAIExample. This commit adds the api and fix several typos in README.

## Issues

https://github.com/opea-project/GenAIComps/issues/1776

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

N/A

## Tests

curl  --location http://ip:port/v1/postgres/health \
--header 'Content-Type: application/json' \
--data '{"conn_str": {"user": "'${POSTGRES_USER}'","password": "'${POSTGRES_PASSWORD}'","host": "'${your_ip}'", "port": "5442", "database": "'${POSTGRES_DB}'"}}'
