### PR TITLE
Fix opensearch db fail to start issue

### DIFF
--- a/comps/third_parties/opensearch/deployment/docker_compose/compose.yaml
+++ b/comps/third_parties/opensearch/deployment/docker_compose/compose.yaml
@@ -12,8 +12,7 @@ services:
       - host_ip=${host_ip}
       - cluster.name=opensearch-cluster
       - node.name=opensearch-vector-db
-      - discovery.seed_hosts=opensearch-vector-db
-      - cluster.initial_master_nodes=opensearch-vector-db
+      - discovery.type=single-node
       - bootstrap.memory_lock=true  # along with the memlock settings below, disables swapping
       - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"  # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
       - OPENSEARCH_INITIAL_ADMIN_PASSWORD=${OPENSEARCH_INITIAL_ADMIN_PASSWORD}  # Sets the demo admin user password when using demo configuration, required for OpenSearch 2.12 and later
@@ -22,7 +21,7 @@ services:
         soft: -1
         hard: -1
       nofile:
-        soft: 65536  # maximum number of open files for the OpenSearch user, set to at least 65536 on modern systems
+        soft: 262144
         hard: 262144
     ports:
       - "${OPENSEARCH_PORT1:-9200}:9200"


### PR DESCRIPTION
## Description

Fix opensearch db fail to start issue.
On new CI machines, error `max virtual memory areas vm.max_map_count [65530] is too low, increase to at least [262144]` occurs when starting opensearch db service.
Enlarge this parameter to fix this issue.

## Issues

failed CI test: https://github.com/opea-project/GenAIComps/actions/runs/16926181462/job/47962184848?pr=1878#step:5:1864

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Dependencies

None

## Tests

Local tested
