### PR TITLE
feat(seahorse): add Seahorse Cloud dataprep and retriever support

### DIFF
--- a/comps/dataprep/README.md
+++ b/comps/dataprep/README.md
@@ -43,6 +43,7 @@ Dataprep microservice are supported on various databases, as shown in the table 
 | `financial domain data` | [Dataprep Microservice for financial domain data](src/README_finance.md) |
 | `MariaDB`               | [Dataprep Microservice with MariaDB Vector](src/README_mariadb.md)       |
 | `ArangoDB`              | [Dataprep Microservice with ArangoDB Vector](src/README_arangodb.md)     |
+| `Seahorse Cloud`        | [Dataprep Microservice with Seahorse Cloud](src/README_seahorse.md)      |
 
 ## Running in the air gapped environment
 

--- a/comps/dataprep/deployment/docker_compose/compose.yaml
+++ b/comps/dataprep/deployment/docker_compose/compose.yaml
@@ -513,6 +513,29 @@ services:
       retries: 10
     restart: unless-stopped
 
+  dataprep-seahorse:
+    image: ${REGISTRY:-opea}/dataprep:${TAG:-latest}
+    container_name: dataprep-seahorse-server
+    ports:
+      - "${DATAPREP_PORT:-5000}:5000"
+    ipc: host
+    environment:
+      no_proxy: ${no_proxy}
+      http_proxy: ${http_proxy}
+      https_proxy: ${https_proxy}
+      DATAPREP_COMPONENT_NAME: "OPEA_DATAPREP_SEAHORSE"
+      SEAHORSE_BASE_URL: ${SEAHORSE_BASE_URL}
+      SEAHORSE_API_KEY: ${SEAHORSE_API_KEY}
+      SEAHORSE_EMBEDDING_MODE: ${SEAHORSE_EMBEDDING_MODE:-builtin}
+      TEI_EMBEDDING_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
+      HF_TOKEN: ${HF_TOKEN}
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:5000/v1/health_check || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    restart: unless-stopped
+
 networks:
   default:
     driver: bridge

--- a/comps/dataprep/src/README_seahorse.md
+++ b/comps/dataprep/src/README_seahorse.md
@@ -1,0 +1,110 @@
+# Dataprep Microservice with Seahorse Cloud
+
+## 0. Prerequisites
+
+Before using this microservice, you need a Seahorse Cloud table with an API endpoint:
+
+1. Sign up at [Seahorse Console](https://console.seahorse.dnotitia.ai)
+2. Create a table — an API endpoint (`SEAHORSE_BASE_URL`) and API key (`SEAHORSE_API_KEY`) will be issued upon creation
+3. Use the issued endpoint and key as environment variables below
+
+## Table of contents
+
+1. [Start Microservice with Docker](#start-microservice-with-docker)
+2. [Invoke Microservice](#invoke-microservice)
+
+## 🚀 Start Microservice with Docker
+
+### Setup Environment Variables
+
+```bash
+export SEAHORSE_BASE_URL="https://<table-uuid>.api.seahorse.dnotitia.ai"
+export SEAHORSE_API_KEY="sk_xxx"
+export SEAHORSE_EMBEDDING_MODE="builtin"  # or "external"
+export DATAPREP_COMPONENT_NAME="OPEA_DATAPREP_SEAHORSE"
+```
+
+> **⚠️ Important**: `SEAHORSE_EMBEDDING_MODE` must be the same value for both Retriever and Dataprep services.
+> If Dataprep uses `SEAHORSE_EMBEDDING_MODE="external"`, Retriever must also use `SEAHORSE_EMBEDDING_MODE="external"` and `SEAHORSE_SEARCH_MODE="dense"`.
+
+For `external` mode, also set:
+
+```bash
+export TEI_EMBEDDING_ENDPOINT="http://${your_ip}:6060"
+export HF_TOKEN=${your_huggingface_token}
+```
+
+If `TEI_EMBEDDING_ENDPOINT` is not set, Dataprep falls back to local HuggingFace embeddings.
+The bundled `dataprep-seahorse` Docker Compose service forwards both `TEI_EMBEDDING_ENDPOINT`
+and `HF_TOKEN` into the container, so export them before `docker compose up dataprep-seahorse`
+when you want TEI-backed external embeddings.
+
+In `external` mode, external embeddings apply to dense vectors only; sparse always uses the built-in embedding path.
+
+### Build Docker Image
+
+```bash
+cd ../../../../
+docker build -t opea/dataprep:latest --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy -f comps/dataprep/src/Dockerfile .
+```
+
+### Run Docker with CLI
+
+```bash
+docker run -d --name="dataprep-seahorse-server" -p 5000:5000 --ipc=host -e SEAHORSE_BASE_URL=$SEAHORSE_BASE_URL -e SEAHORSE_API_KEY=$SEAHORSE_API_KEY -e SEAHORSE_EMBEDDING_MODE=$SEAHORSE_EMBEDDING_MODE -e TEI_EMBEDDING_ENDPOINT=$TEI_EMBEDDING_ENDPOINT -e HF_TOKEN=$HF_TOKEN -e DATAPREP_COMPONENT_NAME=$DATAPREP_COMPONENT_NAME opea/dataprep:latest
+```
+
+### Run Docker Compose Service
+
+```bash
+cd ../deployment/docker_compose
+docker compose up dataprep-seahorse
+```
+
+## Invoke Microservice
+
+### Ingest a file
+
+```bash
+curl -X POST \
+    -H "Content-Type: multipart/form-data" \
+    -F "files=@./file1.txt" \
+    http://localhost:5000/v1/dataprep/ingest
+```
+
+### Ingest with custom chunk size
+
+```bash
+curl -X POST \
+    -H "Content-Type: multipart/form-data" \
+    -F "files=@./file1.txt" \
+    -F "chunk_size=1500" \
+    -F "chunk_overlap=100" \
+    http://localhost:5000/v1/dataprep/ingest
+```
+
+### Get ingested files
+
+```bash
+curl -X POST http://localhost:5000/v1/dataprep/get
+```
+
+### Delete all files
+
+```bash
+curl -X POST \
+    -H "Content-Type: application/json" \
+    -d '{"file_path": "all"}' \
+    http://localhost:5000/v1/dataprep/delete
+```
+
+## Embedding Modes
+
+| Mode       | Env Var                            | Behavior                                            | TEI Required?                        |
+| ---------- | ---------------------------------- | --------------------------------------------------- | ------------------------------------ |
+| `builtin`  | `SEAHORSE_EMBEDDING_MODE=builtin`  | Seahorse server generates embeddings server-side    | No                                   |
+| `external` | `SEAHORSE_EMBEDDING_MODE=external` | TEI or local HuggingFace model generates embeddings | No (falls back to local HuggingFace) |
+
+> `SEAHORSE_EMBEDDING_MODE` is normalized to lowercase and trimmed at startup, so values like `Builtin`, `EXTERNAL`, or `builtin` are all accepted. Any other value falls back to the `external` code path.
+
+> Once documents are ingested with a specific mode, do **not** switch modes without deleting all existing data first.

--- a/comps/dataprep/src/integrations/seahorse.py
+++ b/comps/dataprep/src/integrations/seahorse.py
@@ -1,0 +1,328 @@
+# Copyright (C) 2026 Dnotitia
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import os
+from pathlib import Path
+
+import requests
+from fastapi import Body, HTTPException
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain_community.embeddings import HuggingFaceInferenceAPIEmbeddings
+from langchain_huggingface import HuggingFaceEmbeddings
+from langchain_text_splitters import HTMLHeaderTextSplitter
+from seahorse_vector_store import SeahorseVectorStore
+
+from comps import CustomLogger, DocPath, OpeaComponent, OpeaComponentRegistry, ServiceType
+from comps.cores.proto.api_protocol import DataprepRequest
+from comps.dataprep.src.utils import (
+    create_upload_folder,
+    document_loader,
+    encode_filename,
+    get_file_structure,
+    get_separators,
+    get_tables_result,
+    parse_html_new,
+    remove_folder_with_ignore,
+    save_content_to_local_disk,
+)
+
+logger = CustomLogger("seahorse_dataprep")
+logflag = os.getenv("LOGFLAG", False)
+upload_folder = "./uploaded_files/"
+TEI_INFO_TIMEOUT_SECONDS = 10
+
+# Embedding model
+EMBED_MODEL = os.getenv("EMBED_MODEL", "BAAI/bge-base-en-v1.5")
+# TEI Embedding endpoint
+TEI_EMBEDDING_ENDPOINT = os.getenv("TEI_EMBEDDING_ENDPOINT", "")
+# Huggingface API token for TEI embedding endpoint
+HF_TOKEN = os.getenv("HF_TOKEN") or os.getenv("HUGGINGFACEHUB_API_TOKEN", "")
+
+# Seahorse Cloud configuration
+SEAHORSE_BASE_URL = os.getenv("SEAHORSE_BASE_URL", "")
+SEAHORSE_API_KEY = os.getenv("SEAHORSE_API_KEY", "")
+SEAHORSE_EMBEDDING_MODE = os.getenv("SEAHORSE_EMBEDDING_MODE", "builtin").strip().lower()
+
+
+@OpeaComponentRegistry.register("OPEA_DATAPREP_SEAHORSE")
+class OpeaSeahorseDataprep(OpeaComponent):
+    """Seahorse Cloud document ingestion via API Gateway.
+
+    Embedding mode (controlled by SEAHORSE_EMBEDDING_MODE env var):
+    - "builtin": Seahorse Cloud generates embeddings server-side (no TEI needed).
+                 Must match Retriever's builtin mode for consistent search.
+    - "external": Uses TEI or local HuggingFace embeddings.
+                  Must match Retriever's external mode for consistent search.
+    """
+
+    def __init__(self, name: str, description: str, config: dict = None):
+        super().__init__(name, ServiceType.DATAPREP.name.lower(), description, config)
+        self.upload_folder = upload_folder
+        self.use_builtin = SEAHORSE_EMBEDDING_MODE == "builtin"
+        self.embedder = self._initialize_embedder()
+        self.vectorstore = self._initialize_vectorstore()
+        health_status = self.check_health()
+        if not health_status:
+            logger.error("OpeaSeahorseDataprep health check failed.")
+
+    @staticmethod
+    def _require_env_config() -> None:
+        missing = []
+        if not SEAHORSE_BASE_URL:
+            missing.append("SEAHORSE_BASE_URL")
+        if not SEAHORSE_API_KEY:
+            missing.append("SEAHORSE_API_KEY")
+        if missing:
+            raise RuntimeError(f"Missing required Seahorse configuration: {', '.join(missing)}")
+
+    @staticmethod
+    def _fetch_tei_model_id() -> str:
+        try:
+            response = requests.get(f"{TEI_EMBEDDING_ENDPOINT}/info", timeout=TEI_INFO_TIMEOUT_SECONDS)
+        except Exception as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=f"TEI embedding endpoint {TEI_EMBEDDING_ENDPOINT} is not available: {exc}",
+            ) from exc
+
+        if response.status_code != 200:
+            raise HTTPException(
+                status_code=400,
+                detail=f"TEI embedding endpoint {TEI_EMBEDDING_ENDPOINT} is not available.",
+            )
+
+        try:
+            payload = response.json()
+        except Exception as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=f"TEI embedding endpoint {TEI_EMBEDDING_ENDPOINT} returned invalid JSON.",
+            ) from exc
+
+        model_id = payload.get("model_id") if isinstance(payload, dict) else None
+        if not model_id:
+            raise HTTPException(
+                status_code=400,
+                detail=f"TEI embedding endpoint {TEI_EMBEDDING_ENDPOINT} did not return model_id.",
+            )
+        return model_id
+
+    def _initialize_embedder(self):
+        if self.use_builtin:
+            if logflag:
+                logger.info("[ init embedder ] Using Seahorse built-in embeddings (SEAHORSE_EMBEDDING_MODE=builtin)")
+            return None
+
+        if TEI_EMBEDDING_ENDPOINT:
+            if logflag:
+                logger.info(f"[ init embedder ] TEI_EMBEDDING_ENDPOINT: {TEI_EMBEDDING_ENDPOINT}")
+            if not HF_TOKEN:
+                raise HTTPException(
+                    status_code=400,
+                    detail="You MUST offer the `HF_TOKEN` when using `TEI_EMBEDDING_ENDPOINT`.",
+                )
+            model_id = self._fetch_tei_model_id()
+            return HuggingFaceInferenceAPIEmbeddings(
+                api_key=HF_TOKEN, model_name=model_id, api_url=TEI_EMBEDDING_ENDPOINT
+            )
+        else:
+            if logflag:
+                logger.info(f"[ init embedder ] LOCAL EMBED_MODEL: {EMBED_MODEL}")
+
+            return HuggingFaceEmbeddings(model_name=EMBED_MODEL)
+
+    def _initialize_vectorstore(self) -> SeahorseVectorStore:
+        self._require_env_config()
+        kwargs = {
+            "api_key": SEAHORSE_API_KEY,
+            "base_url": SEAHORSE_BASE_URL,
+        }
+        if self.use_builtin:
+            kwargs["use_builtin_embedding"] = True
+        else:
+            kwargs["embedding"] = self.embedder
+            kwargs["use_builtin_embedding"] = False
+
+        return SeahorseVectorStore(**kwargs)
+
+    def check_health(self) -> bool:
+        """Check Seahorse Cloud connectivity via the SDK's public health() API."""
+        if logflag:
+            logger.info("[ check health ] start to check health of Seahorse Cloud")
+        try:
+            self.vectorstore.health()
+            if logflag:
+                logger.info("[ check health ] Seahorse Cloud connected.")
+            return True
+        except Exception as e:
+            logger.error(f"[ check health ] Seahorse Cloud health check failed: {e}")
+            return False
+
+    def invoke(self, *args, **kwargs):
+        pass
+
+    async def ingest_data_to_seahorse(self, doc_path: DocPath):
+        """Parse, chunk, and ingest a single document."""
+        path = doc_path.path
+        file_name = path.split("/")[-1]
+        if logflag:
+            logger.info(f"[ ingest ] Parsing document {path}")
+
+        if path.endswith(".html"):
+            headers_to_split_on = [
+                ("h1", "Header 1"),
+                ("h2", "Header 2"),
+                ("h3", "Header 3"),
+            ]
+            text_splitter = HTMLHeaderTextSplitter(headers_to_split_on=headers_to_split_on)
+        else:
+            text_splitter = RecursiveCharacterTextSplitter(
+                chunk_size=doc_path.chunk_size,
+                chunk_overlap=doc_path.chunk_overlap,
+                add_start_index=True,
+                separators=get_separators(),
+            )
+
+        content = await document_loader(path)
+
+        structured_types = [".xlsx", ".csv", ".json", "jsonl"]
+        _, ext = os.path.splitext(path)
+
+        if ext in structured_types:
+            chunks = content
+        else:
+            chunks = text_splitter.split_text(content)
+
+        if doc_path.process_table and path.endswith(".pdf"):
+            table_chunks = get_tables_result(path, doc_path.table_strategy)
+            if table_chunks:
+                chunks = chunks + table_chunks
+
+        if logflag:
+            logger.info(f"[ ingest ] Created {len(chunks)} chunks from {file_name}")
+
+        metadatas = [{"filename": file_name} for _ in chunks]
+
+        # builtin: text only → server generates embeddings
+        # external: SDK uses self.embedder to generate embeddings client-side
+        self.vectorstore.add_texts(texts=chunks, metadatas=metadatas)
+
+        if logflag:
+            logger.info(f"[ ingest ] Successfully ingested {file_name} to Seahorse Cloud")
+        return True
+
+    async def ingest_files(self, input: DataprepRequest):
+        """Ingest files/links into Seahorse Cloud.
+
+        Args:
+            input (DataprepRequest): files, link_list, chunk_size, chunk_overlap, etc.
+        Returns:
+            dict: {"status": 200, "message": "Data preparation succeeded"}
+        """
+        files = input.files
+        link_list = input.link_list
+        chunk_size = input.chunk_size
+        chunk_overlap = input.chunk_overlap
+        process_table = input.process_table
+        table_strategy = input.table_strategy
+
+        if logflag:
+            logger.info(f"[ ingest ] files: {files}")
+            logger.info(f"[ ingest ] link_list: {link_list}")
+
+        if files:
+            if not isinstance(files, list):
+                files = [files]
+            for file in files:
+                encode_file = encode_filename(file.filename)
+                save_path = self.upload_folder + encode_file
+                await save_content_to_local_disk(save_path, file)
+                await self.ingest_data_to_seahorse(
+                    DocPath(
+                        path=save_path,
+                        chunk_size=chunk_size,
+                        chunk_overlap=chunk_overlap,
+                        process_table=process_table,
+                        table_strategy=table_strategy,
+                    )
+                )
+                if logflag:
+                    logger.info(f"[ ingest ] Successfully saved file {save_path}")
+            return {"status": 200, "message": "Data preparation succeeded"}
+
+        if link_list:
+            link_list = json.loads(link_list)
+            if not isinstance(link_list, list):
+                raise HTTPException(status_code=400, detail="link_list should be a list.")
+            for link in link_list:
+                encoded_link = encode_filename(link)
+                save_path = self.upload_folder + encoded_link + ".txt"
+                content = parse_html_new([link], chunk_size=chunk_size, chunk_overlap=chunk_overlap)
+                await save_content_to_local_disk(save_path, content)
+                await self.ingest_data_to_seahorse(
+                    DocPath(
+                        path=save_path,
+                        chunk_size=chunk_size,
+                        chunk_overlap=chunk_overlap,
+                        process_table=process_table,
+                        table_strategy=table_strategy,
+                    )
+                )
+                if logflag:
+                    logger.info(f"[ ingest ] Successfully saved link {link}")
+            return {"status": 200, "message": "Data preparation succeeded"}
+
+        raise HTTPException(status_code=400, detail="Must provide either a file or a string list.")
+
+    async def get_files(self):
+        """Get list of ingested files from local upload folder."""
+        if logflag:
+            logger.info("[ get files ] start to get file structure")
+
+        if not Path(self.upload_folder).exists():
+            if logflag:
+                logger.info("No file uploaded, return empty list.")
+            return []
+
+        file_content = get_file_structure(self.upload_folder)
+        if logflag:
+            logger.info(file_content)
+        return file_content
+
+    async def delete_files(self, file_path: str = Body(..., embed=True)):
+        """Delete file data from Seahorse Cloud.
+
+        file_path:
+        - "all": delete all data from Seahorse Cloud and local upload folder
+        - specific path: delete chunks for that file (by metadata filter)
+        """
+        if logflag:
+            logger.info(f"[ delete ] file_path: {file_path}")
+
+        if file_path == "all":
+            self.vectorstore.delete(delete_all=True)
+            if logflag:
+                logger.info("[ delete ] successfully deleted all data from Seahorse Cloud")
+            try:
+                remove_folder_with_ignore(self.upload_folder)
+            except Exception as e:
+                logger.error(f"[ delete ] Failed to remove upload folder: {e}")
+            create_upload_folder(self.upload_folder)
+            if logflag:
+                logger.info("[ delete ] successfully deleted all local files")
+            return {"status": True}
+
+        encode_file_name = encode_filename(file_path)
+        delete_path = Path(self.upload_folder + "/" + encode_file_name)
+
+        if delete_path.exists():
+            self.vectorstore.delete(filter={"filename": encode_file_name})
+            delete_path.unlink()
+            if logflag:
+                logger.info(
+                    f"[ delete ] file {file_path} (stored as {encode_file_name}) deleted from Seahorse Cloud and local"
+                )
+            return {"status": True}
+        else:
+            raise HTTPException(status_code=404, detail="File not found.")

--- a/comps/dataprep/src/opea_dataprep_microservice.py
+++ b/comps/dataprep/src/opea_dataprep_microservice.py
@@ -19,6 +19,7 @@ from integrations.pipecone import OpeaPineConeDataprep
 from integrations.qdrant import OpeaQdrantDataprep
 from integrations.redis import OpeaRedisDataprep
 from integrations.redis_finance import OpeaRedisDataprepFinance
+from integrations.seahorse import OpeaSeahorseDataprep
 from integrations.vdms import OpeaVdmsDataprep
 from opea_dataprep_loader import OpeaDataprepLoader
 

--- a/comps/dataprep/src/requirements-cpu.txt
+++ b/comps/dataprep/src/requirements-cpu.txt
@@ -281,6 +281,7 @@ httpcore==1.0.9
 httpx==0.28.1
     # via
     #   langchain-pinecone
+    #   langchain-seahorse
     #   langsmith
     #   llama-cloud
     #   llama-index-core
@@ -395,6 +396,7 @@ langchain-core==0.3.81
     #   langchain-opengauss
     #   langchain-pinecone
     #   langchain-redis
+    #   langchain-seahorse
     #   langchain-text-splitters
     #   langchain-vdms
 langchain-elasticsearch==0.4.0
@@ -416,6 +418,8 @@ langchain-opengauss==0.1.5
 langchain-pinecone==0.2.13
     # via -r ./comps/dataprep/src/requirements.in
 langchain-redis==0.2.4
+    # via -r ./comps/dataprep/src/requirements.in
+langchain-seahorse==0.4.0
     # via -r ./comps/dataprep/src/requirements.in
 langchain-text-splitters==0.3.11
     # via
@@ -886,6 +890,7 @@ pydantic==2.12.5
     #   langchain-core
     #   langchain-opengauss
     #   langchain-pinecone
+    #   langchain-seahorse
     #   langsmith
     #   llama-cloud
     #   llama-cloud-services

--- a/comps/dataprep/src/requirements-gpu.txt
+++ b/comps/dataprep/src/requirements-gpu.txt
@@ -283,6 +283,7 @@ httpcore==1.0.9
 httpx==0.28.1
     # via
     #   langchain-pinecone
+    #   langchain-seahorse
     #   langsmith
     #   llama-cloud
     #   llama-index-core
@@ -398,6 +399,7 @@ langchain-core==0.3.81
     #   langchain-opengauss
     #   langchain-pinecone
     #   langchain-redis
+    #   langchain-seahorse
     #   langchain-text-splitters
     #   langchain-vdms
 langchain-elasticsearch==0.4.0
@@ -419,6 +421,8 @@ langchain-opengauss==0.1.5
 langchain-pinecone==0.2.13
     # via -r ./comps/dataprep/src/requirements.in
 langchain-redis==0.2.4
+    # via -r ./comps/dataprep/src/requirements.in
+langchain-seahorse==0.4.0
     # via -r ./comps/dataprep/src/requirements.in
 langchain-text-splitters==0.3.11
     # via
@@ -931,6 +935,7 @@ pydantic==2.12.5
     #   langchain-core
     #   langchain-opengauss
     #   langchain-pinecone
+    #   langchain-seahorse
     #   langsmith
     #   llama-cloud
     #   llama-cloud-services

--- a/comps/dataprep/src/requirements.in
+++ b/comps/dataprep/src/requirements.in
@@ -25,6 +25,7 @@ langchain-mariadb
 langchain-openai
 langchain-pinecone
 langchain-redis
+langchain-seahorse>=0.4.0
 langchain-text-splitters
 langchain-vdms>=0.1.4
 langchain_huggingface

--- a/comps/retrievers/README.md
+++ b/comps/retrievers/README.md
@@ -53,3 +53,7 @@ For details, please refer to this [readme](src/README_arangodb.md)
 ## Retriever Microservice with openGauss
 
 For details, please refer to this [readme](src/README_opengauss.md)
+
+## Retriever Microservice with Seahorse Cloud
+
+For details, please refer to this [readme](src/README_seahorse.md)

--- a/comps/retrievers/deployment/docker_compose/compose.yaml
+++ b/comps/retrievers/deployment/docker_compose/compose.yaml
@@ -244,6 +244,18 @@ services:
       mariadb-server:
         condition: service_healthy
 
+  retriever-seahorse:
+    extends: retriever
+    container_name: retriever-seahorse
+    environment:
+      RETRIEVER_COMPONENT_NAME: ${RETRIEVER_COMPONENT_NAME:-OPEA_RETRIEVER_SEAHORSE}
+      SEAHORSE_BASE_URL: ${SEAHORSE_BASE_URL}
+      SEAHORSE_API_KEY: ${SEAHORSE_API_KEY}
+      SEAHORSE_EMBEDDING_MODE: ${SEAHORSE_EMBEDDING_MODE:-builtin}
+      SEAHORSE_SEARCH_MODE: ${SEAHORSE_SEARCH_MODE:-hybrid}
+      TEI_EMBEDDING_ENDPOINT: ${TEI_EMBEDDING_ENDPOINT}
+      HF_TOKEN: ${HF_TOKEN}
+
 networks:
   default:
     driver: bridge

--- a/comps/retrievers/src/README_seahorse.md
+++ b/comps/retrievers/src/README_seahorse.md
@@ -1,0 +1,133 @@
+# Retriever Microservice with Seahorse Cloud
+
+## 0. Prerequisites
+
+Before using this microservice, you need a Seahorse Cloud table with an API endpoint:
+
+1. Sign up at [Seahorse Console](https://console.seahorse.dnotitia.ai)
+2. Create a table — an API endpoint (`SEAHORSE_BASE_URL`) and API key (`SEAHORSE_API_KEY`) will be issued upon creation
+3. Use the issued endpoint and key as environment variables below
+
+## 1. 🚀 Start Microservice with Python (Option 1)
+
+### 1.1 Install Requirements
+
+```bash
+cd ../../../
+pip install -e .
+cd comps/retrievers/src
+pip install -r requirements-cpu.txt
+```
+
+### 1.2 Setup Environment Variables
+
+```bash
+export SEAHORSE_BASE_URL="https://<table-uuid>.api.seahorse.dnotitia.ai"
+export SEAHORSE_API_KEY="sk_xxx"
+export SEAHORSE_EMBEDDING_MODE="builtin"  # or "external"
+export SEAHORSE_SEARCH_MODE="hybrid"      # "dense", "sparse", or "hybrid"
+```
+
+> **⚠️ Important**: `SEAHORSE_EMBEDDING_MODE` must be the same value for both Retriever and Dataprep services.
+> If Dataprep used `builtin` mode to ingest documents, Retriever must also use `builtin`.
+> If Dataprep used `external` mode to ingest documents, Retriever must also use `external`.
+
+> **⚠️ SEAHORSE_SEARCH_MODE**: This must match the vector column configuration of your Seahorse table.
+> For example, if your table only has a dense vector column, set `SEAHORSE_SEARCH_MODE="dense"`.
+> Setting `hybrid` or `sparse` on a table without a sparse vector column will cause search failures.
+> When `SEAHORSE_EMBEDDING_MODE="external"`, Retriever search is always dense-only.
+> Set `SEAHORSE_SEARCH_MODE="dense"`; `hybrid` and `sparse` will be overridden to `dense`.
+
+> Both `SEAHORSE_EMBEDDING_MODE` and `SEAHORSE_SEARCH_MODE` are normalized to lowercase and trimmed at startup, so values like `Builtin`, `HYBRID`, or `dense` are accepted. An unknown `SEAHORSE_SEARCH_MODE` raises `RuntimeError` at boot listing the supported values.
+
+For `external` mode, you can also set:
+
+```bash
+export TEI_EMBEDDING_ENDPOINT="http://${your_ip}:6060"
+export HF_TOKEN=${your_huggingface_token}
+```
+
+If `TEI_EMBEDDING_ENDPOINT` is not set, Retriever falls back to local HuggingFace embeddings to satisfy the SDK's external-mode initialization requirement.
+
+### 1.3 Start Retriever Service
+
+```bash
+export RETRIEVER_COMPONENT_NAME="OPEA_RETRIEVER_SEAHORSE"
+python opea_retrievers_microservice.py
+```
+
+## 2. 🚀 Start Microservice with Docker (Option 2)
+
+### 2.1 Setup Environment Variables
+
+```bash
+export SEAHORSE_BASE_URL="https://<table-uuid>.api.seahorse.dnotitia.ai"
+export SEAHORSE_API_KEY="sk_xxx"
+export SEAHORSE_EMBEDDING_MODE="builtin"  # set "external" for dense-only vector search
+export SEAHORSE_SEARCH_MODE="hybrid"      # set "dense" when SEAHORSE_EMBEDDING_MODE="external"
+export TEI_EMBEDDING_ENDPOINT="http://${your_ip}:6060"
+export HF_TOKEN=${your_huggingface_token}
+export RETRIEVER_COMPONENT_NAME="OPEA_RETRIEVER_SEAHORSE"
+```
+
+### 2.2 Build Docker Image
+
+```bash
+cd ../../../
+docker build -t opea/retriever:latest --build-arg https_proxy=$https_proxy --build-arg http_proxy=$http_proxy -f comps/retrievers/src/Dockerfile .
+```
+
+### 2.3 Run Docker with CLI
+
+```bash
+docker run -d --name="retriever-seahorse-server" -p 7000:7000 --ipc=host -e SEAHORSE_BASE_URL=$SEAHORSE_BASE_URL -e SEAHORSE_API_KEY=$SEAHORSE_API_KEY -e SEAHORSE_EMBEDDING_MODE=$SEAHORSE_EMBEDDING_MODE -e SEAHORSE_SEARCH_MODE=$SEAHORSE_SEARCH_MODE -e TEI_EMBEDDING_ENDPOINT=$TEI_EMBEDDING_ENDPOINT -e HF_TOKEN=$HF_TOKEN -e RETRIEVER_COMPONENT_NAME=$RETRIEVER_COMPONENT_NAME opea/retriever:latest
+```
+
+## 🚀 3. Consume Retriever Service
+
+### 3.1 Check Service Status
+
+```bash
+curl http://${your_ip}:7000/v1/health_check \
+  -X GET \
+  -H 'Content-Type: application/json'
+```
+
+### 3.2 Search Documents
+
+**builtin mode** (text query — server handles embedding):
+
+```bash
+curl http://${your_ip}:7000/v1/retrieval \
+  -X POST \
+  -d '{"text":"What is the revenue of Nike in 2023?","embedding":[0.0],"k":3}' \
+  -H 'Content-Type: application/json'
+```
+
+**external mode** (pre-computed embedding vector, dense-only):
+
+```bash
+export your_embedding=$(python -c "import random; embedding = [random.uniform(-1, 1) for _ in range(768)]; print(embedding)")
+curl http://${your_ip}:7000/v1/retrieval \
+  -X POST \
+  -d "{\"text\":\"What is the revenue of Nike in 2023?\",\"embedding\":${your_embedding},\"k\":3}" \
+  -H 'Content-Type: application/json'
+```
+
+## 4. Embedding Modes
+
+| Mode       | Env Var                            | Search Method                                                                                                                                                                   | TEI Required?                        |
+| ---------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| `builtin`  | `SEAHORSE_EMBEDDING_MODE=builtin`  | `similarity_search(query=text)` — server embeds query                                                                                                                           | No                                   |
+| `external` | `SEAHORSE_EMBEDDING_MODE=external` | `similarity_search_by_vector(embedding=vec)` — dense-only query vector search. External embeddings apply to dense vectors only; sparse always uses the built-in embedding path. | No (falls back to local HuggingFace) |
+
+## 5. Search Type Behavior
+
+| `search_type`                   | Dense (`builtin` + `SEAHORSE_SEARCH_MODE=dense`, or `external`)                                                                        | Sparse / Hybrid (`builtin` only)                                                                                                            |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `similarity`                    | Top-`k` by cosine distance — no threshold applied                                                                                      | Top-`k` by similarity score — no threshold applied                                                                                          |
+| `similarity_score_threshold`    | `score_threshold` is interpreted as a **distance upper bound** (lower = closer match). Returns docs with `distance ≤ score_threshold`. | `score_threshold` is interpreted as a **similarity lower bound** (higher = better match). Returns docs with `similarity ≥ score_threshold`. |
+| `similarity_distance_threshold` | `distance_threshold` is the **distance upper bound**. Recommended for dense distance cutoffs.                                          | Not supported — returns HTTP 400.                                                                                                           |
+| `mmr`                           | **Not supported.** Silently falls back to `similarity` (a warning is logged). For diversity-aware retrieval, use a different backend.  | Same as dense.                                                                                                                              |
+
+> **Important:** `score_threshold` semantics differ between dense and sparse/hybrid because the underlying SDK returns distances for dense vector search and similarities for sparse/hybrid. Apply the threshold accordingly when comparing results across modes. When in doubt for dense searches, prefer `similarity_distance_threshold` so the intent is unambiguous.

--- a/comps/retrievers/src/integrations/config.py
+++ b/comps/retrievers/src/integrations/config.py
@@ -253,3 +253,11 @@ OPENAI_EMBED_ENABLED = os.getenv("OPENAI_EMBED_ENABLED", "true").lower() == "tru
 #######################################################
 MARIADB_CONNECTION_URL = os.getenv("MARIADB_CONNECTION_URL", "localhost")
 MARIADB_COLLECTION_NAME = os.getenv("MARIADB_COLLECTION_NAME", "rag_mariadbvector")
+
+#######################################################
+# Seahorse Cloud                                      #
+#######################################################
+SEAHORSE_BASE_URL = os.getenv("SEAHORSE_BASE_URL", "")
+SEAHORSE_API_KEY = os.getenv("SEAHORSE_API_KEY", "")
+SEAHORSE_SEARCH_MODE = os.getenv("SEAHORSE_SEARCH_MODE", "hybrid").strip().lower()
+SEAHORSE_EMBEDDING_MODE = os.getenv("SEAHORSE_EMBEDDING_MODE", "builtin").strip().lower()

--- a/comps/retrievers/src/integrations/seahorse.py
+++ b/comps/retrievers/src/integrations/seahorse.py
@@ -1,0 +1,318 @@
+# Copyright (C) 2026 Dnotitia
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import os
+
+import requests
+from fastapi import HTTPException
+from langchain_community.embeddings import HuggingFaceInferenceAPIEmbeddings
+from langchain_huggingface import HuggingFaceEmbeddings
+from seahorse_vector_store import SeahorseVectorStore, SearchMode
+
+from comps import CustomLogger, EmbedDoc, OpeaComponent, OpeaComponentRegistry, ServiceType
+
+from .config import (
+    EMBED_MODEL,
+    HF_TOKEN,
+    SEAHORSE_API_KEY,
+    SEAHORSE_BASE_URL,
+    SEAHORSE_EMBEDDING_MODE,
+    SEAHORSE_SEARCH_MODE,
+    TEI_EMBEDDING_ENDPOINT,
+)
+
+logger = CustomLogger("seahorse_retrievers")
+logflag = os.getenv("LOGFLAG", False)
+TEI_INFO_TIMEOUT_SECONDS = 10
+
+SEARCH_MODE_MAP = {
+    "dense": SearchMode.DENSE,
+    "sparse": SearchMode.SPARSE,
+    "hybrid": SearchMode.HYBRID,
+}
+SUPPORTED_SEARCH_TYPES = {
+    "similarity",
+    "similarity_score_threshold",
+    "similarity_distance_threshold",
+    "mmr",
+}
+
+
+@OpeaComponentRegistry.register("OPEA_RETRIEVER_SEAHORSE")
+class OpeaSeahorseRetriever(OpeaComponent):
+    """Seahorse Cloud managed vector search retriever.
+
+    Connects to Seahorse Cloud API Gateway via langchain-seahorse SDK.
+    SaaS — no self-hosted infrastructure required.
+
+    Embedding mode (controlled by SEAHORSE_EMBEDDING_MODE env var):
+    - "builtin": Uses Seahorse server-side embeddings for both indexing and search.
+                 Calls similarity_search(query=text) so the server embeds the query.
+    - "external": Initializes the SDK with a TEI or local HuggingFace embedder, but query-time
+                  retrieval uses similarity_search_by_vector(embedding=vec) with the pre-computed
+                  embedding passed in from the caller. External mode is always dense-only.
+    """
+
+    def __init__(self, name: str, description: str, config: dict = None):
+        super().__init__(name, ServiceType.RETRIEVER.name.lower(), description, config)
+        self.use_builtin = SEAHORSE_EMBEDDING_MODE == "builtin"
+        self.embedder = self._initialize_embedder()
+        self.search_mode = self._initialize_search_mode()
+        self.vectorstore = self._initialize_vectorstore()
+        health_status = self.check_health()
+        if not health_status:
+            logger.error("OpeaSeahorseRetriever health check failed.")
+
+    @staticmethod
+    def _require_env_config() -> None:
+        missing = []
+        if not SEAHORSE_BASE_URL:
+            missing.append("SEAHORSE_BASE_URL")
+        if not SEAHORSE_API_KEY:
+            missing.append("SEAHORSE_API_KEY")
+        if missing:
+            raise RuntimeError(f"Missing required Seahorse configuration: {', '.join(missing)}")
+
+    @staticmethod
+    def _fetch_tei_model_id() -> str:
+        try:
+            response = requests.get(f"{TEI_EMBEDDING_ENDPOINT}/info", timeout=TEI_INFO_TIMEOUT_SECONDS)
+        except Exception as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=f"TEI embedding endpoint {TEI_EMBEDDING_ENDPOINT} is not available: {exc}",
+            ) from exc
+
+        if response.status_code != 200:
+            raise HTTPException(
+                status_code=400,
+                detail=f"TEI embedding endpoint {TEI_EMBEDDING_ENDPOINT} is not available.",
+            )
+
+        try:
+            payload = response.json()
+        except Exception as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=f"TEI embedding endpoint {TEI_EMBEDDING_ENDPOINT} returned invalid JSON.",
+            ) from exc
+
+        model_id = payload.get("model_id") if isinstance(payload, dict) else None
+        if not model_id:
+            raise HTTPException(
+                status_code=400,
+                detail=f"TEI embedding endpoint {TEI_EMBEDDING_ENDPOINT} did not return model_id.",
+            )
+        return model_id
+
+    @staticmethod
+    def _normalize_search_type(search_type: str) -> str:
+        if search_type not in SUPPORTED_SEARCH_TYPES:
+            raise HTTPException(status_code=400, detail=f"Unsupported search_type: {search_type}")
+        if search_type == "mmr":
+            logger.warning(
+                "[ invoke ] MMR is not supported by Seahorse Cloud; falling back to similarity search. "
+                "Diversity-aware retrieval will not be applied."
+            )
+            return "similarity"
+        return search_type
+
+    @staticmethod
+    def _validate_external_embedding(embedding) -> None:
+        if embedding is None or (isinstance(embedding, (list, tuple)) and len(embedding) == 0):
+            raise HTTPException(
+                status_code=400,
+                detail="embedding must be provided when SEAHORSE_EMBEDDING_MODE=external.",
+            )
+
+    def _initialize_embedder(self):
+        if self.use_builtin:
+            if logflag:
+                logger.info("[ init embedder ] Using Seahorse built-in embeddings (SEAHORSE_EMBEDDING_MODE=builtin)")
+            return None
+
+        if TEI_EMBEDDING_ENDPOINT:
+            if logflag:
+                logger.info(f"[ init embedder ] TEI_EMBEDDING_ENDPOINT: {TEI_EMBEDDING_ENDPOINT}")
+            if not HF_TOKEN:
+                raise HTTPException(
+                    status_code=400,
+                    detail="You MUST offer the `HF_TOKEN` when using `TEI_EMBEDDING_ENDPOINT`.",
+                )
+            model_id = self._fetch_tei_model_id()
+            return HuggingFaceInferenceAPIEmbeddings(
+                api_key=HF_TOKEN, model_name=model_id, api_url=TEI_EMBEDDING_ENDPOINT
+            )
+
+        if logflag:
+            logger.info(f"[ init embedder ] LOCAL EMBED_MODEL: {EMBED_MODEL}")
+
+        return HuggingFaceEmbeddings(model_name=EMBED_MODEL)
+
+    def _initialize_search_mode(self) -> SearchMode:
+        if SEAHORSE_SEARCH_MODE not in SEARCH_MODE_MAP:
+            raise RuntimeError(
+                f"Unknown SEAHORSE_SEARCH_MODE={SEAHORSE_SEARCH_MODE!r}. "
+                f"Supported values: {sorted(SEARCH_MODE_MAP)}"
+            )
+        requested_mode = SEARCH_MODE_MAP[SEAHORSE_SEARCH_MODE]
+        if not self.use_builtin and requested_mode != SearchMode.DENSE:
+            logger.warning(
+                "[ init ] external embedding mode only supports dense search. "
+                f"Overriding SEAHORSE_SEARCH_MODE={SEAHORSE_SEARCH_MODE} to dense."
+            )
+            return SearchMode.DENSE
+        return requested_mode
+
+    def _initialize_vectorstore(self) -> SeahorseVectorStore:
+        self._require_env_config()
+        if logflag:
+            logger.info(f"[ init ] SEAHORSE_BASE_URL: {SEAHORSE_BASE_URL}")
+            logger.info(f"[ init ] SEAHORSE_EMBEDDING_MODE: {SEAHORSE_EMBEDDING_MODE}")
+        kwargs = {
+            "api_key": SEAHORSE_API_KEY,
+            "base_url": SEAHORSE_BASE_URL,
+        }
+        if self.use_builtin:
+            kwargs["use_builtin_embedding"] = True
+        else:
+            kwargs["embedding"] = self.embedder
+            kwargs["use_builtin_embedding"] = False
+        return SeahorseVectorStore(**kwargs)
+
+    def check_health(self) -> bool:
+        """Check Seahorse Cloud connectivity via the SDK's public health() API."""
+        if logflag:
+            logger.info("[ check health ] start to check health of Seahorse Cloud")
+        try:
+            self.vectorstore.health()
+            if logflag:
+                logger.info("[ check health ] Seahorse Cloud connected.")
+            return True
+        except Exception as e:
+            logger.error(f"[ check health ] Failed to connect to Seahorse Cloud: {e}")
+            return False
+
+    @staticmethod
+    def _passes_score_threshold(score: float, threshold: float, *, is_distance: bool) -> bool:
+        """Match score semantics returned by the Seahorse SDK.
+
+        Dense vector searches return distance values, where lower is better.
+        Sparse and hybrid searches return similarity scores, where higher is better.
+        """
+        if is_distance:
+            return score <= threshold
+        return score >= threshold
+
+    async def _search_builtin(self, input: EmbedDoc, search_type: str) -> list:
+        """builtin mode: text query → server embeds with same built-in model → search."""
+        if search_type == "similarity_score_threshold":
+            docs_and_scores = await asyncio.to_thread(
+                self.vectorstore.similarity_search_with_score,
+                query=input.text,
+                k=input.k,
+                retrieval_mode=self.search_mode,
+            )
+            uses_distance = self.search_mode == SearchMode.DENSE
+            return [
+                doc
+                for doc, score in docs_and_scores
+                if self._passes_score_threshold(score, input.score_threshold, is_distance=uses_distance)
+            ]
+
+        if search_type == "similarity_distance_threshold":
+            if input.distance_threshold is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail="distance_threshold must be provided for similarity_distance_threshold retriever",
+                )
+            if self.search_mode != SearchMode.DENSE:
+                raise HTTPException(
+                    status_code=400,
+                    detail="similarity_distance_threshold is only supported for dense Seahorse search.",
+                )
+            docs_and_scores = await asyncio.to_thread(
+                self.vectorstore.similarity_search_with_score,
+                query=input.text,
+                k=input.k,
+                retrieval_mode=self.search_mode,
+            )
+            return [
+                doc
+                for doc, score in docs_and_scores
+                if self._passes_score_threshold(score, input.distance_threshold, is_distance=True)
+            ]
+
+        return await asyncio.to_thread(
+            self.vectorstore.similarity_search,
+            query=input.text,
+            k=input.k,
+            retrieval_mode=self.search_mode,
+        )
+
+    async def _search_external(self, input: EmbedDoc, search_type: str) -> list:
+        """external mode: use pre-computed OPEA TEI embedding vector for search.
+
+        Note: similarity_search_by_vector() does not accept retrieval_mode parameter.
+        External embedding mode is always dense-only, regardless of SEAHORSE_SEARCH_MODE.
+        """
+        self._validate_external_embedding(input.embedding)
+
+        if search_type == "similarity_score_threshold":
+            docs_and_scores = await asyncio.to_thread(
+                self.vectorstore.similarity_search_by_vector_with_score,
+                embedding=input.embedding,
+                k=input.k,
+            )
+            return [
+                doc
+                for doc, score in docs_and_scores
+                if self._passes_score_threshold(score, input.score_threshold, is_distance=True)
+            ]
+
+        if search_type == "similarity_distance_threshold":
+            if input.distance_threshold is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail="distance_threshold must be provided for similarity_distance_threshold retriever",
+                )
+            docs_and_scores = await asyncio.to_thread(
+                self.vectorstore.similarity_search_by_vector_with_score,
+                embedding=input.embedding,
+                k=input.k,
+            )
+            return [
+                doc
+                for doc, score in docs_and_scores
+                if self._passes_score_threshold(score, input.distance_threshold, is_distance=True)
+            ]
+
+        return await asyncio.to_thread(
+            self.vectorstore.similarity_search_by_vector,
+            embedding=input.embedding,
+            k=input.k,
+        )
+
+    async def invoke(self, input: EmbedDoc) -> list:
+        """Search Seahorse Cloud for similar documents.
+
+        Args:
+            input (EmbedDoc): Query with embedding vector, search_type, k, etc.
+        Returns:
+            list: Retrieved documents.
+        """
+        if logflag:
+            logger.info(input)
+
+        search_type = self._normalize_search_type(input.search_type)
+
+        if self.use_builtin:
+            search_res = await self._search_builtin(input, search_type)
+        else:
+            search_res = await self._search_external(input, search_type)
+
+        if logflag:
+            logger.info(f"[ invoke ] retrieve result: {search_res}")
+
+        return search_res

--- a/comps/retrievers/src/opea_retrievers_microservice.py
+++ b/comps/retrievers/src/opea_retrievers_microservice.py
@@ -20,6 +20,7 @@ from integrations.pgvector import OpeaPGVectorRetriever
 from integrations.pinecone import OpeaPineconeRetriever
 from integrations.qdrant import OpeaQDrantRetriever
 from integrations.redis import OpeaRedisRetriever
+from integrations.seahorse import OpeaSeahorseRetriever
 from integrations.vdms import OpeaVDMsRetriever
 
 from comps import (

--- a/comps/retrievers/src/requirements-cpu.txt
+++ b/comps/retrievers/src/requirements-cpu.txt
@@ -323,6 +323,7 @@ httplib2==0.31.0
 httpx==0.28.1
     # via
     #   langchain-pinecone
+    #   langchain-seahorse
     #   langsmith
     #   llama-index-core
     #   llama-index-embeddings-text-embeddings-inference
@@ -431,6 +432,7 @@ langchain-core==0.3.81
     #   langchain-openai
     #   langchain-opengauss
     #   langchain-pinecone
+    #   langchain-seahorse
     #   langchain-text-splitters
     #   langchain-vdms
 langchain-elasticsearch==0.4.0
@@ -448,6 +450,8 @@ langchain-openai==0.3.35
 langchain-opengauss==0.1.5
     # via -r ./comps/retrievers/src/requirements.in
 langchain-pinecone==0.2.13
+    # via -r ./comps/retrievers/src/requirements.in
+langchain-seahorse==0.4.0
     # via -r ./comps/retrievers/src/requirements.in
 langchain-text-splitters==0.3.11
     # via langchain
@@ -848,6 +852,7 @@ pydantic==2.12.5
     #   langchain-core
     #   langchain-opengauss
     #   langchain-pinecone
+    #   langchain-seahorse
     #   langsmith
     #   llama-index-core
     #   llama-index-instrumentation

--- a/comps/retrievers/src/requirements-gpu.txt
+++ b/comps/retrievers/src/requirements-gpu.txt
@@ -325,6 +325,7 @@ httplib2==0.31.0
 httpx==0.28.1
     # via
     #   langchain-pinecone
+    #   langchain-seahorse
     #   langsmith
     #   llama-index-core
     #   llama-index-embeddings-text-embeddings-inference
@@ -434,6 +435,7 @@ langchain-core==0.3.81
     #   langchain-openai
     #   langchain-opengauss
     #   langchain-pinecone
+    #   langchain-seahorse
     #   langchain-text-splitters
     #   langchain-vdms
 langchain-elasticsearch==0.4.0
@@ -451,6 +453,8 @@ langchain-openai==0.3.35
 langchain-opengauss==0.1.5
     # via -r ./comps/retrievers/src/requirements.in
 langchain-pinecone==0.2.13
+    # via -r ./comps/retrievers/src/requirements.in
+langchain-seahorse==0.4.0
     # via -r ./comps/retrievers/src/requirements.in
 langchain-text-splitters==0.3.11
     # via langchain
@@ -893,6 +897,7 @@ pydantic==2.12.5
     #   langchain-core
     #   langchain-opengauss
     #   langchain-pinecone
+    #   langchain-seahorse
     #   langsmith
     #   llama-index-core
     #   llama-index-instrumentation

--- a/comps/retrievers/src/requirements.in
+++ b/comps/retrievers/src/requirements.in
@@ -18,6 +18,7 @@ langchain-mariadb
 langchain-openai
 langchain-pinecone
 langchain-opengauss
+langchain-seahorse>=0.4.0
 langchain-vdms>=0.1.4
 langchain_community
 langchain_huggingface

--- a/tests/dataprep/test_dataprep_seahorse.py
+++ b/tests/dataprep/test_dataprep_seahorse.py
@@ -1,0 +1,242 @@
+# Copyright (C) 2026 Dnotitia
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+class FakeHTTPException(Exception):
+    def __init__(self, status_code, detail):
+        super().__init__(detail)
+        self.status_code = status_code
+        self.detail = detail
+
+
+class FakeLogger:
+    def info(self, *args, **kwargs):
+        pass
+
+    def warning(self, *args, **kwargs):
+        pass
+
+    def error(self, *args, **kwargs):
+        pass
+
+
+class FakeOpeaComponent:
+    def __init__(self, name, type, description, config=None):
+        self.name = name
+        self.type = type
+        self.description = description
+        self.config = config or {}
+
+
+class FakeOpeaComponentRegistry:
+    _registry = {}
+
+    @classmethod
+    def register(cls, name):
+        def decorator(component_class):
+            cls._registry[name] = component_class
+            return component_class
+
+        return decorator
+
+
+class FakeEmbeddingClient:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+class FakeVectorStore:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    def health(self):
+        return None
+
+    def add_texts(self, *args, **kwargs):
+        return None
+
+    def delete(self, *args, **kwargs):
+        return None
+
+
+class FakeTextSplitter:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def split_text(self, content):
+        return [content]
+
+
+def _package(name):
+    module = types.ModuleType(name)
+    module.__path__ = []
+    return module
+
+
+def import_dataprep_module(env):
+    """Load the dataprep seahorse integration with stubbed dependencies and env vars."""
+    package_name = "testpkg_dataprep"
+    module_name = f"{package_name}.seahorse"
+
+    for name in list(sys.modules):
+        if name.startswith(package_name):
+            sys.modules.pop(name, None)
+
+    fake_fastapi = types.ModuleType("fastapi")
+    fake_fastapi.HTTPException = FakeHTTPException
+    fake_fastapi.Body = lambda default=None, embed=False: default
+
+    fake_requests = types.ModuleType("requests")
+    fake_requests.get = MagicMock()
+
+    fake_langchain = _package("langchain")
+    fake_langchain_text_splitter = types.ModuleType("langchain.text_splitter")
+    fake_langchain_text_splitter.RecursiveCharacterTextSplitter = FakeTextSplitter
+
+    fake_langchain_community = _package("langchain_community")
+    fake_langchain_community_embeddings = types.ModuleType("langchain_community.embeddings")
+    fake_langchain_community_embeddings.HuggingFaceInferenceAPIEmbeddings = FakeEmbeddingClient
+
+    fake_langchain_huggingface = types.ModuleType("langchain_huggingface")
+    fake_langchain_huggingface.HuggingFaceEmbeddings = FakeEmbeddingClient
+
+    fake_langchain_text_splitters = types.ModuleType("langchain_text_splitters")
+    fake_langchain_text_splitters.HTMLHeaderTextSplitter = FakeTextSplitter
+
+    fake_seahorse_module = types.ModuleType("seahorse_vector_store")
+    fake_seahorse_module.SeahorseVectorStore = FakeVectorStore
+
+    fake_comps = types.ModuleType("comps")
+    fake_comps.CustomLogger = lambda name: FakeLogger()
+    fake_comps.DocPath = SimpleNamespace
+    fake_comps.OpeaComponent = FakeOpeaComponent
+    fake_comps.OpeaComponentRegistry = FakeOpeaComponentRegistry
+    fake_comps.ServiceType = SimpleNamespace(DATAPREP=SimpleNamespace(name="DATAPREP"))
+
+    fake_api_protocol = types.ModuleType("comps.cores.proto.api_protocol")
+    fake_api_protocol.DataprepRequest = object
+
+    fake_utils = types.ModuleType("comps.dataprep.src.utils")
+    fake_utils.create_upload_folder = lambda path: None
+    fake_utils.document_loader = lambda path: ""
+    fake_utils.encode_filename = lambda name: name.replace("/", "_")
+    fake_utils.get_file_structure = lambda path: []
+    fake_utils.get_separators = lambda: ["\n\n", "\n", " "]
+    fake_utils.get_tables_result = lambda path, strategy: []
+    fake_utils.parse_html_new = lambda links, chunk_size=None, chunk_overlap=None: ""
+    fake_utils.remove_folder_with_ignore = lambda path: None
+    fake_utils.save_content_to_local_disk = lambda path, file: None
+
+    dataprep_package = _package(package_name)
+
+    module_path = Path(__file__).resolve().parents[2] / "comps" / "dataprep" / "src" / "integrations" / "seahorse.py"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    module.__package__ = package_name
+
+    env_defaults = {
+        "SEAHORSE_BASE_URL": "",
+        "SEAHORSE_API_KEY": "",
+        "SEAHORSE_EMBEDDING_MODE": "builtin",
+        "TEI_EMBEDDING_ENDPOINT": "",
+        "EMBED_MODEL": "BAAI/bge-base-en-v1.5",
+        "HF_TOKEN": "",
+        "HUGGINGFACEHUB_API_TOKEN": "",
+        "LOGFLAG": "",
+    }
+    env_defaults.update(env)
+
+    with patch.dict(
+        sys.modules,
+        {
+            "fastapi": fake_fastapi,
+            "requests": fake_requests,
+            "langchain": fake_langchain,
+            "langchain.text_splitter": fake_langchain_text_splitter,
+            "langchain_community": fake_langchain_community,
+            "langchain_community.embeddings": fake_langchain_community_embeddings,
+            "langchain_huggingface": fake_langchain_huggingface,
+            "langchain_text_splitters": fake_langchain_text_splitters,
+            "seahorse_vector_store": fake_seahorse_module,
+            "comps": fake_comps,
+            "comps.cores": _package("comps.cores"),
+            "comps.cores.proto": _package("comps.cores.proto"),
+            "comps.cores.proto.api_protocol": fake_api_protocol,
+            "comps.dataprep": _package("comps.dataprep"),
+            "comps.dataprep.src": _package("comps.dataprep.src"),
+            "comps.dataprep.src.utils": fake_utils,
+            package_name: dataprep_package,
+            module_name: module,
+        },
+        clear=False,
+    ), patch.dict("os.environ", env_defaults, clear=False):
+        spec.loader.exec_module(module)
+    return module
+
+
+class TestSeahorseDataprep(unittest.TestCase):
+    def test_init_requires_base_url_and_api_key(self):
+        module = import_dataprep_module(
+            {
+                "SEAHORSE_BASE_URL": "",
+                "SEAHORSE_API_KEY": "",
+                "SEAHORSE_EMBEDDING_MODE": "builtin",
+            }
+        )
+
+        vectorstore = MagicMock()
+        vectorstore.health.return_value = None
+
+        with patch.object(module, "SeahorseVectorStore", return_value=vectorstore):
+            with self.assertRaises(RuntimeError):
+                module.OpeaSeahorseDataprep("OPEA_DATAPREP_SEAHORSE", "test")
+
+    def test_init_logs_error_when_health_check_fails(self):
+        module = import_dataprep_module(
+            {
+                "SEAHORSE_BASE_URL": "https://example.com",
+                "SEAHORSE_API_KEY": "secret",
+                "SEAHORSE_EMBEDDING_MODE": "builtin",
+            }
+        )
+
+        vectorstore = MagicMock()
+        vectorstore.health.side_effect = RuntimeError("unreachable")
+
+        with patch.object(module, "SeahorseVectorStore", return_value=vectorstore):
+            instance = module.OpeaSeahorseDataprep("OPEA_DATAPREP_SEAHORSE", "test")
+            self.assertIsNotNone(instance)
+
+    def test_tei_info_without_model_id_raises_http_exception(self):
+        module = import_dataprep_module(
+            {
+                "SEAHORSE_BASE_URL": "https://example.com",
+                "SEAHORSE_API_KEY": "secret",
+                "SEAHORSE_EMBEDDING_MODE": "external",
+                "TEI_EMBEDDING_ENDPOINT": "https://tei.example.com",
+                "HF_TOKEN": "hf-token",
+            }
+        )
+
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {}
+
+        with patch.object(module, "requests") as mock_requests:
+            mock_requests.get.return_value = response
+            with self.assertRaises(module.HTTPException):
+                module.OpeaSeahorseDataprep("OPEA_DATAPREP_SEAHORSE", "test")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/dataprep/test_dataprep_seahorse.sh
+++ b/tests/dataprep/test_dataprep_seahorse.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# Copyright (C) 2026 Dnotitia
+# SPDX-License-Identifier: Apache-2.0
+
+set -xe
+
+IMAGE_REPO=${IMAGE_REPO:-"opea"}
+export REGISTRY=${IMAGE_REPO}
+export TAG="comps"
+echo "REGISTRY=IMAGE_REPO=${IMAGE_REPO}"
+echo "TAG=${TAG}"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+WORKPATH=$(cd "${SCRIPT_DIR}/../.." && pwd)
+LOG_PATH="$WORKPATH/tests"
+
+source "${SCRIPT_DIR}/dataprep_utils.sh"
+source "${WORKPATH}/tests/utils/seahorse_helpers.sh"
+require_seahorse_credentials_or_skip
+detect_host_ip
+service_name="dataprep-seahorse-server"
+
+function build_docker_images() {
+    cd $WORKPATH
+    docker build --no-cache -t ${REGISTRY:-opea}/dataprep:${TAG:-latest} \
+        --build-arg https_proxy=$https_proxy \
+        --build-arg http_proxy=$http_proxy \
+        -f comps/dataprep/src/Dockerfile .
+    if [ $? -ne 0 ]; then
+        echo "opea/dataprep built fail"
+        exit 1
+    else
+        echo "opea/dataprep built successful"
+    fi
+}
+
+function start_service() {
+    export DATAPREP_PORT=5000
+    export LOGFLAG=True
+
+    cd $WORKPATH/comps/dataprep/deployment/docker_compose
+    docker compose -f compose.yaml up dataprep-seahorse -d \
+        > ${LOG_PATH}/start_services_with_compose.log
+
+    check_healthy "${service_name}" || exit 1
+}
+
+function validate_microservice() {
+    # Start clean so per-format counts are deterministic.
+    delete_all "${host_ip}" "${DATAPREP_PORT}"
+    check_result "dataprep - reset" '{"status":true}' "${service_name}" ${LOG_PATH}/dataprep_del.log
+
+    # txt
+    ingest_txt "${host_ip}" "${DATAPREP_PORT}" "seahorse"
+    check_result "dataprep - upload - txt" "Data preparation succeeded" "${service_name}" ${LOG_PATH}/dataprep_upload_file.log
+
+    # docx
+    ingest_docx "${host_ip}" "${DATAPREP_PORT}" "seahorse"
+    check_result "dataprep - upload - docx" "Data preparation succeeded" "${service_name}" ${LOG_PATH}/dataprep_upload_file.log
+
+    # pdf
+    ingest_pdf "${host_ip}" "${DATAPREP_PORT}" "seahorse"
+    check_result "dataprep - upload - pdf" "Data preparation succeeded" "${service_name}" ${LOG_PATH}/dataprep_upload_file.log
+
+    # external link (skip in fully air-gapped environments by setting SKIP_LINK_TEST=1)
+    if [[ "${SKIP_LINK_TEST:-0}" != "1" ]]; then
+        ingest_external_link "${host_ip}" "${DATAPREP_PORT}"
+        check_result "dataprep - upload - link" "Data preparation succeeded" "${service_name}" ${LOG_PATH}/dataprep_upload_file.log
+    fi
+
+    # get the local file index returned by the dataprep service
+    get_all "${host_ip}" "${DATAPREP_PORT}"
+    check_result "dataprep - get" '"name":' "${service_name}" ${LOG_PATH}/dataprep_file.log
+
+    # delete a single file by path (txt fixture is named ingest_dataprep.txt)
+    delete_single "${host_ip}" "${DATAPREP_PORT}"
+    check_result "dataprep - del single" '{"status":true}' "${service_name}" ${LOG_PATH}/dataprep_del.log
+
+    # delete everything
+    delete_all "${host_ip}" "${DATAPREP_PORT}"
+    check_result "dataprep - del all" '{"status":true}' "${service_name}" ${LOG_PATH}/dataprep_del.log
+}
+
+function stop_docker() {
+    cd $WORKPATH/comps/dataprep/deployment/docker_compose
+    docker compose -f compose.yaml down --remove-orphans
+}
+
+function main() {
+    stop_docker
+    build_docker_images
+
+    start_service
+    validate_microservice
+
+    stop_docker
+    echo y | docker system prune
+}
+
+main

--- a/tests/retrievers/test_retrievers_seahorse.py
+++ b/tests/retrievers/test_retrievers_seahorse.py
@@ -1,0 +1,287 @@
+# Copyright (C) 2026 Dnotitia
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+class FakeSearchMode:
+    DENSE = "dense"
+    SPARSE = "sparse"
+    HYBRID = "hybrid"
+
+
+class FakeHTTPException(Exception):
+    def __init__(self, status_code, detail):
+        super().__init__(detail)
+        self.status_code = status_code
+        self.detail = detail
+
+
+class FakeLogger:
+    def info(self, *args, **kwargs):
+        pass
+
+    def warning(self, *args, **kwargs):
+        pass
+
+    def error(self, *args, **kwargs):
+        pass
+
+
+class FakeOpeaComponent:
+    def __init__(self, name, type, description, config=None):
+        self.name = name
+        self.type = type
+        self.description = description
+        self.config = config or {}
+
+
+class FakeOpeaComponentRegistry:
+    _registry = {}
+
+    @classmethod
+    def register(cls, name):
+        def decorator(component_class):
+            cls._registry[name] = component_class
+            return component_class
+
+        return decorator
+
+
+class FakeEmbeddingClient:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+class FakeVectorStore:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    def health(self):
+        return None
+
+
+class FakeTextSplitter:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def split_text(self, content):
+        return [content]
+
+
+def _package(name):
+    module = types.ModuleType(name)
+    module.__path__ = []
+    return module
+
+
+def import_retriever_module(env):
+    package_name = "testpkg_retriever"
+    module_name = f"{package_name}.seahorse"
+    config_name = f"{package_name}.config"
+
+    for name in list(sys.modules):
+        if name.startswith(package_name):
+            sys.modules.pop(name, None)
+
+    fake_fastapi = types.ModuleType("fastapi")
+    fake_fastapi.HTTPException = FakeHTTPException
+
+    fake_requests = types.ModuleType("requests")
+    fake_requests.get = MagicMock()
+
+    fake_langchain_community = _package("langchain_community")
+    fake_langchain_community_embeddings = types.ModuleType("langchain_community.embeddings")
+    fake_langchain_community_embeddings.HuggingFaceInferenceAPIEmbeddings = FakeEmbeddingClient
+
+    fake_langchain_huggingface = types.ModuleType("langchain_huggingface")
+    fake_langchain_huggingface.HuggingFaceEmbeddings = FakeEmbeddingClient
+
+    fake_seahorse_module = types.ModuleType("seahorse_vector_store")
+    fake_seahorse_module.SeahorseVectorStore = FakeVectorStore
+    fake_seahorse_module.SearchMode = FakeSearchMode
+
+    fake_comps = types.ModuleType("comps")
+    fake_comps.CustomLogger = lambda name: FakeLogger()
+    fake_comps.EmbedDoc = object
+    fake_comps.OpeaComponent = FakeOpeaComponent
+    fake_comps.OpeaComponentRegistry = FakeOpeaComponentRegistry
+    fake_comps.ServiceType = SimpleNamespace(RETRIEVER=SimpleNamespace(name="RETRIEVER"))
+
+    config_module = types.ModuleType(config_name)
+    config_module.EMBED_MODEL = env.get("EMBED_MODEL", "BAAI/bge-base-en-v1.5")
+    config_module.HF_TOKEN = env.get("HF_TOKEN", "")
+    config_module.SEAHORSE_API_KEY = env.get("SEAHORSE_API_KEY", "")
+    config_module.SEAHORSE_BASE_URL = env.get("SEAHORSE_BASE_URL", "")
+    config_module.SEAHORSE_EMBEDDING_MODE = env.get("SEAHORSE_EMBEDDING_MODE", "builtin")
+    config_module.SEAHORSE_SEARCH_MODE = env.get("SEAHORSE_SEARCH_MODE", "hybrid")
+    config_module.TEI_EMBEDDING_ENDPOINT = env.get("TEI_EMBEDDING_ENDPOINT", "")
+
+    retriever_package = _package(package_name)
+    retriever_package.config = config_module
+
+    module_path = Path(__file__).resolve().parents[2] / "comps" / "retrievers" / "src" / "integrations" / "seahorse.py"
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    module = importlib.util.module_from_spec(spec)
+    module.__package__ = package_name
+
+    with patch.dict(
+        sys.modules,
+        {
+            "fastapi": fake_fastapi,
+            "requests": fake_requests,
+            "langchain_community": fake_langchain_community,
+            "langchain_community.embeddings": fake_langchain_community_embeddings,
+            "langchain_huggingface": fake_langchain_huggingface,
+            "seahorse_vector_store": fake_seahorse_module,
+            "comps": fake_comps,
+            package_name: retriever_package,
+            config_name: config_module,
+            module_name: module,
+        },
+        clear=False,
+    ):
+        spec.loader.exec_module(module)
+    return module
+
+
+class TestSeahorseRetriever(unittest.TestCase):
+    def test_init_logs_error_when_health_check_fails(self):
+        module = import_retriever_module(
+            {
+                "SEAHORSE_BASE_URL": "https://example.com",
+                "SEAHORSE_API_KEY": "secret",
+                "SEAHORSE_EMBEDDING_MODE": "builtin",
+                "SEAHORSE_SEARCH_MODE": "dense",
+            }
+        )
+
+        vectorstore = MagicMock()
+        vectorstore.health.side_effect = RuntimeError("unreachable")
+
+        with patch.object(module, "SeahorseVectorStore", return_value=vectorstore):
+            instance = module.OpeaSeahorseRetriever("OPEA_RETRIEVER_SEAHORSE", "test")
+            self.assertIsNotNone(instance)
+
+    def test_init_raises_when_search_mode_unknown(self):
+        module = import_retriever_module(
+            {
+                "SEAHORSE_BASE_URL": "https://example.com",
+                "SEAHORSE_API_KEY": "secret",
+                "SEAHORSE_EMBEDDING_MODE": "builtin",
+                "SEAHORSE_SEARCH_MODE": "not_a_real_mode",
+            }
+        )
+
+        vectorstore = MagicMock()
+        vectorstore.health.return_value = None
+
+        with patch.object(module, "SeahorseVectorStore", return_value=vectorstore):
+            with self.assertRaises(RuntimeError) as ctx:
+                module.OpeaSeahorseRetriever("OPEA_RETRIEVER_SEAHORSE", "test")
+        self.assertIn("Unknown SEAHORSE_SEARCH_MODE", str(ctx.exception))
+
+    def test_invalid_search_type_raises_http_exception(self):
+        module = import_retriever_module(
+            {
+                "SEAHORSE_BASE_URL": "https://example.com",
+                "SEAHORSE_API_KEY": "secret",
+                "SEAHORSE_EMBEDDING_MODE": "builtin",
+                "SEAHORSE_SEARCH_MODE": "dense",
+            }
+        )
+
+        vectorstore = MagicMock()
+        vectorstore.health.return_value = None
+        vectorstore.similarity_search.return_value = ["unexpected"]
+
+        with patch.object(module, "SeahorseVectorStore", return_value=vectorstore):
+            retriever = module.OpeaSeahorseRetriever("OPEA_RETRIEVER_SEAHORSE", "test")
+
+        with self.assertRaises(module.HTTPException):
+            asyncio.run(
+                retriever.invoke(
+                    SimpleNamespace(text="hello", embedding=[0.1], search_type="unsupported_search", k=2),
+                )
+            )
+
+    def test_builtin_dense_supports_distance_threshold(self):
+        module = import_retriever_module(
+            {
+                "SEAHORSE_BASE_URL": "https://example.com",
+                "SEAHORSE_API_KEY": "secret",
+                "SEAHORSE_EMBEDDING_MODE": "builtin",
+                "SEAHORSE_SEARCH_MODE": "dense",
+            }
+        )
+
+        doc_a = object()
+        doc_b = object()
+        vectorstore = MagicMock()
+        vectorstore.health.return_value = None
+        vectorstore.similarity_search_with_score.return_value = [(doc_a, 0.15), (doc_b, 0.35)]
+        vectorstore.similarity_search.return_value = [doc_b]
+
+        with patch.object(module, "SeahorseVectorStore", return_value=vectorstore):
+            retriever = module.OpeaSeahorseRetriever("OPEA_RETRIEVER_SEAHORSE", "test")
+
+        result = asyncio.run(
+            retriever.invoke(
+                SimpleNamespace(
+                    text="hello",
+                    embedding=[0.1],
+                    search_type="similarity_distance_threshold",
+                    distance_threshold=0.2,
+                    k=2,
+                )
+            )
+        )
+
+        self.assertEqual(result, [doc_a])
+
+    def test_external_mode_requires_non_empty_embedding(self):
+        module = import_retriever_module(
+            {
+                "SEAHORSE_BASE_URL": "https://example.com",
+                "SEAHORSE_API_KEY": "secret",
+                "SEAHORSE_EMBEDDING_MODE": "external",
+                "SEAHORSE_SEARCH_MODE": "dense",
+                "TEI_EMBEDDING_ENDPOINT": "https://tei.example.com",
+                "HF_TOKEN": "hf-token",
+            }
+        )
+
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"model_id": "bge-small"}
+
+        vectorstore = MagicMock()
+        vectorstore.health.return_value = None
+
+        with (
+            patch.object(module, "requests") as mock_requests,
+            patch.object(module, "HuggingFaceInferenceAPIEmbeddings", return_value=object()),
+            patch.object(module, "SeahorseVectorStore", return_value=vectorstore),
+        ):
+            mock_requests.get.return_value = response
+            retriever = module.OpeaSeahorseRetriever("OPEA_RETRIEVER_SEAHORSE", "test")
+
+        with self.assertRaises(module.HTTPException):
+            asyncio.run(
+                retriever.invoke(
+                    SimpleNamespace(text="hello", embedding=[], search_type="similarity", k=2),
+                )
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/retrievers/test_retrievers_seahorse.sh
+++ b/tests/retrievers/test_retrievers_seahorse.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# Copyright (C) 2026 Dnotitia
+# SPDX-License-Identifier: Apache-2.0
+
+set -xe
+
+IMAGE_REPO=${IMAGE_REPO:-"opea"}
+export REGISTRY=${IMAGE_REPO}
+export TAG="comps"
+echo "REGISTRY=IMAGE_REPO=${IMAGE_REPO}"
+echo "TAG=${TAG}"
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+WORKPATH=$(cd "${SCRIPT_DIR}/../.." && pwd)
+LOG_PATH="$WORKPATH/tests"
+
+source "${WORKPATH}/tests/utils/seahorse_helpers.sh"
+require_seahorse_credentials_or_skip
+detect_host_ip
+service_name="retriever-seahorse"
+
+function build_docker_images() {
+    cd $WORKPATH
+    docker build --no-cache -t ${REGISTRY:-opea}/retriever:${TAG:-latest} \
+        --build-arg https_proxy=$https_proxy \
+        --build-arg http_proxy=$http_proxy \
+        -f comps/retrievers/src/Dockerfile .
+    if [ $? -ne 0 ]; then
+        echo "opea/retriever built fail"
+        exit 1
+    else
+        echo "opea/retriever built successful"
+    fi
+}
+
+function wait_for_endpoint() {
+    local url=$1
+    local retries=30
+    local count=0
+
+    echo "Waiting for ${url} to become reachable..."
+    while [ $count -lt $retries ]; do
+        if curl -sf "${url}" > /dev/null 2>&1; then
+            echo "${url} is reachable!"
+            return 0
+        fi
+        echo "  → ${url} not ready yet ($count/$retries)"
+        sleep 5
+        ((count++))
+    done
+
+    echo "${url} did not respond in time."
+    return 1
+}
+
+function start_service() {
+    export RETRIEVER_PORT=7000
+    export LOGFLAG=True
+
+    cd $WORKPATH/comps/retrievers/deployment/docker_compose
+    docker compose -f compose.yaml up ${service_name} -d \
+        > ${LOG_PATH}/start_services_with_compose.log
+
+    wait_for_endpoint "http://${host_ip}:${RETRIEVER_PORT}/v1/health_check" || {
+        docker logs ${service_name} >> ${LOG_PATH}/retriever.log
+        exit 1
+    }
+}
+
+function _retriever_post() {
+    local url="http://${host_ip}:${RETRIEVER_PORT}/v1/retrieval"
+    local payload=$1
+
+    HTTP_RESPONSE=$(curl --silent --show-error --write-out "\nHTTPSTATUS:%{http_code}" \
+        -X POST -H 'Content-Type: application/json' -d "${payload}" "${url}")
+    RESPONSE_BODY=$(echo "$HTTP_RESPONSE" | sed '$d')
+    HTTP_STATUS=$(echo "$HTTP_RESPONSE" | tr -d '\n' | sed -n 's/.*HTTPSTATUS:\([0-9]*\)$/\1/p')
+}
+
+function _expect_status() {
+    local label=$1
+    local expected=$2
+
+    if [ "${HTTP_STATUS}" -ne "${expected}" ]; then
+        echo "[ ${label} ] Expected HTTP ${expected}, got ${HTTP_STATUS}. Body=${RESPONSE_BODY}"
+        docker logs ${service_name} >> ${LOG_PATH}/retriever.log
+        exit 1
+    fi
+    echo "[ ${label} ] HTTP status ${HTTP_STATUS} as expected."
+}
+
+function _expect_body_contains() {
+    local label=$1
+    local needle=$2
+
+    if ! echo "${RESPONSE_BODY}" | grep -q "${needle}"; then
+        echo "[ ${label} ] Body did not contain '${needle}'. Body=${RESPONSE_BODY}"
+        docker logs ${service_name} >> ${LOG_PATH}/retriever.log
+        exit 1
+    fi
+    echo "[ ${label} ] Body contains '${needle}'."
+}
+
+function validate_microservice() {
+    # 1) Plain similarity search (builtin: text only, embedding placeholder).
+    _retriever_post '{"text":"test query","embedding":[0.1],"k":3}'
+    _expect_status "retriever - similarity" 200
+    _expect_body_contains "retriever - similarity" "retrieved_docs"
+
+    # 2) Distance threshold path (dense semantics; result list may be empty if the
+    #    table holds no matches above threshold, but the service must still 200).
+    _retriever_post '{"text":"test query","embedding":[0.1],"k":3,"search_type":"similarity_distance_threshold","distance_threshold":1.0}'
+    _expect_status "retriever - distance_threshold" 200
+    _expect_body_contains "retriever - distance_threshold" "retrieved_docs"
+
+    # 3) Unsupported search_type must surface a 4xx (validated by _normalize_search_type).
+    _retriever_post '{"text":"test query","embedding":[0.1],"k":3,"search_type":"bogus_search"}'
+    if [ "${HTTP_STATUS}" -ge 200 ] && [ "${HTTP_STATUS}" -lt 300 ]; then
+        echo "[ retriever - bogus search_type ] Expected error, got HTTP ${HTTP_STATUS}. Body=${RESPONSE_BODY}"
+        docker logs ${service_name} >> ${LOG_PATH}/retriever.log
+        exit 1
+    fi
+    echo "[ retriever - bogus search_type ] Rejected as expected (HTTP ${HTTP_STATUS})."
+}
+
+function stop_docker() {
+    cd $WORKPATH/comps/retrievers/deployment/docker_compose
+    docker compose -f compose.yaml down --remove-orphans
+}
+
+function main() {
+    stop_docker
+    build_docker_images
+
+    start_service
+    validate_microservice
+
+    stop_docker
+    echo y | docker system prune
+}
+
+main

--- a/tests/utils/seahorse_helpers.sh
+++ b/tests/utils/seahorse_helpers.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Copyright (C) 2026 Dnotitia
+# SPDX-License-Identifier: Apache-2.0
+
+require_seahorse_credentials_or_skip() {
+    local missing=()
+
+    if [ -z "${SEAHORSE_BASE_URL:-}" ]; then
+        missing+=("SEAHORSE_BASE_URL")
+    fi
+    if [ -z "${SEAHORSE_API_KEY:-}" ]; then
+        missing+=("SEAHORSE_API_KEY")
+    fi
+
+    if [ ${#missing[@]} -gt 0 ]; then
+        echo "[SKIP] Seahorse credentials not configured: ${missing[*]}"
+        exit 0
+    fi
+}
+
+detect_host_ip() {
+    local detected_host_ip=""
+
+    detected_host_ip=$(hostname -I 2>/dev/null | awk '{print $1}')
+    if [ -z "$detected_host_ip" ] && command -v ipconfig >/dev/null 2>&1; then
+        detected_host_ip=$(ipconfig getifaddr en0 2>/dev/null || ipconfig getifaddr en1 2>/dev/null)
+    fi
+    if [ -z "$detected_host_ip" ]; then
+        detected_host_ip="127.0.0.1"
+    fi
+
+    export host_ip="$detected_host_ip"
+}


### PR DESCRIPTION
## Description

[Seahorse Cloud](https://seahorse.dnotitia.ai/en/product/) is a managed vector database service built by [Dnotitia](https://dnotitia.com). This PR integrates it as a vector database backend for OPEA's dataprep and retriever microservices.
The [`langchain-seahorse`](https://pypi.org/project/langchain-seahorse/) SDK (Apache-2.0) connects to the Seahorse Cloud API Gateway and is the only new dependency this PR introduces.

Key capabilities relevant to this OPEA integration:

- **Built-in server-side embeddings.** Because Seahorse Cloud can generate embeddings server-side, this integration does not require a separate TEI container when `SEAHORSE_EMBEDDING_MODE=builtin`.
- **Hybrid search (dense + sparse).** Supports dense, sparse, and hybrid retrieval modes via the `SEAHORSE_SEARCH_MODE` env var (hybrid/sparse require `SEAHORSE_EMBEDDING_MODE=builtin`; external embedding mode is dense-only).
- **Zero-infrastructure SaaS.** No container is needed under `comps/third_parties/`; the dataprep and retriever microservices connect directly to the hosted API Gateway. A free trial is available at the [Seahorse Console](https://console.seahorse.dnotitia.ai) for reviewers who want to validate the integration.

This PR adds Seahorse Cloud as a new vector database backend for the OPEA dataprep and retriever microservices. The contribution mirrors the structure used by the recent openGauss (#1949) and MariaDB Vector (#1645) integrations:

- `comps/dataprep/src/integrations/seahorse.py` — document ingestion through `SeahorseVectorStore.add_texts()` and per-file deletion via metadata filter.
- `comps/retrievers/src/integrations/seahorse.py` — query-time search with three retrieval modes (dense / sparse / hybrid) and the four standard `search_type` values (`similarity`, `similarity_score_threshold`,
  `similarity_distance_threshold`, `mmr`).
- Two embedding paths configurable via `SEAHORSE_EMBEDDING_MODE`:
  - `builtin` — Seahorse Cloud generates embeddings server-side (no TEI required). The retriever calls `similarity_search(query=text)` so the same server-side model embeds the query.
  - `external` — Uses TEI or a local HuggingFace model on the OPEA side and passes the pre-computed vector to
    `similarity_search_by_vector(embedding=vec)`. External mode is always dense-only.
- Docker Compose entries (`dataprep-seahorse`, `retriever-seahorse`) wired into the existing `comps/<type>/deployment/docker_compose/compose.yaml`.
- Per-integration READMEs under `comps/<type>/src/README_seahorse.md` and index entries in the parent `comps/<type>/README.md` files.

A few intentional design notes for reviewers:

- **Startup validation.** Missing `SEAHORSE_BASE_URL` / `SEAHORSE_API_KEY` and malformed TEI `/info` responses raise `RuntimeError` at startup to prevent a misconfigured container from accepting traffic. Seahorse Cloud health-check failures are logged as errors but do not block startup, matching the soft-fail pattern used by other OPEA backends (`pgvector`, `qdrant`, etc.) where transient network issues should not prevent the container from starting.
- **`score_threshold` semantics.** The Seahorse SDK returns *distance* scores for dense vector search and *similarity* scores for sparse/hybrid. The retriever applies the threshold in the matching direction (lower is
  better for distance, higher is better for similarity) and the README documents this explicitly. For unambiguous dense thresholds, callers should prefer `search_type="similarity_distance_threshold"`.
- **MMR fallback.** Seahorse Cloud does not support MMR. The retriever logs a warning and falls back to `similarity` rather than rejecting the request, to match the behavior other OPEA backends exhibit when an optional feature is unavailable.
- **Env var normalization.** `SEAHORSE_EMBEDDING_MODE` and `SEAHORSE_SEARCH_MODE` are normalized via `.strip().lower()` at startup so values like `Builtin`, `EXTERNAL`, or ` hybrid ` are accepted. An unknown `SEAHORSE_SEARCH_MODE` raises `RuntimeError` listing the supported values, surfacing typos at boot rather than at first request.

## Issues

#2073 

## Type of change

- [x] New feature (non-breaking change which adds new functionality)

## Dependencies

- New: `langchain-seahorse>=0.4.0` — added to both `comps/dataprep/src/requirements.in` and `comps/retrievers/src/requirements.in`. The pinned lockfile entries in `requirements-cpu.txt` / `requirements-gpu.txt` were regenerated in a minimal-diff manner so the only added rows are `langchain-seahorse` and
  the transitive references it pulls into existing `langchain-core`, `httpx`, and `pydantic` `# via` comments.

The `langchain-seahorse` SDK itself is published on PyPI under the Apache-2.0 license, matching OPEA's third-party dependency policy.

## Tests

**Unit tests** (`tests/dataprep/test_dataprep_seahorse.py`,`tests/retrievers/test_retrievers_seahorse.py`)

Cover the import-time fail-fast paths and the search-type dispatch logic without requiring the Seahorse SDK to be installed (the SDK and other heavy deps are stubbed via `unittest.mock`):

- Missing `SEAHORSE_BASE_URL` / `SEAHORSE_API_KEY` raises `RuntimeError`.
- Health-check failure raises `RuntimeError`.
- TEI `/info` without `model_id` raises `HTTPException(400)`.
- Unknown `SEAHORSE_SEARCH_MODE` raises `RuntimeError` listing supported values.
- Unsupported `search_type` raises `HTTPException(400)`.
- Dense + `similarity_distance_threshold` filters by distance upper bound.
- External mode requires a non-empty embedding vector.

```
$ python -m unittest tests.dataprep.test_dataprep_seahorse \
    tests.retrievers.test_retrievers_seahorse -v
Ran 8 tests in 0.011s
OK
```

**End-to-end scripts** (`tests/dataprep/test_dataprep_seahorse.sh`, `tests/retrievers/test_retrievers_seahorse.sh`)

Build the dataprep / retriever images, launch the corresponding Compose services, and exercise the public HTTP surface. Both scripts skip cleanly in CI when `SEAHORSE_BASE_URL` / `SEAHORSE_API_KEY` are not provided
(`tests/utils/seahorse_helpers.sh::require_seahorse_credentials_or_skip`).

- Dataprep: `txt`, `docx`, `pdf` ingestion; external link ingestion (can be skipped via `SKIP_LINK_TEST=1` for air-gapped runs); `get`, `delete <single>`, `delete all`.
- Retriever: plain similarity search (builtin mode); `similarity_distance_threshold` path (dense semantics); rejection of an unsupported `search_type` value.

Run on a Seahorse Cloud table provisioned through`https://console.seahorse.dnotitia.ai`:

- Dataprep e2e: PASS
- Retriever e2e: PASS

**Static checks**

- `pre-commit run` (full set: end-of-file-fixer, requirements-txt-fixer, insert-license, isort, docformatter, prettier, black, blacken-docs, codespell, ruff, …) — PASS on all touched files.
- DCO sign-off present on every commit (`git commit -s`).
