### PR TITLE
Add mcp support for text2sql

### DIFF
--- a/comps/text2sql/deployment/docker_compose/compose.yaml
+++ b/comps/text2sql/deployment/docker_compose/compose.yaml
@@ -25,6 +25,7 @@ services:
       - ${TEXT2SQL_PORT:-8080}:8080
     environment:
       - TGI_LLM_ENDPOINT=${TGI_LLM_ENDPOINT}
+      - ENABLE_MCP=${ENABLE_MCP:-false}
     depends_on:
       - tgi-server
       - postgres
@@ -36,6 +37,7 @@ services:
       - ${TEXT2SQL_PORT:-8080}:8080
     environment:
       - TGI_LLM_ENDPOINT=${TGI_LLM_ENDPOINT}
+      - ENABLE_MCP=${ENABLE_MCP:-false}
     depends_on:
       - tgi-gaudi-server
       - postgres

--- a/comps/text2sql/src/README.md
+++ b/comps/text2sql/src/README.md
@@ -117,6 +117,8 @@ export TGI_LLM_ENDPOINT="http://${your_ip}:${TGI_PORT}"
 docker run  --runtime=runc --name="comps-langchain-text2sql"  -p 9090:8080 --ipc=host -e llm_endpoint_url=${TGI_LLM_ENDPOINT} opea/text2sql:latest
 ```
 
+Note: when ENABLE_MCP=true, the service starts an MCP SSE server instead of the regular HTTP endpoint.
+
 #### Run via docker compose (Option B)
 
 ##### Setup Environment Variables.
@@ -128,6 +130,7 @@ export LLM_MODEL_ID="mistralai/Mistral-7B-Instruct-v0.3"
 export POSTGRES_USER=postgres
 export POSTGRES_PASSWORD=testpwd
 export POSTGRES_DB=chinook
+export ENABLE_MCP=${ENABLE_MCP:-false}
 export LLM_ENDPOINT_PORT=${TGI_PORT}
 export host_ip=${your_ip}
 ```

--- a/comps/text2sql/src/opea_text2sql_microservice.py
+++ b/comps/text2sql/src/opea_text2sql_microservice.py
@@ -9,6 +9,7 @@ from fastapi import status
 from fastapi.exceptions import HTTPException
 
 from comps import CustomLogger, OpeaComponentLoader, opea_microservices, register_microservice
+from comps.cores.mega.constants import MCPFuncType
 from comps.text2sql.src.integrations.opea import DBConnectionInput, Input, OpeaText2SQL
 
 cur_path = pathlib.Path(__file__).parent.resolve()
@@ -19,6 +20,7 @@ logger = CustomLogger("text2sql")
 logflag = os.getenv("LOGFLAG", False)
 
 text2sql_component_name = os.getenv("TEXT2SQL_COMPONENT_NAME", "OPEA_TEXT2SQL")
+enable_mcp = os.getenv("ENABLE_MCP", "").strip().lower() in {"true", "1", "yes"}
 # Initialize OpeaComponentLoader
 loader = OpeaComponentLoader(
     text2sql_component_name,
@@ -31,6 +33,9 @@ loader = OpeaComponentLoader(
     endpoint="/v1/postgres/health",
     host="0.0.0.0",
     port=8080,
+    enable_mcp=enable_mcp,
+    mcp_func_type=MCPFuncType.TOOL,
+    description="Check the connection to the PostgreSQL database.",
 )
 async def postgres_connection_check(input: DBConnectionInput):
     """Check the connection to the PostgreSQL database.
@@ -60,6 +65,9 @@ async def postgres_connection_check(input: DBConnectionInput):
     endpoint="/v1/text2sql",
     host="0.0.0.0",
     port=8080,
+    enable_mcp=enable_mcp,
+    mcp_func_type=MCPFuncType.TOOL,
+    description="Generate and execute SQL from natural language input.",
 )
 async def execute_agent(input: Input):
     """Execute a SQL query from the input text.

--- a/comps/text2sql/src/requirements-cpu.txt
+++ b/comps/text2sql/src/requirements-cpu.txt
@@ -146,9 +146,11 @@ markdown-it-py==3.0.0
 markupsafe==3.0.2
     # via jinja2
 marshmallow==3.26.1
+    # via markdown-it-py
+mcp==1.25.0
     # via dataclasses-json
 mdurl==0.1.2
-    # via markdown-it-py
+    # via -r ./comps/text2sql/src/requirements.in
 ml-dtypes==0.4.1
     # via
     #   jax

--- a/comps/text2sql/src/requirements-cpu.txt
+++ b/comps/text2sql/src/requirements-cpu.txt
@@ -23,8 +23,6 @@ attrs==25.3.0
     #   aiohttp
     #   jsonschema
     #   referencing
-av==14.4.0
-    # via docarray
 certifi==2025.6.15
     # via
     #   httpcore

--- a/comps/text2sql/src/requirements-gpu.txt
+++ b/comps/text2sql/src/requirements-gpu.txt
@@ -150,9 +150,11 @@ markdown-it-py==3.0.0
 markupsafe==3.0.2
     # via jinja2
 marshmallow==3.26.1
+    # via markdown-it-py
+mcp==1.25.0
     # via dataclasses-json
 mdurl==0.1.2
-    # via markdown-it-py
+    # via -r ./comps/text2sql/src/requirements.in
 ml-dtypes==0.4.1
     # via
     #   jax

--- a/comps/text2sql/src/requirements-gpu.txt
+++ b/comps/text2sql/src/requirements-gpu.txt
@@ -23,8 +23,6 @@ attrs==25.3.0
     #   aiohttp
     #   jsonschema
     #   referencing
-av==14.4.0
-    # via docarray
 certifi==2025.6.15
     # via
     #   httpcore

--- a/comps/text2sql/src/requirements.in
+++ b/comps/text2sql/src/requirements.in
@@ -1,4 +1,4 @@
-docarray[full]
+docarray
 fastapi
 langchain==0.2.9
 langchain-huggingface

--- a/comps/text2sql/src/requirements.in
+++ b/comps/text2sql/src/requirements.in
@@ -3,6 +3,7 @@ fastapi
 langchain==0.2.9
 langchain-huggingface
 langchain_community==0.2.7
+mcp>=1.23.0
 numpy
 opentelemetry-api
 opentelemetry-exporter-otlp

--- a/tests/text2sql/test_text2sql.sh
+++ b/tests/text2sql/test_text2sql.sh
@@ -4,7 +4,7 @@
 
 set -x
 
-WORKPATH=$(git rev-parse --show-toplevel)
+WORKPATH=$(dirname "$PWD")
 LOG_PATH="$WORKPATH/tests"
 ip_address=$(hostname -I | awk '{print $1}')
 export DATA_PATH=${model_cache:-./data}
@@ -63,11 +63,7 @@ function start_service() {
     unset http_proxy
 
     cd $WORKPATH/comps/text2sql/deployment/docker_compose
-    docker compose -f compose.yaml up ${service_name} -d > ${LOG_PATH}/start_services_with_compose.log 2>&1
-    if [ $? -ne 0 ]; then
-        cat ${LOG_PATH}/start_services_with_compose.log
-        exit 1
-    fi
+    docker compose -f compose.yaml up ${service_name} -d > ${LOG_PATH}/start_services_with_compose.log
     check_tgi_connection "${TGI_LLM_ENDPOINT}/health"
 }
 

--- a/tests/text2sql/test_text2sql_mcp.sh
+++ b/tests/text2sql/test_text2sql_mcp.sh
@@ -1,26 +1,26 @@
 #!/bin/bash
-# Copyright (C) 2024 Intel Corporation
+# Copyright (C) 2025 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 set -x
 
 WORKPATH=$(git rev-parse --show-toplevel)
 LOG_PATH="$WORKPATH/tests"
+host_addr=${MCP_HOST:-127.0.0.1}
 ip_address=$(hostname -I | awk '{print $1}')
 export DATA_PATH=${model_cache:-./data}
 
 export TAG='comps'
-
+export ENABLE_MCP=true
 export TEXT2SQL_PORT=11700
 export LLM_ENDPOINT_PORT=11710
-
+export host_ip=${host_ip:-$ip_address}
 
 export LLM_MODEL_ID="mistralai/Mistral-7B-Instruct-v0.3"
 export HF_TOKEN=${HF_TOKEN}
 export POSTGRES_USER=postgres
 export POSTGRES_PASSWORD=testpwd
 export POSTGRES_DB=chinook
-
 
 export service_name="text2sql"
 
@@ -55,11 +55,8 @@ check_tgi_connection() {
   done
 }
 
-
 function start_service() {
-
-
-    export TGI_LLM_ENDPOINT="http://${ip_address}:${LLM_ENDPOINT_PORT}"
+    export TGI_LLM_ENDPOINT="http://${host_ip}:${LLM_ENDPOINT_PORT}"
     unset http_proxy
 
     cd $WORKPATH/comps/text2sql/deployment/docker_compose
@@ -72,21 +69,36 @@ function start_service() {
 }
 
 function validate_microservice() {
-    result=$(http_proxy="" curl http://${ip_address}:${TEXT2SQL_PORT}/v1/text2sql\
-        -X POST \
-        -d '{"input_text": "Find the total number of Albums.","conn_str": {"user": "'${POSTGRES_USER}'","password": "'${POSTGRES_PASSWORD}'","host": "'${ip_address}'", "port": "5442", "database": "'${POSTGRES_DB}'" }}' \
-        -H 'Content-Type: application/json')
+    echo "Waiting for SSE endpoint availability..."
+    local attempt=0
+    local max_attempts=24
+    local sse_response=000
+    while [[ $attempt -lt $max_attempts ]]; do
+        sse_response=$(curl -s -o /dev/null -w "%{http_code}" \
+            --max-time 5 \
+            -H "Accept: text/event-stream" \
+            http://$host_addr:${TEXT2SQL_PORT}/sse)
+        if [[ $sse_response -eq 200 ]]; then
+            break
+        fi
+        attempt=$((attempt + 1))
+        sleep 5
+    done
 
-    if [[ $result == *"output"* ]]; then
-        echo $result
-        echo "Result correct."
-    else
-        echo "Result wrong. Received was $result"
-        docker logs text2sql-server > ${LOG_PATH}/text2sql.log
-        docker logs tgi-server > ${LOG_PATH}/tgi.log
+    if [[ $sse_response -ne 200 ]]; then
+        echo "ERROR: SSE endpoint should be available when MCP is enabled (got HTTP $sse_response)"
+        docker logs text2sql-server
         exit 1
     fi
 
+    pip install mcp
+    python3 $WORKPATH/tests/text2sql/validate_mcp.py \
+        $host_addr \
+        $TEXT2SQL_PORT \
+        $POSTGRES_USER \
+        $POSTGRES_PASSWORD \
+        $host_ip \
+        $POSTGRES_DB
 }
 
 function stop_docker() {

--- a/tests/text2sql/validate_mcp.py
+++ b/tests/text2sql/validate_mcp.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# Copyright (C) 2025 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import json
+import sys
+
+from mcp.client.session import ClientSession
+from mcp.client.sse import sse_client
+
+
+def extract_text(content):
+    if not content:
+        return ""
+    first = content[0]
+    if hasattr(first, "text"):
+        return first.text
+    if isinstance(first, str):
+        return first
+    return str(first)
+
+
+def parse_payload(text):
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        try:
+            import ast
+
+            return ast.literal_eval(text)
+        except Exception:
+            return None
+
+
+async def validate_text2sql_mcp(ip_address, service_port, db_config):
+    endpoint = f"http://{ip_address}:{service_port}"
+    async with sse_client(endpoint + "/sse") as streams:
+        async with ClientSession(*streams) as session:
+            await session.initialize()
+            tool_result = await session.call_tool(
+                "execute_agent",
+                {
+                    "input": {
+                        "input_text": "Find the total number of Albums.",
+                        "conn_str": db_config,
+                    }
+                },
+            )
+            response_text = extract_text(tool_result.content)
+            if not response_text:
+                print("No response content from MCP tool.")
+                return False
+
+            payload = parse_payload(response_text)
+            if isinstance(payload, dict) and ("result" in payload or "output" in payload):
+                print("MCP text2sql returned a result.")
+                return True
+
+            if "output" in response_text.lower():
+                print("MCP text2sql returned output (string match).")
+                return True
+
+            print(f"Unexpected response content: {response_text}")
+            return False
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 7:
+        print("Usage: python3 validate_mcp.py <ip> <port> <user> <password> <host> <db>")
+        sys.exit(1)
+
+    ip_address = sys.argv[1]
+    service_port = sys.argv[2]
+    db_config = {
+        "user": sys.argv[3],
+        "password": sys.argv[4],
+        "host": sys.argv[5],
+        "port": 5442,
+        "database": sys.argv[6],
+    }
+
+    success = asyncio.run(validate_text2sql_mcp(ip_address, service_port, db_config))
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
## Description

Adds MCP support to text2sql by wiring ENABLE_MCP into the microservice registration and including MCP  tool metadata for both endpoints. Updates dependencies to include mcp, surfaces the flag in  docker‑compose and README, and introduces MCP validation + test scripts with SSE readiness checks. Also  fixes text2sql test scripts to use the repo root and fail fast on compose errors.