### PR TITLE
Use one local image registry for gaudi and xeon test

### DIFF
--- a/.github/workflows/manual-comps-test.yml
+++ b/.github/workflows/manual-comps-test.yml
@@ -16,7 +16,7 @@ on:
         required: false
         type: boolean
       image_build_nodes:
-        default: "gaudi,xeon"
+        default: "gaudi"
         description: "Build test required images for Comps on gaudi,xeon"
         required: true
         type: string

--- a/.github/workflows/push-base-image-upstream.yml
+++ b/.github/workflows/push-base-image-upstream.yml
@@ -21,7 +21,7 @@ jobs:
   image-build:
     strategy:
       matrix:
-        node: [xeon, gaudi]
+        node: [gaudi]
     runs-on: docker-build-${{ matrix.node }}
     continue-on-error: true
     steps:

--- a/.github/workflows/push-image-build.yml
+++ b/.github/workflows/push-image-build.yml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       matrix:
         service: ${{ fromJSON(needs.get-build-matrix.outputs.services) }}
-        node: [xeon, gaudi]
+        node: [gaudi]
     runs-on: docker-build-${{ matrix.node }}
     continue-on-error: true
     steps:


### PR DESCRIPTION
## Description

Use the same local image registry for gaudi and xeon for the new CICD cluster. 

## Issues

List the issue or RFC link this PR is working on. If there is no such link, please mark it as `n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [x] Others (enhancement, documentation, validation, etc.)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
