### PR TITLE
Fix the source of LibreOffice

### DIFF
--- a/comps/dataprep/src/Dockerfile.openEuler
+++ b/comps/dataprep/src/Dockerfile.openEuler
@@ -26,7 +26,7 @@ RUN yum update -y && yum install -y \
 
 ENV TESSDATA_PREFIX=/usr/share/tesseract/tessdata
 
-RUN LIBREOFFICE_URL=https://mirrors.tuna.tsinghua.edu.cn/libreoffice/libreoffice/stable/25.8.1/rpm/x86_64/LibreOffice_25.8.1_Linux_x86-64_rpm.tar.gz && \
+RUN LIBREOFFICE_URL=https://downloadarchive.documentfoundation.org/libreoffice/old/25.8.2.2/rpm/x86_64/LibreOffice_25.8.2.2_Linux_x86-64_rpm.tar.gz && \
     wget $LIBREOFFICE_URL -O /tmp/libreOffice.tar.gz && \
     tar --strip-components=1 -xvf /tmp/libreOffice.tar.gz -C /tmp && \
     yum install -y /tmp/RPMS/*.rpm && \


### PR DESCRIPTION
## Description

This pull request updates the LibreOffice installation source and version in the `Dockerfile.openEuler`. The change ensures that the Docker image uses a newer and more reliable LibreOffice package.

Dependency update:

* Updated the LibreOffice download URL and version from `25.8.1` to `25.8.2.2` in the `RUN` command of `Dockerfile.openEuler` to use the official Document Foundation archive, improving reliability and ensuring the latest fixes are included.
## Issues

List the issue or RFC link this PR is working on. If there is no such link, please mark it as `n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Dependencies

List the newly introduced 3rd party dependency if exists.

## Tests

Describe the tests that you ran to verify your changes.
