### PR TITLE
Fix GenAIExamples#2275

### DIFF
--- a/comps/third_parties/gpt-sovits/src/start.sh
+++ b/comps/third_parties/gpt-sovits/src/start.sh
@@ -23,6 +23,12 @@ else
   exit 1
 fi
 
+# Fast-langdetect version 1.0.0 and later requires a user-specified cache directory to be created manually if it doesn't already exist.
+fast_langdetect_cache_dir="/home/user/GPT-SoVITS/GPT_SoVITS/pretrained_models/fast_langdetect"
+if [ ! -d "${fast_langdetect_cache_dir}" ]; then
+  mkdir -p ${fast_langdetect_cache_dir}
+fi
+
 export NLTK_DATA=/home/user/nltk_data
 
 python api.py --default_refer_path ./welcome_cn.wav --default_refer_text "欢迎使用" --default_refer_language "zh"


### PR DESCRIPTION
## Description

Fast-langdetect version 1.0.0 and later requires a user-specified cache directory to be created manually if it doesn't already exist.

## Issues

opea-project/GenAIExamples#2275

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

n/a

## Tests

n/a
