### PR TITLE
Add mcp support for image2video

### DIFF
--- a/comps/image2video/deployment/docker_compose/README.md
+++ b/comps/image2video/deployment/docker_compose/README.md
@@ -133,3 +133,11 @@ To stop and remove the container you started manually, use the `docker stop` and
   docker stop image2video-gaudi-service
   docker rm image2video-gaudi-service
   ```
+
+---
+
+## MCP Usage (Optional)
+
+Set `ENABLE_MCP=true` to run the Image-to-Video service in MCP (Model Context Protocol) mode. When MCP is enabled, the service exposes tools over the MCP SSE server on port `9369` and regular HTTP endpoints are not served.
+
+The MCP tool maps to the `image2video` function and accepts the same payload as the HTTP API.

--- a/comps/image2video/deployment/docker_compose/compose.yaml
+++ b/comps/image2video/deployment/docker_compose/compose.yaml
@@ -12,6 +12,7 @@ services:
       - https_proxy=${https_proxy}
       - http_proxy=${http_proxy}
       - HF_TOKEN=${HF_TOKEN}
+      - ENABLE_MCP=${ENABLE_MCP:-false}
     ipc: host
     restart: always
   image2video-gaudi:

--- a/comps/image2video/src/README.md
+++ b/comps/image2video/src/README.md
@@ -29,3 +29,9 @@ The following configurations have been validated for the Image-to-Video microser
 | **Deploy Method** | **Core Models**              | **Platform**      |
 | ----------------- | ---------------------------- | ----------------- |
 | Docker Compose    | Stable Video Diffusion (SVD) | Intel Xeon/Gaudi2 |
+
+## MCP Usage (Optional)
+
+Set `ENABLE_MCP=true` to run the Image-to-Video service in MCP (Model Context Protocol) mode. When MCP is enabled, the service exposes tools over the MCP SSE server on port `9369` and regular HTTP endpoints are not served.
+
+The MCP tool maps to the `image2video` function and accepts the same payload as the HTTP API (e.g., an `ImagesPath` object with `images_path` entries).

--- a/comps/image2video/src/opea_image2video_microservice.py
+++ b/comps/image2video/src/opea_image2video_microservice.py
@@ -16,9 +16,11 @@ from comps import (
     register_statistics,
     statistics_dict,
 )
+from comps.cores.mega.constants import MCPFuncType
 from comps.image2video.src.integrations.native import OpeaImage2video
 
 logger = CustomLogger("opea_image2video_microservice")
+enable_mcp = os.getenv("ENABLE_MCP", "").strip().lower() in {"true", "1", "yes"}
 
 component_loader = None
 
@@ -31,6 +33,9 @@ component_loader = None
     port=9369,
     input_datatype=ImagesPath,
     output_datatype=VideoPath,
+    enable_mcp=enable_mcp,
+    mcp_func_type=MCPFuncType.TOOL,
+    description="Generate a short video clip from one or more images.",
 )
 @register_statistics(names=["opea_service@image2video"])
 async def image2video(input: ImagesPath):

--- a/comps/image2video/src/requirements-cpu.txt
+++ b/comps/image2video/src/requirements-cpu.txt
@@ -95,6 +95,8 @@ httpx==0.28.1
     # via
     #   datasets
     #   trimesh
+httpx-sse==0.4.3
+    # via mcp
 huggingface-hub==0.36.0
     # via
     #   accelerate
@@ -137,6 +139,8 @@ markdown-it-py==4.0.0
     # via rich
 markupsafe==3.0.3
     # via jinja2
+mcp==1.25.0
+    # via -r ./comps/image2video/src/requirements.in
 mdurl==0.1.2
     # via markdown-it-py
 ml-dtypes==0.4.1
@@ -263,18 +267,27 @@ pydantic==2.12.5
     #   -r ./comps/image2video/src/requirements.in
     #   docarray
     #   fastapi
+    #   mcp
 pydantic-core==2.41.5
     # via pydantic
+pydantic-settings==2.12.0
+    # via mcp
 pydub==0.25.1
     # via
     #   -r ./comps/image2video/src/requirements.in
     #   docarray
 pygments==2.19.2
     # via rich
+pyjwt==2.10.1
+    # via mcp
 python-dateutil==2.9.0.post0
     # via
     #   pandas
     #   pycollada
+python-dotenv==1.2.1
+    # via pydantic-settings
+python-multipart==0.0.21
+    # via mcp
 pytz==2025.2
     # via pandas
 pyyaml==6.0.3
@@ -344,6 +357,8 @@ starlette==0.50.0
     #   -r ./comps/image2video/src/requirements.in
     #   fastapi
     #   prometheus-fastapi-instrumentator
+sse-starlette==3.0.4
+    # via mcp
 svg-path==7.0
     # via trimesh
 threadpoolctl==3.6.0

--- a/comps/image2video/src/requirements-cpu.txt
+++ b/comps/image2video/src/requirements-cpu.txt
@@ -351,13 +351,13 @@ shapely==2.1.2
 shortuuid==1.0.13
     # via -r ./comps/image2video/src/requirements.in
 six==1.17.0
-    # via python-dateutil
-starlette==0.50.0
     # via
     #   -r ./comps/image2video/src/requirements.in
     #   fastapi
     #   prometheus-fastapi-instrumentator
 sse-starlette==3.0.4
+    # via python-dateutil
+starlette==0.50.0
     # via mcp
 svg-path==7.0
     # via trimesh

--- a/comps/image2video/src/requirements-gpu.txt
+++ b/comps/image2video/src/requirements-gpu.txt
@@ -398,13 +398,13 @@ shapely==2.1.2
 shortuuid==1.0.13
     # via -r ./comps/image2video/src/requirements.in
 six==1.17.0
-    # via python-dateutil
-starlette==0.50.0
     # via
     #   -r ./comps/image2video/src/requirements.in
     #   fastapi
     #   prometheus-fastapi-instrumentator
 sse-starlette==3.0.4
+    # via python-dateutil
+starlette==0.50.0
     # via mcp
 svg-path==7.0
     # via trimesh

--- a/comps/image2video/src/requirements-gpu.txt
+++ b/comps/image2video/src/requirements-gpu.txt
@@ -97,6 +97,8 @@ httpx==0.28.1
     # via
     #   datasets
     #   trimesh
+httpx-sse==0.4.3
+    # via mcp
 huggingface-hub==0.36.0
     # via
     #   accelerate
@@ -141,6 +143,8 @@ markdown-it-py==4.0.0
     # via rich
 markupsafe==3.0.3
     # via jinja2
+mcp==1.25.0
+    # via -r ./comps/image2video/src/requirements.in
 mdurl==0.1.2
     # via markdown-it-py
 ml-dtypes==0.4.1
@@ -308,18 +312,27 @@ pydantic==2.12.5
     #   -r ./comps/image2video/src/requirements.in
     #   docarray
     #   fastapi
+    #   mcp
 pydantic-core==2.41.5
     # via pydantic
+pydantic-settings==2.12.0
+    # via mcp
 pydub==0.25.1
     # via
     #   -r ./comps/image2video/src/requirements.in
     #   docarray
 pygments==2.19.2
     # via rich
+pyjwt==2.10.1
+    # via mcp
 python-dateutil==2.9.0.post0
     # via
     #   pandas
     #   pycollada
+python-dotenv==1.2.1
+    # via pydantic-settings
+python-multipart==0.0.21
+    # via mcp
 pytz==2025.2
     # via pandas
 pyyaml==6.0.3
@@ -391,6 +404,8 @@ starlette==0.50.0
     #   -r ./comps/image2video/src/requirements.in
     #   fastapi
     #   prometheus-fastapi-instrumentator
+sse-starlette==3.0.4
+    # via mcp
 svg-path==7.0
     # via trimesh
 sympy==1.14.0

--- a/comps/image2video/src/requirements.in
+++ b/comps/image2video/src/requirements.in
@@ -3,6 +3,7 @@ datasets
 diffusers
 docarray[full]
 fastapi
+mcp>=1.23.0
 numpy<2.0.0
 opencv-python
 opentelemetry-api

--- a/tests/image2video/test_image2video_mcp.sh
+++ b/tests/image2video/test_image2video_mcp.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+set -x
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+WORKPATH=$(cd "${SCRIPT_DIR}/../.." && pwd)
+ip_address=127.0.0.1
+
+export IMAGE2VIDEO_PORT=19369
+export TAG=mcp-test
+export ENABLE_MCP=true
+
+function build_docker_images() {
+    cd $WORKPATH
+    echo $(pwd)
+
+    docker build --no-cache -t opea/image2video:$TAG \
+        --build-arg https_proxy=$https_proxy \
+        --build-arg http_proxy=$http_proxy \
+        -f comps/image2video/src/Dockerfile .
+    if [ $? -ne 0 ]; then
+        echo "opea/image2video built fail"
+        exit 1
+    else
+        echo "opea/image2video built successful"
+    fi
+}
+
+function start_service() {
+    cd $WORKPATH
+
+    docker run -d --name="image2video-mcp-server" \
+        -p ${IMAGE2VIDEO_PORT}:9369 \
+        -e http_proxy=$http_proxy \
+        -e https_proxy=$https_proxy \
+        -e no_proxy=$no_proxy \
+        -e ENABLE_MCP=${ENABLE_MCP} \
+        --ipc=host \
+        opea/image2video:$TAG
+
+    sleep 10s
+}
+
+function validate_microservice() {
+    # Wait for SSE endpoint
+    echo "Waiting for SSE endpoint availability..."
+    sse_response=000
+    for i in $(seq 1 24); do
+        sse_response=$(curl -s -o /dev/null -w "%{http_code}" \
+            --max-time 5 \
+            -H "Accept: text/event-stream" \
+            http://$ip_address:${IMAGE2VIDEO_PORT}/sse)
+        if [[ $sse_response -eq 200 ]]; then
+            echo "SSE endpoint is available when MCP is enabled (HTTP 200)"
+            break
+        fi
+        echo "SSE not ready (HTTP $sse_response), retrying..."
+        sleep 5
+    done
+
+    if [[ $sse_response -ne 200 ]]; then
+        echo "ERROR: SSE endpoint should be available when MCP is enabled (got HTTP $sse_response)"
+        docker logs image2video-mcp-server
+        exit 1
+    fi
+
+    # Install mcp package for testing (avoid system Python)
+    echo "Installing mcp package in venv..."
+    python3 -m venv .venv-mcp-test
+    . .venv-mcp-test/bin/activate
+    pip install -q --upgrade pip
+    pip install -q mcp
+
+    # Test MCP functionality using the dedicated validation script
+    echo "Testing MCP functionality..."
+    python3 ${WORKPATH}/tests/image2video/validate_mcp.py $ip_address ${IMAGE2VIDEO_PORT}
+
+    if [ $? -ne 0 ]; then
+        echo "MCP validation test failed"
+        docker logs image2video-mcp-server
+        deactivate
+        rm -rf .venv-mcp-test
+        exit 1
+    else
+        echo "MCP validation test passed"
+    fi
+
+    deactivate
+    rm -rf .venv-mcp-test
+}
+
+function stop_docker() {
+    if docker ps -a | grep -q image2video-mcp-server; then
+        docker stop image2video-mcp-server 2>/dev/null || true
+        docker rm image2video-mcp-server 2>/dev/null || true
+    fi
+}
+
+function main() {
+    stop_docker
+
+    build_docker_images
+    start_service
+
+    validate_microservice
+
+    stop_docker
+    echo y | docker system prune -f
+
+    echo "MCP test completed successfully!"
+}
+
+main

--- a/tests/image2video/validate_mcp.py
+++ b/tests/image2video/validate_mcp.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+"""MCP validation script for image2video service."""
+
+import asyncio
+import os
+import sys
+
+from mcp.client.session import ClientSession
+from mcp.client.sse import sse_client
+
+
+def _get_tools_from_init(result):
+    tools = []
+    if hasattr(result, "capabilities") and hasattr(result.capabilities, "tools"):
+        tools_data = result.capabilities.tools
+        if isinstance(tools_data, dict):
+            tools = list(tools_data.keys())
+        elif isinstance(tools_data, list):
+            if tools_data and hasattr(tools_data[0], "name"):
+                tools = [tool.name for tool in tools_data]
+            else:
+                tools = tools_data
+    return tools
+
+
+async def validate_image2video_mcp(ip_address, service_port):
+    endpoint = f"http://{ip_address}:{service_port}"
+
+    async with sse_client(endpoint + "/sse") as streams:
+        async with ClientSession(*streams) as session:
+            result = await session.initialize()
+
+            tools = _get_tools_from_init(result)
+            if not tools:
+                tool_list = await session.list_tools()
+                if hasattr(tool_list, "tools"):
+                    tools_data = tool_list.tools
+                    if isinstance(tools_data, list):
+                        if tools_data and hasattr(tools_data[0], "name"):
+                            tools = [tool.name for tool in tools_data]
+                        else:
+                            tools = tools_data
+
+            expected_tools = ["image2video"]
+            missing_tools = [t for t in expected_tools if t not in tools]
+            if missing_tools:
+                print(f"Missing expected tools: {missing_tools}")
+                return False
+
+            if os.getenv("IMAGE2VIDEO_MCP_SMOKE_CALL", "").strip().lower() in {"1", "true", "yes"}:
+                tool_result = await session.call_tool(
+                    "image2video",
+                    {
+                        "input": {
+                            "images_path": [
+                                {
+                                    "image_path": "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/svd/rocket.png"
+                                }
+                            ]
+                        }
+                    },
+                )
+                if not tool_result.content:
+                    print("Image2video tool call failed: no content returned")
+                    return False
+
+            print("Image2video MCP validation passed")
+            return True
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python3 validate_mcp.py <ip_address> <service_port>")
+        sys.exit(1)
+
+    ip_address = sys.argv[1]
+    service_port = sys.argv[2]
+
+    success = asyncio.run(validate_image2video_mcp(ip_address, service_port))
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
## Description

Added MCP support to the image2video microservice, wired the ENABLE_MCP toggle, and included MCP deps + docs + tests.

### Changes made

- MCP tool registration and toggle in comps/image2video/src/opea_image2video_microservice.py.
- MCP deps added to comps/image2video/src/requirements.in, plus pinned deps in comps/image2video/src/requirements-
  cpu.txt and comps/image2video/src/requirements-gpu.txt.
- Compose env updated in comps/image2video/deployment/docker_compose/compose.yaml.
- MCP usage docs in comps/image2video/src/README.md and comps/image2video/deployment/docker_compose/README.md.
- MCP tests added: tests/image2video/validate_mcp.py and tests/image2video/test_image2video_mcp.sh (uses a temp venv to
  avoid PEP 668).