### PR TITLE
Update the URL of  `libreoffice` for DataPrep openEuler

### DIFF
--- a/comps/dataprep/src/Dockerfile.openEuler
+++ b/comps/dataprep/src/Dockerfile.openEuler
@@ -26,13 +26,13 @@ RUN yum update -y && yum install -y \
 
 ENV TESSDATA_PREFIX=/usr/share/tesseract/tessdata
 
-RUN LIBREOFFICE_URL=https://mirrors.tuna.tsinghua.edu.cn/libreoffice/libreoffice/stable/25.2.6/rpm/x86_64/LibreOffice_25.2.6_Linux_x86-64_rpm.tar.gz && \
+RUN LIBREOFFICE_URL=https://mirrors.tuna.tsinghua.edu.cn/libreoffice/libreoffice/stable/25.8.1/rpm/x86_64/LibreOffice_25.8.1_Linux_x86-64_rpm.tar.gz && \
     wget $LIBREOFFICE_URL -O /tmp/libreOffice.tar.gz && \
     tar --strip-components=1 -xvf /tmp/libreOffice.tar.gz -C /tmp && \
     yum install -y /tmp/RPMS/*.rpm && \
     yum clean all && \
     rm -fr /tmp/libreOffice.tar.gz /tmp/RPMS && \
-    ln -sf /usr/bin/libreoffice25.2 /usr/bin/libreoffice
+    ln -sf /usr/bin/libreoffice25.8 /usr/bin/libreoffice
 
 RUN useradd -m -s /bin/bash user && \
     mkdir -p /home/user && \

--- a/comps/dataprep/src/Dockerfile.openEuler
+++ b/comps/dataprep/src/Dockerfile.openEuler
@@ -26,7 +26,7 @@ RUN yum update -y && yum install -y \
 
 ENV TESSDATA_PREFIX=/usr/share/tesseract/tessdata
 
-RUN LIBREOFFICE_URL=https://mirrors.tuna.tsinghua.edu.cn/libreoffice/libreoffice/stable/25.2.4/rpm/x86_64/LibreOffice_25.2.4_Linux_x86-64_rpm.tar.gz && \
+RUN LIBREOFFICE_URL=https://mirrors.tuna.tsinghua.edu.cn/libreoffice/libreoffice/stable/25.2.6/rpm/x86_64/LibreOffice_25.2.6_Linux_x86-64_rpm.tar.gz && \
     wget $LIBREOFFICE_URL -O /tmp/libreOffice.tar.gz && \
     tar --strip-components=1 -xvf /tmp/libreOffice.tar.gz -C /tmp && \
     yum install -y /tmp/RPMS/*.rpm && \


### PR DESCRIPTION
## Description

The URL of `libreoffice` is outdated.

## Issues

https://github.com/opea-project/GenAIExamples/issues/2233

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
