### PR TITLE
Add mcp support for finetuning comp

### DIFF
--- a/comps/finetuning/deployment/docker_compose/compose.yaml
+++ b/comps/finetuning/deployment/docker_compose/compose.yaml
@@ -13,6 +13,7 @@ services:
       - https_proxy=${https_proxy}
       - http_proxy=${http_proxy}
       - HF_TOKEN=${HF_TOKEN}
+      - ENABLE_MCP=${ENABLE_MCP:-false}
     ipc: host
     restart: always
   finetuning-xtune:
@@ -27,6 +28,7 @@ services:
       - https_proxy=${https_proxy}
       - http_proxy=${http_proxy}
       - HF_TOKEN=${HF_TOKEN}
+      - ENABLE_MCP=${ENABLE_MCP:-false}
     devices:
       - "/dev/dri:/dev/dri"
     volumes:

--- a/comps/finetuning/src/README.md
+++ b/comps/finetuning/src/README.md
@@ -8,6 +8,7 @@ Fine-tuning microservice involves adapting a model to a specific task or dataset
 2. [🚀2. Start Microservice with Docker (Option 2)](#2-Start-Microservice-with-Docker-Option-2)
 3. [🚀3. Consume Finetuning Service](#3-Consume-Finetuning-Service)
 4. [🚀4. Descriptions for Finetuning parameters](#4-Descriptions-for-Finetuning-parameters)
+5. [🤖5. MCP Usage (Optional)](#5-MCP-Usage-Optional)
 
 ## 🚀1. Start Microservice with Python (Option 1)
 
@@ -318,3 +319,9 @@ Please see [Xtune doc](./integrations/xtune/README.md) for details.
 ## 🚀4. Descriptions for Finetuning parameters
 
 We utilize [OpenAI finetuning parameters](https://platform.openai.com/docs/api-reference/fine-tuning) and extend it with more customizable parameters, see the definitions at [finetune_config](https://github.com/opea-project/GenAIComps/blob/main/comps/finetuning/src/integrations/finetune_config.py).
+
+## 🤖5. MCP Usage (Optional)
+
+Set `ENABLE_MCP=true` to run the service in MCP (Model Context Protocol) mode. When MCP is enabled, the service exposes tools over the MCP SSE server on port 8015 and regular HTTP endpoints are not served.
+
+The MCP tools map to the same functionality as the HTTP APIs (create/list/retrieve/cancel jobs and list checkpoints). For training data upload in MCP mode, use the base64 upload tool `upload_training_files_mcp` with `filename`, `content_base64`, and optional `purpose` fields.

--- a/comps/finetuning/src/integrations/native.py
+++ b/comps/finetuning/src/integrations/native.py
@@ -4,11 +4,12 @@
 import os
 import random
 import re
+import threading
 import time
 import urllib.parse
 import uuid
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional
 
 from fastapi import BackgroundTasks, File, Form, HTTPException, UploadFile
 from pydantic_yaml import to_yaml_file
@@ -66,6 +67,14 @@ def update_job_status(job_id: FineTuningJobID):
         time.sleep(CHECK_JOB_STATUS_INTERVAL)
 
 
+def schedule_job_status_update(background_tasks: Optional[BackgroundTasks], job_id: FineTuningJobID):
+    if background_tasks is None:
+        thread = threading.Thread(target=update_job_status, args=(job_id,), daemon=True)
+        thread.start()
+    else:
+        background_tasks.add_task(update_job_status, job_id)
+
+
 async def save_content_to_local_disk(save_path: str, content):
     save_path = Path(save_path)
     try:
@@ -92,7 +101,7 @@ class OpeaFinetuning(OpeaComponent):
     def __init__(self, name: str, description: str, config: dict = None):
         super().__init__(name, "finetuning", description, config)
 
-    def create_finetuning_jobs(self, request: FineTuningParams, background_tasks: BackgroundTasks):
+    def create_finetuning_jobs(self, request: FineTuningParams, background_tasks: Optional[BackgroundTasks] = None):
         base_model = request.model
         train_file = request.training_file
         train_file_path = os.path.join(DATASET_BASE_PATH, train_file)
@@ -167,7 +176,7 @@ class OpeaFinetuning(OpeaComponent):
         running_finetuning_jobs[job.id] = job
         finetuning_job_to_ray_job[job.id] = ray_job_id
 
-        background_tasks.add_task(update_job_status, job.id)
+        schedule_job_status_update(background_tasks, job.id)
 
         return job
 

--- a/comps/finetuning/src/opea_finetuning_microservice.py
+++ b/comps/finetuning/src/opea_finetuning_microservice.py
@@ -1,10 +1,14 @@
 # Copyright (C) 2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
+import base64
+import io
 import os
 
-from fastapi import BackgroundTasks, Depends
+from fastapi import Depends, UploadFile
+from pydantic import BaseModel
 
 from comps import CustomLogger, opea_microservices, register_microservice
+from comps.cores.mega.constants import MCPFuncType
 from comps.cores.proto.api_protocol import FineTuningJobIDRequest, UploadFileRequest
 from comps.finetuning.src.integrations.finetune_config import FineTuningParams
 from comps.finetuning.src.integrations.native import OpeaFinetuning, upload_file
@@ -12,6 +16,7 @@ from comps.finetuning.src.integrations.xtune import XtuneFinetuning
 from comps.finetuning.src.opea_finetuning_loader import OpeaFinetuningLoader
 
 logger = CustomLogger("opea_finetuning_microservice")
+enable_mcp = os.getenv("ENABLE_MCP", "").strip().lower() in {"true", "1", "yes"}
 
 finetuning_component_name = os.getenv("FINETUNING_COMPONENT_NAME", "OPEA_FINETUNING")
 # Initialize OpeaComponentLoader
@@ -21,20 +26,47 @@ loader = OpeaFinetuningLoader(
 )
 
 
-@register_microservice(name="opea_service@finetuning", endpoint="/v1/fine_tuning/jobs", host="0.0.0.0", port=8015)
-def create_finetuning_jobs(request: FineTuningParams, background_tasks: BackgroundTasks):
-    return loader.create_finetuning_jobs(request, background_tasks)
+class UploadTrainingFileMCPRequest(BaseModel):
+    filename: str
+    content_base64: str
+    purpose: str = "fine-tune"
 
 
 @register_microservice(
-    name="opea_service@finetuning", endpoint="/v1/fine_tuning/jobs", host="0.0.0.0", port=8015, methods=["GET"]
+    name="opea_service@finetuning",
+    endpoint="/v1/fine_tuning/jobs",
+    host="0.0.0.0",
+    port=8015,
+    enable_mcp=enable_mcp,
+    mcp_func_type=MCPFuncType.TOOL,
+    description="Create a fine-tuning job.",
+)
+def create_finetuning_jobs(request: FineTuningParams):
+    return loader.create_finetuning_jobs(request, None)
+
+
+@register_microservice(
+    name="opea_service@finetuning",
+    endpoint="/v1/fine_tuning/jobs",
+    host="0.0.0.0",
+    port=8015,
+    methods=["GET"],
+    enable_mcp=enable_mcp,
+    mcp_func_type=MCPFuncType.TOOL,
+    description="List fine-tuning jobs.",
 )
 def list_finetuning_jobs():
     return loader.list_finetuning_jobs()
 
 
 @register_microservice(
-    name="opea_service@finetuning", endpoint="/v1/fine_tuning/jobs/retrieve", host="0.0.0.0", port=8015
+    name="opea_service@finetuning",
+    endpoint="/v1/fine_tuning/jobs/retrieve",
+    host="0.0.0.0",
+    port=8015,
+    enable_mcp=enable_mcp,
+    mcp_func_type=MCPFuncType.TOOL,
+    description="Retrieve a fine-tuning job by ID.",
 )
 def retrieve_finetuning_job(request: FineTuningJobIDRequest):
     job = loader.retrieve_finetuning_job(request)
@@ -42,7 +74,13 @@ def retrieve_finetuning_job(request: FineTuningJobIDRequest):
 
 
 @register_microservice(
-    name="opea_service@finetuning", endpoint="/v1/fine_tuning/jobs/cancel", host="0.0.0.0", port=8015
+    name="opea_service@finetuning",
+    endpoint="/v1/fine_tuning/jobs/cancel",
+    host="0.0.0.0",
+    port=8015,
+    enable_mcp=enable_mcp,
+    mcp_func_type=MCPFuncType.TOOL,
+    description="Cancel a fine-tuning job by ID.",
 )
 def cancel_finetuning_job(request: FineTuningJobIDRequest):
     job = loader.cancel_finetuning_job(request)
@@ -54,6 +92,7 @@ def cancel_finetuning_job(request: FineTuningJobIDRequest):
     endpoint="/v1/files",
     host="0.0.0.0",
     port=8015,
+    enable_mcp=False,
 )
 async def upload_training_files(request: UploadFileRequest = Depends(upload_file)):
     uploadFileInfo = await loader.upload_training_files(request)
@@ -61,7 +100,30 @@ async def upload_training_files(request: UploadFileRequest = Depends(upload_file
 
 
 @register_microservice(
-    name="opea_service@finetuning", endpoint="/v1/finetune/list_checkpoints", host="0.0.0.0", port=8015
+    name="opea_service@finetuning",
+    endpoint="/v1/files/base64",
+    host="0.0.0.0",
+    port=8015,
+    enable_mcp=enable_mcp,
+    mcp_func_type=MCPFuncType.TOOL,
+    description="Upload a training file using base64-encoded content.",
+)
+async def upload_training_files_mcp(request: UploadTrainingFileMCPRequest):
+    file_bytes = base64.b64decode(request.content_base64)
+    upload_file_obj = UploadFile(filename=request.filename, file=io.BytesIO(file_bytes))
+    upload_request = UploadFileRequest(purpose=request.purpose, file=upload_file_obj)
+    uploadFileInfo = await loader.upload_training_files(upload_request)
+    return uploadFileInfo
+
+
+@register_microservice(
+    name="opea_service@finetuning",
+    endpoint="/v1/finetune/list_checkpoints",
+    host="0.0.0.0",
+    port=8015,
+    enable_mcp=enable_mcp,
+    mcp_func_type=MCPFuncType.TOOL,
+    description="List checkpoints for a fine-tuning job.",
 )
 def list_checkpoints(request: FineTuningJobIDRequest):
     checkpoints = loader.list_finetuning_checkpoints(request)

--- a/comps/finetuning/src/requirements-cpu.txt
+++ b/comps/finetuning/src/requirements-cpu.txt
@@ -125,6 +125,8 @@ httptools==0.6.4
     # via uvicorn
 httpx==0.28.1
     # via -r ./comps/finetuning/src/requirements.in
+httpx-sse==0.4.3
+    # via mcp
 huggingface-hub==0.33.0
     # via
     #   accelerate
@@ -158,6 +160,8 @@ markdown-it-py==3.0.0
     #   textual
 markupsafe==3.0.2
     # via jinja2
+mcp==1.25.0
+    # via -r ./comps/finetuning/src/requirements.in
 mdit-py-plugins==0.4.2 ; sys_platform != 'win32'
     # via markdown-it-py
 mdurl==0.1.2
@@ -309,25 +313,33 @@ pyasn1-modules==0.4.2
     # via google-auth
 pycparser==2.22 ; platform_python_implementation != 'PyPy'
     # via cffi
-pydantic==2.8.2
+pydantic==2.12.5
     # via
     #   -r ./comps/finetuning/src/requirements.in
     #   docarray
     #   fastapi
+    #   mcp
+    #   pydantic-settings
     #   pydantic-yaml
     #   ray
-pydantic-core==2.20.1
+pydantic-core==2.41.5
     # via pydantic
+pydantic-settings==2.12.0
+    # via mcp
 pydantic-yaml==1.5.1
     # via -r ./comps/finetuning/src/requirements.in
 pygments==2.19.1
     # via rich
+pyjwt==2.10.1
+    # via mcp
 pyopenssl==25.1.0
     # via ray
 python-dateutil==2.9.0.post0
     # via pandas
 python-dotenv==1.1.0
-    # via uvicorn
+    # via
+    #   pydantic-settings
+    #   uvicorn
 python-multipart==0.0.20
     # via -r ./comps/finetuning/src/requirements.in
 pytz==2025.2
@@ -391,6 +403,8 @@ smart-open==7.1.0
     # via ray
 sniffio==1.3.1
     # via anyio
+sse-starlette==2.1.3
+    # via mcp
 starlette==0.46.2
     # via
     #   fastapi
@@ -414,7 +428,7 @@ transformers==4.52.4
     #   peft
 types-requests==2.32.4.20250611
     # via docarray
-typing-extensions==4.14.0
+typing-extensions==4.15.0
     # via
     #   anyio
     #   exceptiongroup
@@ -438,6 +452,10 @@ typing-extensions==4.14.0
     #   uvicorn
 typing-inspect==0.9.0
     # via docarray
+typing-inspection==0.4.2
+    # via
+    #   mcp
+    #   pydantic-settings
 tzdata==2025.2
     # via pandas
 uc-micro-py==1.0.3 ; sys_platform != 'win32'

--- a/comps/finetuning/src/requirements.in
+++ b/comps/finetuning/src/requirements.in
@@ -4,12 +4,13 @@ docarray
 fastapi
 httpx
 langchain-core>=0.3.81
+mcp>=1.23.0
 opentelemetry-api
 opentelemetry-exporter-otlp
 opentelemetry-sdk
 peft
 prometheus-fastapi-instrumentator
-pydantic==2.8.2
+pydantic==2.12.5
 pydantic_yaml
 python-multipart
 pyyaml

--- a/tests/finetuning/test_finetuning_mcp.sh
+++ b/tests/finetuning/test_finetuning_mcp.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+set -x
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+WORKPATH=$(cd "${SCRIPT_DIR}/../.." && pwd)
+ip_address=127.0.0.1
+
+export FINETUNING_PORT=18015
+export TAG=mcp-test
+export ENABLE_MCP=true
+
+function build_docker_images() {
+    cd $WORKPATH
+    echo $(pwd)
+
+    docker build --no-cache -t opea/finetuning:$TAG \
+        --build-arg https_proxy=$https_proxy \
+        --build-arg http_proxy=$http_proxy \
+        --build-arg HF_TOKEN=$HF_TOKEN \
+        -f comps/finetuning/src/Dockerfile .
+    if [ $? -ne 0 ]; then
+        echo "opea/finetuning built fail"
+        exit 1
+    else
+        echo "opea/finetuning built successful"
+    fi
+}
+
+function start_service() {
+    cd $WORKPATH
+
+    docker run -d --name="finetuning-mcp-server" \
+        -p ${FINETUNING_PORT}:8015 \
+        -e http_proxy=$http_proxy \
+        -e https_proxy=$https_proxy \
+        -e no_proxy=$no_proxy \
+        -e HF_TOKEN=$HF_TOKEN \
+        -e ENABLE_MCP=${ENABLE_MCP} \
+        --ipc=host \
+        opea/finetuning:$TAG
+
+    sleep 10s
+}
+
+function validate_microservice() {
+    # Wait for SSE endpoint
+    echo "Waiting for SSE endpoint availability..."
+    sse_response=000
+    for i in $(seq 1 24); do
+        sse_response=$(curl -s -o /dev/null -w "%{http_code}" \
+            --max-time 5 \
+            -H "Accept: text/event-stream" \
+            http://$ip_address:${FINETUNING_PORT}/sse)
+        if [[ $sse_response -eq 200 ]]; then
+            echo "SSE endpoint is available when MCP is enabled (HTTP 200)"
+            break
+        fi
+        echo "SSE not ready (HTTP $sse_response), retrying..."
+        sleep 5
+    done
+
+    if [[ $sse_response -ne 200 ]]; then
+        echo "ERROR: SSE endpoint should be available when MCP is enabled (got HTTP $sse_response)"
+        docker logs finetuning-mcp-server
+        exit 1
+    fi
+
+    # Install mcp package for testing (avoid system Python)
+    echo "Installing mcp package in venv..."
+    python3 -m venv .venv-mcp-test
+    . .venv-mcp-test/bin/activate
+    pip install -q --upgrade pip
+    pip install -q mcp
+
+    # Test MCP functionality using the dedicated validation script
+    echo "Testing MCP functionality..."
+    python3 ${WORKPATH}/tests/finetuning/validate_mcp.py $ip_address ${FINETUNING_PORT}
+
+    deactivate
+    rm -rf .venv-mcp-test
+
+    if [ $? -ne 0 ]; then
+        echo "MCP validation test failed"
+        docker logs finetuning-mcp-server
+        exit 1
+    else
+        echo "MCP validation test passed"
+    fi
+}
+
+function stop_docker() {
+    if docker ps -a | grep -q finetuning-mcp-server; then
+        docker stop finetuning-mcp-server 2>/dev/null || true
+        docker rm finetuning-mcp-server 2>/dev/null || true
+    fi
+}
+
+function main() {
+    stop_docker
+
+    build_docker_images
+    start_service
+
+    validate_microservice
+
+    stop_docker
+    echo y | docker system prune -f
+
+    echo "MCP test completed successfully!"
+}
+
+main

--- a/tests/finetuning/validate_mcp.py
+++ b/tests/finetuning/validate_mcp.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""MCP validation script for finetuning service."""
+
+import asyncio
+import base64
+import json
+import sys
+
+from mcp.client.session import ClientSession
+from mcp.client.sse import sse_client
+
+
+def _extract_text(content):
+    if not content:
+        return None
+    first = content[0]
+    if hasattr(first, "text"):
+        return first.text
+    if isinstance(first, str):
+        return first
+    return None
+
+
+def _parse_payload(text):
+    if text is None:
+        return None
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        try:
+            import ast
+
+            return ast.literal_eval(text)
+        except Exception:
+            return None
+
+
+async def validate_finetuning_mcp(ip_address, service_port):
+    endpoint = f"http://{ip_address}:{service_port}"
+
+    async with sse_client(endpoint + "/sse") as streams:
+        async with ClientSession(*streams) as session:
+            result = await session.initialize()
+
+            tools = []
+            try:
+                if hasattr(result, "capabilities") and hasattr(result.capabilities, "tools"):
+                    tools_data = result.capabilities.tools
+                    if isinstance(tools_data, dict):
+                        tools = list(tools_data.keys())
+                    elif isinstance(tools_data, list):
+                        if tools_data and hasattr(tools_data[0], "name"):
+                            tools = [tool.name for tool in tools_data]
+                        else:
+                            tools = tools_data
+
+                if not tools:
+                    tool_list = await session.list_tools()
+                    if hasattr(tool_list, "tools"):
+                        tools_data = tool_list.tools
+                        if isinstance(tools_data, list):
+                            if tools_data and hasattr(tools_data[0], "name"):
+                                tools = [tool.name for tool in tools_data]
+                            else:
+                                tools = tools_data
+            except Exception as exc:
+                print(f"Error getting tools: {exc}")
+                print("Will proceed without tool validation")
+
+            expected_tools = [
+                "create_finetuning_jobs",
+                "list_finetuning_jobs",
+                "retrieve_finetuning_job",
+                "cancel_finetuning_job",
+                "upload_training_files_mcp",
+                "list_checkpoints",
+            ]
+
+            missing_tools = [t for t in expected_tools if t not in tools]
+            if missing_tools:
+                print(f"Missing expected tools: {missing_tools}")
+                return False
+
+            # Test base64 upload tool
+            filename = "mcp_test_finetune.jsonl"
+            payload = '{"instruction":"hello","input":"","output":"world"}\n'
+            encoded = base64.b64encode(payload.encode("utf-8")).decode("utf-8")
+
+            upload_result = await session.call_tool(
+                "upload_training_files_mcp",
+                {"request": {"filename": filename, "content_base64": encoded, "purpose": "fine-tune"}},
+            )
+            upload_text = _extract_text(upload_result.content)
+            upload_data = _parse_payload(upload_text)
+
+            if upload_data is None:
+                print(f"Upload failed: unexpected response {upload_result.content}")
+                return False
+
+            if upload_data.get("filename") != filename:
+                print(f"Upload failed: wrong filename. Got: {upload_data}")
+                return False
+
+            # Test list jobs tool
+            list_result = await session.call_tool("list_finetuning_jobs", {})
+            list_text = _extract_text(list_result.content)
+            list_data = _parse_payload(list_text)
+
+            if list_data is None or "data" not in list_data:
+                print(f"List jobs failed: unexpected response {list_result.content}")
+                return False
+
+            print("Finetuning MCP validation passed")
+            return True
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python3 validate_mcp.py <ip_address> <service_port>")
+        sys.exit(1)
+
+    ip_address = sys.argv[1]
+    service_port = sys.argv[2]
+
+    success = asyncio.run(validate_finetuning_mcp(ip_address, service_port))
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
PR Description

This PR adds MCP support to the finetuning microservice and ships MCP validation tests. It registers finetuning endpoints as MCP tools, adds a base64 upload tool for MCP clients, and ensures job status updates run without FastAPI BackgroundTasks in MCP mode. It also adds MCP dependencies, updates compose/docs, and includes a new MCP test script.

  Key changes

  - MCP enablement: ENABLE_MCP toggle added to finetuning microservice; tool registration for create/list/retrieve/cancel
    jobs + list checkpoints.
  - MCP upload tool: New upload_training_files_mcp accepts base64 file payloads.
  - Background tasks in MCP: schedule_job_status_update fallback uses a daemon thread when BackgroundTasks isn’t
    available.
  - Deps/compose/docs: Added mcp dependencies, updated compose env, and documented MCP usage.
  - Tests: Added tests/finetuning/validate_mcp.py and tests/finetuning/test_finetuning_mcp.sh (venv-based install to
    avoid PEP 668).