### PR TITLE
Add mcp support for text2image

### DIFF
--- a/comps/text2image/deployment/docker_compose/compose.yaml
+++ b/comps/text2image/deployment/docker_compose/compose.yaml
@@ -11,6 +11,7 @@ services:
       - no_proxy=${no_proxy}
       - https_proxy=${https_proxy}
       - http_proxy=${http_proxy}
+      - ENABLE_MCP=${ENABLE_MCP:-false}
       - MODEL=${MODEL}
       - HF_TOKEN=${HF_TOKEN}
     ipc: host

--- a/comps/text2image/src/README.md
+++ b/comps/text2image/src/README.md
@@ -23,6 +23,7 @@ export MODEL=stabilityai/stable-diffusion-2-1
 export MODEL=stabilityai/stable-diffusion-xl-base-1.0
 # SD3
 export MODEL=stabilityai/stable-diffusion-3-medium-diffusers
+export ENABLE_MCP=${ENABLE_MCP:-false}
 ```
 
 Set huggingface token:
@@ -36,6 +37,8 @@ Start the OPEA Microservice:
 ```bash
 python opea_text2image_microservice.py --bf16 --model_name_or_path $MODEL --token $HF_TOKEN
 ```
+
+Note: when ENABLE_MCP=true, the service starts an MCP SSE server instead of the regular HTTP endpoint.
 
 # 🚀2. Start Microservice with Docker (Option 2)
 
@@ -52,6 +55,7 @@ export MODEL=stabilityai/stable-diffusion-2-1
 export MODEL=stabilityai/stable-diffusion-xl-base-1.0
 # SD3
 export MODEL=stabilityai/stable-diffusion-3-medium-diffusers
+export ENABLE_MCP=${ENABLE_MCP:-false}
 ```
 
 ### 2.1.1 Text-to-Image Service Image on Xeon
@@ -79,7 +83,7 @@ docker build -t opea/text2image-gaudi:latest --build-arg https_proxy=$https_prox
 Start text-to-image service on Xeon with below command:
 
 ```bash
-docker run --ipc=host -p 9379:9379 -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e HF_TOKEN=$HF_TOKEN -e MODEL=$MODEL opea/text2image:latest
+docker run --ipc=host -p 9379:9379 -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e HF_TOKEN=$HF_TOKEN -e MODEL=$MODEL -e ENABLE_MCP=$ENABLE_MCP opea/text2image:latest
 ```
 
 Or use docker compose with below command:
@@ -94,7 +98,7 @@ docker compose -f compose.yaml up text2image -d
 Start text-to-image service on Gaudi with below command:
 
 ```bash
-docker run -p 9379:9379 --runtime=habana -e HABANA_VISIBLE_DEVICES=all -e OMPI_MCA_btl_vader_single_copy_mechanism=none --cap-add=sys_nice --ipc=host -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e HF_TOKEN=$HF_TOKEN -e MODEL=$MODEL opea/text2image-gaudi:latest
+docker run -p 9379:9379 --runtime=habana -e HABANA_VISIBLE_DEVICES=all -e OMPI_MCA_btl_vader_single_copy_mechanism=none --cap-add=sys_nice --ipc=host -e http_proxy=$http_proxy -e https_proxy=$https_proxy -e HF_TOKEN=$HF_TOKEN -e MODEL=$MODEL -e ENABLE_MCP=$ENABLE_MCP opea/text2image-gaudi:latest
 ```
 
 Or use docker compose with below command:

--- a/comps/text2image/src/opea_text2image_microservice.py
+++ b/comps/text2image/src/opea_text2image_microservice.py
@@ -16,9 +16,11 @@ from comps import (
     register_statistics,
     statistics_dict,
 )
+from comps.cores.mega.constants import MCPFuncType
 from comps.text2image.src.integrations.native import OpeaText2image
 
 logger = CustomLogger("opea_text2image_microservice")
+enable_mcp = os.getenv("ENABLE_MCP", "").strip().lower() in {"true", "1", "yes"}
 
 
 @register_microservice(
@@ -29,6 +31,9 @@ logger = CustomLogger("opea_text2image_microservice")
     port=9379,
     input_datatype=SDInputs,
     output_datatype=SDOutputs,
+    enable_mcp=enable_mcp,
+    mcp_func_type=MCPFuncType.TOOL,
+    description="Generate image(s) from a text prompt.",
 )
 @register_statistics(names=["opea_service@text2image"])
 async def text2image(input: SDInputs):

--- a/comps/text2image/src/requirements-cpu.txt
+++ b/comps/text2image/src/requirements-cpu.txt
@@ -132,9 +132,11 @@ mapbox-earcut==2.0.0
 markdown-it-py==4.0.0
     # via rich
 markupsafe==3.0.3
+    # via markdown-it-py
+mcp==1.25.0
     # via jinja2
 mdurl==0.1.2
-    # via markdown-it-py
+    # via -r ./comps/text2image/src/requirements.in
 ml-dtypes==0.5.4
     # via
     #   jax
@@ -261,12 +263,12 @@ pyarrow==22.0.0
     # via datasets
 pycollada==0.9.2
     # via trimesh
-pydantic==2.7.2
+pydantic==2.12.5
     # via
     #   -r ./comps/text2image/src/requirements.in
     #   docarray
     #   fastapi
-pydantic-core==2.18.3
+pydantic-core==2.41.5
     # via pydantic
 pydub==0.25.1
     # via

--- a/comps/text2image/src/requirements-gpu.txt
+++ b/comps/text2image/src/requirements-gpu.txt
@@ -136,9 +136,11 @@ mapbox-earcut==2.0.0
 markdown-it-py==4.0.0
     # via rich
 markupsafe==3.0.3
+    # via markdown-it-py
+mcp==1.25.0
     # via jinja2
 mdurl==0.1.2
-    # via markdown-it-py
+    # via -r ./comps/text2image/src/requirements.in
 ml-dtypes==0.5.4
     # via
     #   jax
@@ -306,12 +308,12 @@ pyarrow==22.0.0
     # via datasets
 pycollada==0.9.2
     # via trimesh
-pydantic==2.7.2
+pydantic==2.12.5
     # via
     #   -r ./comps/text2image/src/requirements.in
     #   docarray
     #   fastapi
-pydantic-core==2.18.3
+pydantic-core==2.41.5
     # via pydantic
 pydub==0.25.1
     # via

--- a/comps/text2image/src/requirements.in
+++ b/comps/text2image/src/requirements.in
@@ -3,12 +3,13 @@ datasets
 diffusers
 docarray[full]
 fastapi
+mcp>=1.23.0
 opentelemetry-api
 opentelemetry-exporter-otlp
 opentelemetry-sdk
 pillow>=11.3.0
 prometheus-fastapi-instrumentator
-pydantic==2.7.2
+pydantic==2.12.5
 pydub
 sentencepiece
 shortuuid

--- a/tests/text2image/test_text2image_mcp.sh
+++ b/tests/text2image/test_text2image_mcp.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+set -x
+
+WORKPATH=$(git rev-parse --show-toplevel)
+host_addr=${MCP_HOST:-127.0.0.1}
+service_name="text2image"
+export ENABLE_MCP=true
+export TEXT2IMAGE_PORT=${TEXT2IMAGE_PORT:-9379}
+
+function build_docker_images() {
+    cd $WORKPATH
+    echo $(pwd)
+    docker build --no-cache -t opea/text2image:latest -f comps/text2image/src/Dockerfile .
+    if [ $? -ne 0 ]; then
+        echo "opea/text2image built fail"
+        exit 1
+    else
+        echo "opea/text2image built successful"
+    fi
+}
+
+function start_service() {
+    unset http_proxy
+    export MODEL=stabilityai/stable-diffusion-xl-base-1.0
+    cd $WORKPATH/comps/text2image/deployment/docker_compose
+    docker compose -f compose.yaml up ${service_name} -d > start_services_with_compose.log
+    sleep 30s
+}
+
+function validate_microservice() {
+    echo "===================  START VALIDATE ========================"
+    local attempt=0
+    local max_attempts=24
+    local sse_response=000
+    while [[ $attempt -lt $max_attempts ]]; do
+        sse_response=$(curl -s -o /dev/null -w "%{http_code}" \
+            --max-time 5 \
+            -H "Accept: text/event-stream" \
+            http://$host_addr:${TEXT2IMAGE_PORT}/sse)
+        if [[ $sse_response -eq 200 ]]; then
+            break
+        fi
+        attempt=$((attempt + 1))
+        sleep 10s
+    done
+
+    if [[ $sse_response -ne 200 ]]; then
+        echo "ERROR: SSE endpoint should be available when MCP is enabled (got HTTP $sse_response)"
+        docker logs text2image
+        exit 1
+    fi
+
+    pip install mcp
+    python3 $WORKPATH/tests/text2image/validate_mcp.py $host_addr $TEXT2IMAGE_PORT
+    echo "===================  END VALIDATE ========================"
+}
+
+function stop_docker() {
+    cd $WORKPATH/comps/text2image/deployment/docker_compose
+    docker compose -f compose.yaml down --remove-orphans
+}
+
+function main() {
+
+    stop_docker
+
+    build_docker_images
+    start_service
+
+    validate_microservice
+
+    stop_docker
+    echo y | docker system prune
+
+}
+
+main

--- a/tests/text2image/validate_mcp.py
+++ b/tests/text2image/validate_mcp.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import json
+import sys
+
+from mcp.client.session import ClientSession
+from mcp.client.sse import sse_client
+
+SAMPLE_INPUT = {
+    "prompt": "A small red robot holding a yellow balloon",
+    "num_images_per_prompt": 1,
+}
+
+
+def extract_text(content):
+    if not content:
+        return ""
+    first = content[0]
+    if hasattr(first, "text"):
+        return first.text
+    if isinstance(first, str):
+        return first
+    return str(first)
+
+
+def has_images(payload):
+    if isinstance(payload, dict):
+        images = payload.get("images")
+        return isinstance(images, list) and len(images) > 0
+    return False
+
+
+async def validate_text2image_mcp(ip_address, service_port):
+    endpoint = f"http://{ip_address}:{service_port}"
+    async with sse_client(endpoint + "/sse") as streams:
+        async with ClientSession(*streams) as session:
+            await session.initialize()
+            tool_result = await session.call_tool("text2image", {"input": SAMPLE_INPUT})
+            response_text = extract_text(tool_result.content)
+            if not response_text:
+                print("No response content from MCP tool.")
+                return False
+
+            try:
+                payload = json.loads(response_text)
+            except json.JSONDecodeError:
+                try:
+                    import ast
+
+                    payload = ast.literal_eval(response_text)
+                except Exception:
+                    payload = None
+
+            if payload and has_images(payload):
+                print("MCP text2image returned images.")
+                return True
+
+            if "images" in response_text.lower():
+                print("MCP text2image returned images (string match).")
+                return True
+
+            print(f"Unexpected response content: {response_text}")
+            return False
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python3 validate_mcp.py <ip_address> <service_port>")
+        sys.exit(1)
+
+    ip_address = sys.argv[1]
+    service_port = sys.argv[2]
+    success = asyncio.run(validate_text2image_mcp(ip_address, service_port))
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
Enabled MCP support for both text2graph and text2image microservices, wiring the ENABLE_MCP flag into  service registration and adding SSE/Tool metadata. Updated dependencies to include mcp and aligned  pydantic versions to satisfy MCP constraints, with corresponding lockfile updates. Added MCP-specific  tests and validation scripts with robust SSE readiness checks, plus deployment and README updates to  document MCP mode behavior and env vars.